### PR TITLE
Support `dict_items` for list like fields

### DIFF
--- a/src/input/_pyo3_dict.rs
+++ b/src/input/_pyo3_dict.rs
@@ -26,3 +26,14 @@ pyobject_native_type_core!(
     ffi::PyDictValues_Type,
     #checkfunction=ffi::PyDictValues_Check
 );
+
+/// Represents a Python `dict_items`.
+#[cfg(not(PyPy))]
+pub struct PyDictItems(PyAny, PyAny);
+
+#[cfg(not(PyPy))]
+pyobject_native_type_core!(
+    PyDictItems,
+    ffi::PyDictItems_Type,
+    #checkfunction=ffi::PyDictItems_Check
+);

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -12,7 +12,7 @@ use pyo3::{intern, AsPyPointer};
 use crate::errors::{py_err_string, ErrorKind, InputValue, LocItem, ValError, ValResult};
 
 #[cfg(not(PyPy))]
-use super::_pyo3_dict::{PyDictKeys, PyDictValues};
+use super::_pyo3_dict::{PyDictItems, PyDictKeys, PyDictValues};
 use super::datetime::{
     bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, date_as_datetime, float_as_datetime,
     float_as_duration, float_as_time, int_as_datetime, int_as_duration, int_as_time, EitherDate, EitherDateTime,
@@ -36,6 +36,9 @@ macro_rules! extract_gen_dict {
             Some(<$type>::new($obj.py(), vec))
         } else if let Ok(dict_values) = $obj.cast_as::<PyDictValues>() {
             let vec = dict_values.iter()?.collect::<PyResult<Vec<_>>>().map_err(map_err)?;
+            Some(<$type>::new($obj.py(), vec))
+        } else if let Ok(dict_items) = $obj.cast_as::<PyDictItems>() {
+            let vec = dict_items.iter()?.collect::<PyResult<Vec<_>>>().map_err(map_err)?;
             Some(<$type>::new($obj.py(), vec))
         } else {
             None

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -261,14 +261,15 @@ def test_generator_error():
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'any'}},
             frozenset(((1, 10), (2, 20), ('3', '30'))),
-            id='frozenset_Tuple[Any, Any]',
+            id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'int'}},
             frozenset(((1, 10), (2, 20), (3, 30))),
-            id='frozenset_Tuple[int, int]',
+            id='Tuple[int, int]',
         ),
+        pytest.param({1: 10, 2: 20, '3': '30'}.items(), 'any', {(1, 10), (2, 20), ('3', '30')}, id='Any'),
     ],
 )
 def test_frozenset_from_dict_items(input_value, items_schema, expected):

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -72,6 +72,13 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
         ((), frozenset()),
         (frozenset([1, 2, 3, 2, 3]), frozenset({1, 2, 3})),
         pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            Err('Input should be a valid integer [kind=int_type,'),
+            marks=pytest.mark.skipif(
+                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
+            ),
+        ),
+        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             frozenset({1, 2, 3}),
             marks=pytest.mark.skipif(
@@ -86,8 +93,6 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
             ),
         ),
         ({1: 10, 2: 20, '3': '30'}, Err('Input should be a valid frozenset [kind=frozen_set_type,')),
-        # https://github.com/pydantic/pydantic-core/issues/211
-        ({1: 10, 2: 20, '3': '30'}.items(), Err('Input should be a valid frozenset [kind=frozen_set_type,')),
         ((x for x in [1, 2, '3']), frozenset({1, 2, 3})),
         ({'abc'}, Err('0\n  Input should be a valid integer')),
         ({1, 2, 'wrong'}, Err('Input should be a valid integer')),

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -72,13 +72,6 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
         ((), frozenset()),
         (frozenset([1, 2, 3, 2, 3]), frozenset({1, 2, 3})),
         pytest.param(
-            {1: 10, 2: 20, '3': '30'}.items(),
-            Err('Input should be a valid integer [kind=int_type,'),
-            marks=pytest.mark.skipif(
-                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
-            ),
-        ),
-        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             frozenset({1, 2, 3}),
             marks=pytest.mark.skipif(
@@ -258,3 +251,28 @@ def test_generator_error():
 
     with pytest.raises(ValidationError, match=r'Error iterating over object \[kind=iteration_error,'):
         v.validate_python(gen(True))
+
+
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy')
+@pytest.mark.parametrize(
+    'input_value,items_schema,expected',
+    [
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'any'}},
+            frozenset(((1, 10), (2, 20), ('3', '30'))),
+            id='frozenset_Tuple[Any, Any]',
+        ),
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'int'}},
+            frozenset(((1, 10), (2, 20), (3, 30))),
+            id='frozenset_Tuple[int, int]',
+        ),
+    ],
+)
+def test_frozenset_from_dict_items(input_value, items_schema, expected):
+    v = SchemaValidator({'type': 'frozenset', 'items_schema': items_schema})
+    output = v.validate_python(input_value)
+    assert isinstance(output, frozenset)
+    assert output == expected

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -234,14 +234,15 @@ def test_generator_error():
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'any'}},
             [(1, 10), (2, 20), ('3', '30')],
-            id='list_Tuple[Any, Any]',
+            id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'int'}},
             [(1, 10), (2, 20), (3, 30)],
-            id='list_Tuple[int, int]',
+            id='Tuple[int, int]',
         ),
+        pytest.param({1: 10, 2: 20, '3': '30'}.items(), 'any', [(1, 10), (2, 20), ('3', '30')], id='Any'),
     ],
 )
 def test_list_from_dict_items(input_value, items_schema, expected):

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -46,6 +46,13 @@ def test_list_strict():
         ({1, 2, '3'}, Err('Input should be a valid list/array [kind=list_type,')),
         (frozenset({1, 2, '3'}), Err('Input should be a valid list/array [kind=list_type,')),
         pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            Err('Input should be a valid integer [kind=int_type,'),
+            marks=pytest.mark.skipif(
+                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
+            ),
+        ),
+        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             [1, 2, 3],
             marks=pytest.mark.skipif(
@@ -60,8 +67,6 @@ def test_list_strict():
             ),
         ),
         ({1: 10, 2: 20, '3': '30'}, Err('Input should be a valid list/array [kind=list_type,')),
-        # https://github.com/pydantic/pydantic-core/issues/211
-        ({1: 10, 2: 20, '3': '30'}.items(), Err('Input should be a valid list/array [kind=list_type,')),
         ((x for x in [1, 2, '3']), [1, 2, 3]),
     ],
 )

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -64,13 +64,6 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
         ((), set()),
         (frozenset([1, 2, 3, 2, 3]), {1, 2, 3}),
         pytest.param(
-            {1: 10, 2: 20, '3': '30'}.items(),
-            Err('Input should be a valid integer [kind=int_type,'),
-            marks=pytest.mark.skipif(
-                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
-            ),
-        ),
-        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             {1, 2, 3},
             marks=pytest.mark.skipif(
@@ -226,3 +219,28 @@ def test_generator_error():
 
     with pytest.raises(ValidationError, match=r'Error iterating over object \[kind=iteration_error,'):
         v.validate_python(gen(True))
+
+
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy')
+@pytest.mark.parametrize(
+    'input_value,items_schema,expected',
+    [
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'any'}},
+            {(1, 10), (2, 20), ('3', '30')},
+            id='set_Tuple[Any, Any]',
+        ),
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'int'}},
+            {(1, 10), (2, 20), (3, 30)},
+            id='set_Tuple[int, int]',
+        ),
+    ],
+)
+def test_set_from_dict_items(input_value, items_schema, expected):
+    v = SchemaValidator({'type': 'set', 'items_schema': items_schema})
+    output = v.validate_python(input_value)
+    assert isinstance(output, set)
+    assert output == expected

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -229,14 +229,15 @@ def test_generator_error():
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'any'}},
             {(1, 10), (2, 20), ('3', '30')},
-            id='set_Tuple[Any, Any]',
+            id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'int'}},
             {(1, 10), (2, 20), (3, 30)},
-            id='set_Tuple[int, int]',
+            id='Tuple[int, int]',
         ),
+        pytest.param({1: 10, 2: 20, '3': '30'}.items(), 'any', {(1, 10), (2, 20), ('3', '30')}, id='Any'),
     ],
 )
 def test_set_from_dict_items(input_value, items_schema, expected):

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -64,6 +64,13 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
         ((), set()),
         (frozenset([1, 2, 3, 2, 3]), {1, 2, 3}),
         pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            Err('Input should be a valid integer [kind=int_type,'),
+            marks=pytest.mark.skipif(
+                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
+            ),
+        ),
+        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             {1, 2, 3},
             marks=pytest.mark.skipif(
@@ -78,8 +85,6 @@ def test_frozenset_no_validators_both(py_and_json: PyAndJson, input_value, expec
             ),
         ),
         ({1: 10, 2: 20, '3': '30'}, Err('Input should be a valid set [kind=set_type,')),
-        # https://github.com/pydantic/pydantic-core/issues/211
-        ({1: 10, 2: 20, '3': '30'}.items(), Err('Input should be a valid set [kind=set_type,')),
         ((x for x in [1, 2, '3']), {1, 2, 3}),
         ({'abc'}, Err('0\n  Input should be a valid integer')),
         ({1: 2}, Err('1 validation error for set[int]\n  Input should be a valid set')),

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -107,6 +107,13 @@ def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
         ((1, 2, '3'), (1, 2, 3)),
         ([1, 2, '3'], (1, 2, 3)),
         pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            Err('Input should be a valid integer [kind=int_type,'),
+            marks=pytest.mark.skipif(
+                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
+            ),
+        ),
+        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             (1, 2, 3),
             marks=pytest.mark.skipif(
@@ -121,8 +128,6 @@ def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
             ),
         ),
         ({1: 10, 2: 20, '3': '30'}, Err('Input should be a valid tuple [kind=tuple_type,')),
-        # https://github.com/pydantic/pydantic-core/issues/211
-        ({1: 10, 2: 20, '3': '30'}.items(), Err('Input should be a valid tuple [kind=tuple_type,')),
         ({1, 2, '3'}, Err('Input should be a valid tuple [kind=tuple_type,')),
         (frozenset([1, 2, '3']), Err('Input should be a valid tuple [kind=tuple_type,')),
     ],

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -107,13 +107,6 @@ def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
         ((1, 2, '3'), (1, 2, 3)),
         ([1, 2, '3'], (1, 2, 3)),
         pytest.param(
-            {1: 10, 2: 20, '3': '30'}.items(),
-            Err('Input should be a valid integer [kind=int_type,'),
-            marks=pytest.mark.skipif(
-                platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy'
-            ),
-        ),
-        pytest.param(
             {1: 10, 2: 20, '3': '30'}.keys(),
             (1, 2, 3),
             marks=pytest.mark.skipif(
@@ -409,3 +402,28 @@ def test_generator_error():
 
     with pytest.raises(ValidationError, match=r'Error iterating over object \[kind=iteration_error,'):
         v.validate_python(gen(True))
+
+
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='dict views not implemented in pyo3 for pypy')
+@pytest.mark.parametrize(
+    'input_value,items_schema,expected',
+    [
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'any'}},
+            ((1, 10), (2, 20), ('3', '30')),
+            id='tuple_Tuple[Any, Any]',
+        ),
+        pytest.param(
+            {1: 10, 2: 20, '3': '30'}.items(),
+            {'type': 'tuple', 'items_schema': {'type': 'int'}},
+            ((1, 10), (2, 20), (3, 30)),
+            id='tuple_Tuple[int, int]',
+        ),
+    ],
+)
+def test_frozenset_from_dict_items(input_value, items_schema, expected):
+    v = SchemaValidator({'type': 'tuple', 'items_schema': items_schema})
+    output = v.validate_python(input_value)
+    assert isinstance(output, tuple)
+    assert output == expected

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -412,14 +412,15 @@ def test_generator_error():
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'any'}},
             ((1, 10), (2, 20), ('3', '30')),
-            id='tuple_Tuple[Any, Any]',
+            id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
             {'type': 'tuple', 'items_schema': {'type': 'int'}},
             ((1, 10), (2, 20), (3, 30)),
-            id='tuple_Tuple[int, int]',
+            id='Tuple[int, int]',
         ),
+        pytest.param({1: 10, 2: 20, '3': '30'}.items(), 'any', ((1, 10), (2, 20), ('3', '30')), id='Any'),
     ],
 )
 def test_frozenset_from_dict_items(input_value, items_schema, expected):


### PR DESCRIPTION
Closes #211

This is a follow up to PR #208, which added support for `dict_keys` and `dict_values`.