### PR TITLE
feat: allow fields to be `frozen` and add `strict` + `context` support to `validate_assignment`

### DIFF
--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -21,7 +21,9 @@ class SchemaValidator:
     def isinstance_json(
         self, input: 'str | bytes | bytearray', strict: 'bool | None' = None, context: Any = None
     ) -> bool: ...
-    def validate_assignment(self, field: str, input: Any, data: 'dict[str, Any]') -> 'dict[str, Any]': ...
+    def validate_assignment(
+        self, field: str, input: Any, data: 'dict[str, Any]', strict: 'bool | None' = None, context: Any = None
+    ) -> 'dict[str, Any]': ...
 
 class SchemaError(Exception):
     pass

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -125,6 +125,7 @@ class TypedDictField(TypedDict, total=False):
     default_factory: Callable[[], Any]
     on_error: Literal['raise', 'omit', 'fallback_on_default']  # default: 'raise'
     alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
+    frozen: bool
 
 
 class TypedDictSchema(TypedDict, total=False):

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -30,6 +30,8 @@ pub enum ErrorKind {
     DictAttributesType,
     #[strum(message = "Field required")]
     Missing,
+    #[strum(message = "Field is frozen")]
+    Frozen,
     #[strum(message = "Extra inputs are not permitted")]
     ExtraForbidden,
     #[strum(message = "Keys should be strings")]

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -175,12 +175,20 @@ impl SchemaValidator {
         }
     }
 
-    pub fn validate_assignment(&self, py: Python, field: String, input: &PyAny, data: &PyDict) -> PyResult<PyObject> {
+    pub fn validate_assignment(
+        &self,
+        py: Python,
+        field: String,
+        input: &PyAny,
+        data: &PyDict,
+        strict: Option<bool>,
+        context: Option<&PyAny>,
+    ) -> PyResult<PyObject> {
         let extra = Extra {
             data: Some(data),
             field: Some(field.as_str()),
-            strict: None,
-            context: None,
+            strict,
+            context,
         };
         let r = self
             .validator

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -241,6 +241,24 @@ def test_validate_assignment():
     assert v.validate_assignment('field_a', b'abc', {'field_a': 'test'}) == ({'field_a': 'abc'}, {'field_a'})
 
 
+def test_validate_assignment_strict_field():
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'return_fields_set': True,
+            'fields': {'field_a': {'schema': {'type': 'str', 'strict': True}}},
+        }
+    )
+
+    assert v.validate_python({'field_a': 'test'}) == ({'field_a': 'test'}, {'field_a'})
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_assignment('field_a', b'abc', {'field_a': 'test'})
+    assert exc_info.value.errors() == [
+        {'input_value': b'abc', 'kind': 'str_type', 'loc': ['field_a'], 'message': 'Input should be a valid string'}
+    ]
+
+
 def test_validate_assignment_functions():
     calls = []
 

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -354,6 +354,24 @@ def test_validate_assignment_allow_extra_validate():
     ]
 
 
+def test_validate_assignment_with_strict():
+    v = SchemaValidator(
+        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'int'}}}}
+    )
+
+    r = v.validate_python({'x': 'a', 'y': '123'})
+    assert r == {'x': 'a', 'y': 123}
+
+    assert v.validate_assignment('y', '124', r) == {'x': 'a', 'y': 124}
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_assignment('y', '124', r, True)
+
+    assert exc_info.value.errors() == [
+        {'kind': 'int_type', 'loc': ['y'], 'message': 'Input should be a valid integer', 'input_value': '124'}
+    ]
+
+
 def test_json_error():
     v = SchemaValidator(
         {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'list', 'items_schema': 'int'}}}}


### PR DESCRIPTION
fix #219