### PR TITLE
simplify recursive reference schemas

### DIFF
--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time
-from typing import Any, Callable, Dict, List, Sequence, Union
+from typing import Any, Callable, Dict, List, Union
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired, Required
 else:
-    from typing import NotRequired
+    from typing import NotRequired, Required
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal, TypedDict
@@ -19,9 +19,10 @@ class AnySchema(TypedDict):
     type: Literal['any']
 
 
-class BoolSchema(TypedDict):
-    type: Literal['bool']
-    strict: NotRequired[bool]
+class BoolSchema(TypedDict, total=False):
+    type: Required[Literal['bool']]
+    strict: bool
+    ref: str
 
 
 class ConfigSchema(TypedDict, total=False):
@@ -39,6 +40,7 @@ class DictSchema(TypedDict, total=False):
     min_items: int
     max_items: int
     strict: bool
+    ref: str
 
 
 class FloatSchema(TypedDict, total=False):
@@ -49,7 +51,7 @@ class FloatSchema(TypedDict, total=False):
     lt: float
     gt: float
     strict: bool
-    default: float
+    ref: str
 
 
 class FunctionSchema(TypedDict):
@@ -57,12 +59,14 @@ class FunctionSchema(TypedDict):
     mode: Literal['before', 'after', 'wrap']
     function: Callable[..., Any]
     schema: Schema
+    ref: NotRequired[str]
 
 
 class FunctionPlainSchema(TypedDict):
     type: Literal['function']
     mode: Literal['plain']
     function: Callable[..., Any]
+    ref: NotRequired[str]
 
 
 class IntSchema(TypedDict, total=False):
@@ -73,6 +77,7 @@ class IntSchema(TypedDict, total=False):
     lt: int
     gt: int
     strict: bool
+    ref: str
 
 
 class ListSchema(TypedDict, total=False):
@@ -81,17 +86,20 @@ class ListSchema(TypedDict, total=False):
     min_items: int
     max_items: int
     strict: bool
+    ref: str
 
 
 class LiteralSchema(TypedDict):
     type: Literal['literal']
-    expected: Sequence[Any]
+    expected: List[Any]
+    ref: NotRequired[str]
 
 
 class ModelClassSchema(TypedDict):
     type: Literal['model-class']
     class_type: type
     schema: TypedDictSchema
+    ref: NotRequired[str]
 
 
 class TypedDictField(TypedDict, total=False):
@@ -102,33 +110,30 @@ class TypedDictField(TypedDict, total=False):
     aliases: List[List[Union[str, int]]]
 
 
-class TypedDictSchema(TypedDict):
-    type: Literal['typed-dict']
-    fields: Dict[str, TypedDictField]
-    extra_validator: NotRequired[Schema]
-    config: NotRequired[ConfigSchema]
-    return_fields_set: NotRequired[bool]
+class TypedDictSchema(TypedDict, total=False):
+    type: Required[Literal['typed-dict']]
+    fields: Required[Dict[str, TypedDictField]]
+    extra_validator: Schema
+    config: ConfigSchema
+    return_fields_set: bool
+    ref: str
 
 
 class NoneSchema(TypedDict):
     type: Literal['none']
+    ref: NotRequired[str]
 
 
-class NullableSchema(TypedDict):
-    type: Literal['nullable']
-    schema: Schema
-    strict: NotRequired[bool]
+class NullableSchema(TypedDict, total=False):
+    type: Required[Literal['nullable']]
+    schema: Required[Schema]
+    strict: bool
+    ref: str
 
 
 class RecursiveReferenceSchema(TypedDict):
     type: Literal['recursive-ref']
-    name: str
-
-
-class RecursiveContainerSchema(TypedDict):
-    type: Literal['recursive-container']
-    name: str
-    schema: Schema
+    schema_ref: str
 
 
 class SetSchema(TypedDict, total=False):
@@ -137,6 +142,7 @@ class SetSchema(TypedDict, total=False):
     min_items: int
     max_items: int
     strict: bool
+    ref: str
 
 
 class FrozenSetSchema(TypedDict, total=False):
@@ -145,6 +151,7 @@ class FrozenSetSchema(TypedDict, total=False):
     min_items: int
     max_items: int
     strict: bool
+    ref: str
 
 
 class StringSchema(TypedDict, total=False):
@@ -156,13 +163,14 @@ class StringSchema(TypedDict, total=False):
     to_lower: bool
     to_upper: bool
     strict: bool
+    ref: str
 
 
-class UnionSchema(TypedDict):
-    type: Literal['union']
-    choices: List[Schema]
-    strict: NotRequired[bool]
-    default: NotRequired[Any]
+class UnionSchema(TypedDict, total=False):
+    type: Required[Literal['union']]
+    choices: Required[List[Schema]]
+    strict: bool
+    ref: str
 
 
 class BytesSchema(TypedDict, total=False):
@@ -170,6 +178,7 @@ class BytesSchema(TypedDict, total=False):
     max_length: int
     min_length: int
     strict: bool
+    ref: str
 
 
 class DateSchema(TypedDict, total=False):
@@ -179,7 +188,7 @@ class DateSchema(TypedDict, total=False):
     ge: date
     lt: date
     gt: date
-    default: date
+    ref: str
 
 
 class TimeSchema(TypedDict, total=False):
@@ -189,7 +198,7 @@ class TimeSchema(TypedDict, total=False):
     ge: time
     lt: time
     gt: time
-    default: time
+    ref: str
 
 
 class DatetimeSchema(TypedDict, total=False):
@@ -199,13 +208,14 @@ class DatetimeSchema(TypedDict, total=False):
     ge: datetime
     lt: datetime
     gt: datetime
-    default: datetime
+    ref: str
 
 
-class TupleFixLenSchema(TypedDict):
-    type: Literal['tuple-fix-len']
-    items_schema: List[Schema]
-    strict: NotRequired[bool]
+class TupleFixLenSchema(TypedDict, total=False):
+    type: Required[Literal['tuple-fix-len']]
+    items_schema: Required[List[Schema]]
+    strict: bool
+    ref: str
 
 
 class TupleVarLenSchema(TypedDict, total=False):
@@ -214,6 +224,7 @@ class TupleVarLenSchema(TypedDict, total=False):
     min_items: int
     max_items: int
     strict: bool
+    ref: str
 
 
 # pydantic allows types to be defined via a simple string instead of dict with just `type`, e.g.
@@ -256,7 +267,6 @@ Schema = Union[
     ModelClassSchema,
     NoneSchema,
     NullableSchema,
-    RecursiveContainerSchema,
     RecursiveReferenceSchema,
     SetSchema,
     FrozenSetSchema,

--- a/src/validators/recursive.rs
+++ b/src/validators/recursive.rs
@@ -8,26 +8,17 @@ use crate::input::Input;
 use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
-pub struct RecursiveValidator {
+pub struct RecursiveContainerValidator {
     validator_id: usize,
 }
 
-impl BuildValidator for RecursiveValidator {
-    const EXPECTED_TYPE: &'static str = "recursive-container";
-
-    fn build(
-        schema: &PyDict,
-        config: Option<&PyDict>,
-        build_context: &mut BuildContext,
-    ) -> PyResult<CombinedValidator> {
-        let sub_schema: &PyAny = schema.get_as_req("schema")?;
-        let name: String = schema.get_as_req("name")?;
-        let validator_id = build_context.add_named_slot(name, sub_schema, config)?;
-        Ok(Self { validator_id }.into())
+impl RecursiveContainerValidator {
+    pub fn create(validator_id: usize) -> CombinedValidator {
+        Self { validator_id }.into()
     }
 }
 
-impl Validator for RecursiveValidator {
+impl Validator for RecursiveContainerValidator {
     fn validate<'s, 'data>(
         &'s self,
         py: Python<'data>,
@@ -40,7 +31,7 @@ impl Validator for RecursiveValidator {
     }
 
     fn get_name(&self, _py: Python) -> String {
-        Self::EXPECTED_TYPE.to_string()
+        "recursive-container".to_string()
     }
 }
 
@@ -57,8 +48,8 @@ impl BuildValidator for RecursiveRefValidator {
         _config: Option<&PyDict>,
         build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
-        let name: String = schema.get_as_req("name")?;
-        let validator_id = build_context.find_id(&name)?;
+        let name: String = schema.get_as_req("schema_ref")?;
+        let validator_id = build_context.find_slot_id(&name)?;
         Ok(Self { validator_id }.into())
     }
 }

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -125,19 +125,16 @@ def schema(*, strict: bool = False) -> dict:
                 },
                 'field_recursive': {
                     'schema': {
-                        'type': 'recursive-container',
-                        'name': 'Branch',
-                        'schema': {
-                            'type': 'typed-dict',
-                            'fields': {
-                                'name': {'schema': 'str'},
-                                'sub_branch': {
-                                    'schema': {
-                                        'type': 'nullable',
-                                        'schema': {'type': 'recursive-ref', 'name': 'Branch'},
-                                    },
-                                    'default': None,
+                        'ref': 'Branch',
+                        'type': 'typed-dict',
+                        'fields': {
+                            'name': {'schema': 'str'},
+                            'sub_branch': {
+                                'schema': {
+                                    'type': 'nullable',
+                                    'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'},
                                 },
+                                'default': None,
                             },
                         },
                     }

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -189,20 +189,17 @@ def test_recursive_model_core(recursive_model_data, benchmark):
 
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'Branch',
+            'ref': 'Branch',
+            'type': 'model-class',
+            'class_type': CoreBranch,
             'schema': {
-                'type': 'model-class',
-                'class_type': CoreBranch,
-                'schema': {
-                    'type': 'typed-dict',
-                    'return_fields_set': True,
-                    'fields': {
-                        'width': {'schema': {'type': 'int'}},
-                        'branch': {
-                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'name': 'Branch'}},
-                            'default': None,
-                        },
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {
+                    'width': {'schema': {'type': 'int'}},
+                    'branch': {
+                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
+                        'default': None,
                     },
                 },
             },

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -64,19 +64,16 @@ def test_schema_typing() -> None:
     schema: Schema = {'type': 'function', 'mode': 'plain', 'function': foo}
     SchemaValidator(schema)
     schema: Schema = {
-        'type': 'recursive-container',
-        'name': 'Branch',
-        'schema': {
-            'type': 'typed-dict',
-            'fields': {
-                'name': {'schema': {'type': 'str'}},
-                'sub_branch': {
-                    'schema': {
-                        'type': 'union',
-                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
-                    },
-                    'default': None,
+        'ref': 'Branch',
+        'type': 'typed-dict',
+        'fields': {
+            'name': {'schema': {'type': 'str'}},
+            'sub_branch': {
+                'schema': {
+                    'type': 'union',
+                    'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
                 },
+                'default': None,
             },
         },
     }

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -8,19 +8,16 @@ from pydantic_core import SchemaError, SchemaValidator, ValidationError
 def test_branch_nullable():
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'Branch',
-            'schema': {
-                'type': 'typed-dict',
-                'fields': {
-                    'name': {'schema': {'type': 'str'}},
-                    'sub_branch': {
-                        'schema': {
-                            'type': 'union',
-                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
-                        },
-                        'default': None,
+            'type': 'typed-dict',
+            'ref': 'Branch',
+            'fields': {
+                'name': {'schema': {'type': 'str'}},
+                'sub_branch': {
+                    'schema': {
+                        'type': 'union',
+                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
                     },
+                    'default': None,
                 },
             },
         }
@@ -39,19 +36,16 @@ def test_branch_nullable():
 def test_nullable_error():
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'Branch',
-            'schema': {
-                'type': 'typed-dict',
-                'fields': {
-                    'width': {'schema': 'int'},
-                    'sub_branch': {
-                        'schema': {
-                            'type': 'union',
-                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
-                        },
-                        'default': None,
+            'ref': 'Branch',
+            'type': 'typed-dict',
+            'fields': {
+                'width': {'schema': 'int'},
+                'sub_branch': {
+                    'schema': {
+                        'type': 'union',
+                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
                     },
+                    'default': None,
                 },
             },
         }
@@ -80,16 +74,13 @@ def test_nullable_error():
 def test_list():
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'BranchList',
-            'schema': {
-                'type': 'typed-dict',
-                'fields': {
-                    'width': {'schema': 'int'},
-                    'branches': {
-                        'schema': {'type': 'list', 'items_schema': {'type': 'recursive-ref', 'name': 'BranchList'}},
-                        'default': None,
-                    },
+            'type': 'typed-dict',
+            'ref': 'BranchList',
+            'fields': {
+                'width': {'schema': 'int'},
+                'branches': {
+                    'schema': {'type': 'list', 'items_schema': {'type': 'recursive-ref', 'schema_ref': 'BranchList'}},
+                    'default': None,
                 },
             },
         }
@@ -117,38 +108,32 @@ def test_multiple_intertwined():
 
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'Foo',
-            'schema': {
-                'type': 'typed-dict',
-                'fields': {
-                    'height': {'schema': 'int'},
-                    'bar': {
-                        'schema': {
-                            'type': 'recursive-container',
-                            'name': 'Bar',
-                            'schema': {
-                                'type': 'typed-dict',
-                                'fields': {
-                                    'width': {'schema': 'int'},
-                                    'bars': {
-                                        'schema': {
-                                            'type': 'list',
-                                            'items_schema': {'type': 'recursive-ref', 'name': 'Bar'},
-                                        },
-                                        'default': None,
-                                    },
-                                    'foo': {
-                                        'schema': {
-                                            'type': 'union',
-                                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Foo'}],
-                                        },
-                                        'default': None,
-                                    },
+            'ref': 'Foo',
+            'type': 'typed-dict',
+            'fields': {
+                'height': {'schema': 'int'},
+                'bar': {
+                    'schema': {
+                        'ref': 'Bar',
+                        'type': 'typed-dict',
+                        'fields': {
+                            'width': {'schema': 'int'},
+                            'bars': {
+                                'schema': {
+                                    'type': 'list',
+                                    'items_schema': {'type': 'recursive-ref', 'schema_ref': 'Bar'},
                                 },
+                                'default': None,
                             },
-                        }
-                    },
+                            'foo': {
+                                'schema': {
+                                    'type': 'union',
+                                    'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Foo'}],
+                                },
+                                'default': None,
+                            },
+                        },
+                    }
                 },
             },
         }
@@ -175,23 +160,20 @@ def test_model_class():
 
     v = SchemaValidator(
         {
-            'type': 'recursive-container',
-            'name': 'Branch',
+            'type': 'model-class',
+            'ref': 'Branch',
+            'class_type': Branch,
             'schema': {
-                'type': 'model-class',
-                'class_type': Branch,
-                'schema': {
-                    'type': 'typed-dict',
-                    'return_fields_set': True,
-                    'fields': {
-                        'width': {'schema': 'int'},
-                        'branch': {
-                            'schema': {
-                                'type': 'union',
-                                'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
-                            },
-                            'default': None,
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {
+                    'width': {'schema': 'int'},
+                    'branch': {
+                        'schema': {
+                            'type': 'union',
+                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
                         },
+                        'default': None,
                     },
                 },
             },
@@ -223,10 +205,29 @@ def test_invalid_schema():
                     'fields': {
                         'width': {'schema': {'type': 'int'}},
                         'branch': {
-                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'name': 'Branch'}},
+                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
                             'default': None,
                         },
                     },
                 },
             }
         )
+
+
+def test_outside_parent():
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'tuple1': {
+                    'schema': {'type': 'tuple-fix-len', 'ref': 'tuple-iis', 'items_schema': ['int', 'int', 'str']}
+                },
+                'tuple2': {'schema': {'type': 'recursive-ref', 'schema_ref': 'tuple-iis'}},
+            },
+        }
+    )
+
+    assert v.validate_python({'tuple1': [1, '1', 'frog'], 'tuple2': [2, '2', 'toad']}) == {
+        'tuple1': (1, 1, 'frog'),
+        'tuple2': (2, 2, 'toad'),
+    }


### PR DESCRIPTION
fix #60

Turns out I needed this for #127.

`ref` on any schema type can now be used to make that validator available to be used elsewhere, this involves moving that validator into `slots` so will be slightly slower than not using `ref`.