### PR TITLE
Default validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ v = SchemaValidator({
         },
         'is_developer': {
             'schema': {
-                'type': 'bool',
-            },
-            'default': True,
+                'type': 'default',
+                'schema': {'type': 'bool'},
+                'default': True,
+            }
         },
     },
 })

--- a/pydantic_core/schema_types.py
+++ b/pydantic_core/schema_types.py
@@ -126,7 +126,7 @@ class TypedDictField(TypedDict, total=False):
     required: bool
     default: Any
     default_factory: Callable[[], Any]
-    on_error: Literal['raise', 'omit', 'fallback_on_default']  # default: 'raise'
+    on_error: Literal['raise', 'omit', 'default']  # default: 'raise'
     alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
     frozen: bool
 
@@ -287,8 +287,6 @@ class Parameter(TypedDict, total=False):
     name: Required[str]
     mode: Literal['positional_only', 'positional_or_keyword', 'keyword_only']  # default positional_or_keyword
     schema: Required[Schema]
-    default: Any
-    default_factory: Callable[[], Any]
     alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
 
 
@@ -314,7 +312,7 @@ class WithDefaultSchema(TypedDict, total=False):
     schema: Required[Schema]
     default: Any
     default_factory: Callable[[], Any]
-    on_error: Literal['raise', 'omit', 'fallback_on_default']  # default: 'raise'
+    on_error: Literal['raise', 'omit', 'default']  # default: 'raise'
     strict: bool
     ref: str
 

--- a/pydantic_core/schema_types.py
+++ b/pydantic_core/schema_types.py
@@ -124,9 +124,6 @@ class NewClassSchema(TypedDict):
 class TypedDictField(TypedDict, total=False):
     schema: Required[Schema]
     required: bool
-    default: Any
-    default_factory: Callable[[], Any]
-    on_error: Literal['raise', 'omit', 'default']  # default: 'raise'
     alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
     frozen: bool
 

--- a/pydantic_core/schema_types.py
+++ b/pydantic_core/schema_types.py
@@ -309,6 +309,16 @@ class CallSchema(TypedDict):
     ref: NotRequired[str]
 
 
+class WithDefaultSchema(TypedDict, total=False):
+    type: Required[Literal['default']]
+    schema: Required[Schema]
+    default: Any
+    default_factory: Callable[[], Any]
+    on_error: Literal['raise', 'omit', 'fallback_on_default']  # default: 'raise'
+    strict: bool
+    ref: str
+
+
 # pydantic allows types to be defined via a simple string instead of dict with just `type`, e.g.
 # 'int' is equivalent to {'type': 'int'}, this only applies to schema types which do not have other required fields
 BareType = Literal[
@@ -366,4 +376,5 @@ Schema = Union[
     CallableSchema,
     ArgumentsSchema,
     CallSchema,
+    WithDefaultSchema,
 ]

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -138,6 +138,10 @@ impl SchemaError {
                 SchemaError::new_err(format!("Invalid Schema:\n{}", details))
             }
             ValError::InternalErr(py_err) => py_err,
+            // shouldn't happen
+            ValError::Omit => {
+                SchemaError::new_err(r#"Uncaught Omit error, please check your usage of "default" validators."#)
+            }
         }
     }
 }

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -14,6 +14,7 @@ pub type ValResult<'a, T> = Result<T, ValError<'a>>;
 pub enum ValError<'a> {
     LineErrors(Vec<ValLineError<'a>>),
     InternalErr(PyErr),
+    Omit,
 }
 
 impl<'a> From<PyErr> for ValError<'a> {
@@ -57,6 +58,7 @@ impl<'a> ValError<'a> {
                 Self::LineErrors(line_errors)
             }
             Self::InternalErr(err) => Self::InternalErr(err),
+            Self::Omit => Self::Omit,
         }
     }
 }

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -28,6 +28,9 @@ impl ValidationError {
                 PyErr::new::<ValidationError, _>((line_errors, title))
             }
             ValError::InternalErr(err) => err,
+            ValError::Omit => {
+                PyValueError::new_err(r#"Uncaught Omit error, please check your usage of "default" validators."#)
+            }
         }
     }
 

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -55,6 +55,7 @@ fn validate_iter_to_vec<'a, 's>(
             Err(ValError::LineErrors(line_errors)) => {
                 errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index.into())));
             }
+            Err(ValError::Omit) => (),
             Err(err) => return Err(err),
         }
     }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -8,7 +8,6 @@ use crate::errors::{ErrorKind, ValError, ValLineError, ValResult};
 use crate::input::{GenericArguments, Input};
 use crate::lookup_key::LookupKey;
 use crate::recursion_guard::RecursionGuard;
-use crate::SchemaError;
 
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
@@ -72,9 +71,7 @@ impl BuildValidator for ArgumentsValidator {
                 kwarg_key = Some(PyString::intern(py, &name).into());
             }
 
-            let schema: &PyAny = arg
-                .get_as_req(intern!(py, "schema"))
-                .map_err(|err| SchemaError::new_err(format!("Parameter '{}':\n  {}", name, err)))?;
+            let schema: &PyAny = arg.get_as_req(intern!(py, "schema"))?;
 
             let validator = match build_validator(schema, config, build_context) {
                 Ok(v) => v,

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -84,7 +84,7 @@ impl BuildValidator for ArgumentsValidator {
             let has_default = match validator {
                 CombinedValidator::WithDefault(ref v) => {
                     if v.omit_on_error() {
-                        return py_error!("Parameter '{}': omit_on_error cannot be used with Arguments", name);
+                        return py_error!("Parameter '{}': omit_on_error cannot be used with arguments", name);
                     }
                     v.has_default()
                 }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -18,8 +18,6 @@ struct Parameter {
     name: String,
     kw_lookup_key: Option<LookupKey>,
     kwarg_key: Option<Py<PyString>>,
-    default: Option<PyObject>,
-    default_factory: Option<PyObject>,
     validator: CombinedValidator,
 }
 
@@ -76,17 +74,26 @@ impl BuildValidator for ArgumentsValidator {
 
             let schema: &PyAny = arg
                 .get_as_req(intern!(py, "schema"))
-                .map_err(|err| SchemaError::new_err(format!("Parameter \"{}\":\n  {}", name, err)))?;
+                .map_err(|err| SchemaError::new_err(format!("Parameter '{}':\n  {}", name, err)))?;
 
-            let validator = build_validator(schema, config, build_context)?;
+            let validator = match build_validator(schema, config, build_context) {
+                Ok(v) => v,
+                Err(err) => return py_error!("Parameter '{}':\n  {}", name, err),
+            };
 
-            let default = arg.get_as(intern!(py, "default"))?;
-            let default_factory = arg.get_as(intern!(py, "default_factory"))?;
-            if default.is_some() && default_factory.is_some() {
-                return py_error!("'default' and 'default_factory' cannot be used together");
-            } else if had_default_arg && (default.is_none() && default_factory.is_none()) {
-                return py_error!("Non-default argument follows default argument");
-            } else if default.is_some() || default_factory.is_some() {
+            let has_default = match validator {
+                CombinedValidator::WithDefault(ref v) => {
+                    if v.omit_on_error() {
+                        return py_error!("Parameter '{}': omit_on_error cannot be used with Arguments", name);
+                    }
+                    v.has_default()
+                }
+                _ => false,
+            };
+
+            if had_default_arg && !has_default {
+                return py_error!("Non-default argument '{}' follows default argument", name);
+            } else if has_default {
                 had_default_arg = true;
             }
             parameters.push(Parameter {
@@ -94,8 +101,6 @@ impl BuildValidator for ArgumentsValidator {
                 kw_lookup_key,
                 name,
                 kwarg_key,
-                default,
-                default_factory,
                 validator,
             });
         }
@@ -213,20 +218,18 @@ impl Validator for ArgumentsValidator {
                             }
                         }
                         (None, None) => {
-                            if let Some(ref default) = parameter.default {
-                                if let Some(ref kwarg_key) = parameter.kwarg_key {
-                                    output_kwargs.set_item(kwarg_key, default)?;
-                                } else {
-                                    output_args.push(default.clone_ref(py));
+                            if let CombinedValidator::WithDefault(ref validator) = parameter.validator {
+                                if let Some(value) = validator.default_value(py)? {
+                                    if let Some(ref kwarg_key) = parameter.kwarg_key {
+                                        output_kwargs.set_item(kwarg_key, value.as_ref())?;
+                                    } else {
+                                        output_args.push(value.as_ref().clone_ref(py));
+                                    }
+                                    continue;
                                 }
-                            } else if let Some(ref default_factory) = parameter.default_factory {
-                                let default = default_factory.call0(py)?;
-                                if let Some(ref kwarg_key) = parameter.kwarg_key {
-                                    output_kwargs.set_item(kwarg_key, default)?;
-                                } else {
-                                    output_args.push(default);
-                                }
-                            } else if parameter.kwarg_key.is_some() {
+                            }
+
+                            if parameter.kwarg_key.is_some() {
                                 errors.push(ValLineError::new_with_loc(
                                     ErrorKind::MissingKeywordArgument,
                                     input,

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -9,6 +9,7 @@ use crate::input::{GenericArguments, Input};
 use crate::lookup_key::LookupKey;
 use crate::recursion_guard::RecursionGuard;
 
+use super::with_default::get_default;
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
@@ -215,15 +216,13 @@ impl Validator for ArgumentsValidator {
                             }
                         }
                         (None, None) => {
-                            if let CombinedValidator::WithDefault(ref validator) = parameter.validator {
-                                if let Some(value) = validator.default_value(py)? {
-                                    if let Some(ref kwarg_key) = parameter.kwarg_key {
-                                        output_kwargs.set_item(kwarg_key, value.as_ref())?;
-                                    } else {
-                                        output_args.push(value.as_ref().clone_ref(py));
-                                    }
-                                    continue;
+                            if let Some(value) = get_default(py, &parameter.validator)? {
+                                if let Some(ref kwarg_key) = parameter.kwarg_key {
+                                    output_kwargs.set_item(kwarg_key, value.as_ref())?;
+                                } else {
+                                    output_args.push(value.as_ref().clone_ref(py));
                                 }
+                                continue;
                             }
 
                             if parameter.kwarg_key.is_some() {

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -133,6 +133,7 @@ fn date_from_datetime<'data>(
                     Err(ValError::LineErrors(line_errors))
                 }
                 ValError::InternalErr(internal_err) => Err(ValError::InternalErr(internal_err)),
+                ValError::Omit => unreachable!(),
             };
         }
     };

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -40,6 +40,7 @@ mod timedelta;
 mod tuple;
 mod typed_dict;
 mod union;
+mod with_default;
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
 #[derive(Debug, Clone)]
@@ -369,6 +370,8 @@ pub fn build_validator<'a>(
         callable::CallableValidator,
         // arguments
         arguments::ArgumentsValidator,
+        // default value
+        with_default::WithDefaultValidator,
     )
 }
 
@@ -478,6 +481,8 @@ pub enum CombinedValidator {
     Callable(callable::CallableValidator),
     // arguments
     Arguments(arguments::ArgumentsValidator),
+    // default value
+    WithDefault(with_default::WithDefaultValidator),
 }
 
 /// This trait must be implemented by all validators, it allows various validators to be accessed consistently,

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -13,7 +13,6 @@ use crate::errors::{py_err_string, ErrorKind, ValError, ValLineError, ValResult}
 use crate::input::{GenericMapping, Input};
 use crate::lookup_key::LookupKey;
 use crate::recursion_guard::RecursionGuard;
-use crate::SchemaError;
 
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
@@ -90,9 +89,7 @@ impl BuildValidator for TypedDictValidator {
             let field_info: &PyDict = value.cast_as()?;
             let field_name: &str = key.extract()?;
 
-            let schema = field_info
-                .get_as_req(intern!(py, "schema"))
-                .map_err(|err| SchemaError::new_err(format!("Field '{}':\n  {}", field_name, err)))?;
+            let schema = field_info.get_as_req(intern!(py, "schema"))?;
 
             let validator = match build_validator(schema, config, build_context) {
                 Ok(v) => v,

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use pyo3::intern;
 use pyo3::prelude::*;
 #[cfg(not(PyPy))]
@@ -20,35 +18,13 @@ use crate::SchemaError;
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
-enum OnError {
-    Raise,
-    Omit,
-    FallbackOnDefault,
-}
-
-#[derive(Debug, Clone)]
 struct TypedDictField {
     name: String,
     lookup_key: LookupKey,
     name_pystring: Py<PyString>,
     required: bool,
-    on_error: OnError,
-    default: Option<PyObject>,
-    default_factory: Option<PyObject>,
     validator: CombinedValidator,
     frozen: bool,
-}
-
-impl TypedDictField {
-    fn default_value(&self, py: Python) -> PyResult<Option<Cow<PyObject>>> {
-        if let Some(ref default) = self.default {
-            Ok(Some(Cow::Borrowed(default)))
-        } else if let Some(ref default_factory) = self.default_factory {
-            Ok(Some(Cow::Owned(default_factory.call0(py)?)))
-        } else {
-            Ok(None)
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -117,16 +93,6 @@ impl BuildValidator for TypedDictValidator {
                 .get_as_req(intern!(py, "schema"))
                 .map_err(|err| SchemaError::new_err(format!("Field '{}':\n  {}", field_name, err)))?;
 
-            let (default, default_factory) = match (
-                field_info.get_as(intern!(py, "default"))?,
-                field_info.get_as(intern!(py, "default_factory"))?,
-            ) {
-                (Some(_default), Some(_default_factory)) => {
-                    return py_error!("'default' and 'default_factory' cannot be used together")
-                }
-                (default, default_factory) => (default, default_factory),
-            };
-
             let lookup_key = match field_info.get_item(intern!(py, "alias")) {
                 Some(alias) => {
                     let alt_alias = if populate_by_name { Some(field_name) } else { None };
@@ -135,58 +101,45 @@ impl BuildValidator for TypedDictValidator {
                 None => LookupKey::from_string(py, field_name),
             };
 
+            let validator = match build_validator(schema, config, build_context) {
+                Ok(v) => v,
+                Err(err) => return py_error!("Field \"{}\":\n  {}", field_name, err),
+            };
+
             let required = match field_info.get_as::<bool>(intern!(py, "required"))? {
                 Some(required) => {
-                    if required && (default.is_some() || default_factory.is_some()) {
-                        return py_error!("Field '{}': a required field cannot have a default value", field_name);
+                    if required {
+                        if let CombinedValidator::WithDefault(ref val) = validator {
+                            if val.has_default() {
+                                return py_error!(
+                                    "Field '{}': a required field cannot have a default value",
+                                    field_name
+                                );
+                            }
+                        }
                     }
                     required
                 }
                 None => total,
             };
 
-            let on_error = match field_info.get_as::<&str>(intern!(py, "on_error"))? {
-                Some(on_error) => match on_error {
-                    "raise" => OnError::Raise,
-                    "omit" => {
-                        if required {
-                            return py_error!(
-                                "Field '{}': 'on_error = {}' cannot be set for required fields",
-                                field_name,
-                                on_error
-                            );
-                        }
-
-                        OnError::Omit
+            if required {
+                if let CombinedValidator::WithDefault(ref val) = validator {
+                    if val.omit_on_error() {
+                        return py_error!(
+                            "Field '{}': 'on_error = omit' cannot be set for required fields",
+                            field_name
+                        );
                     }
-                    "fallback_on_default" => {
-                        if default.is_none() && default_factory.is_none() {
-                            return py_error!(
-                                "Field '{}': 'on_error = {}' requires a `default` or `default_factory`",
-                                field_name,
-                                on_error
-                            );
-                        }
-
-                        OnError::FallbackOnDefault
-                    }
-                    _ => unreachable!(),
-                },
-                None => OnError::Raise,
-            };
+                }
+            }
 
             fields.push(TypedDictField {
                 name: field_name.to_string(),
                 lookup_key,
                 name_pystring: PyString::intern(py, field_name).into(),
-                validator: match build_validator(schema, config, build_context) {
-                    Ok(v) => v,
-                    Err(err) => return py_error!("Field \"{}\":\n  {}", field_name, err),
-                },
+                validator,
                 required,
-                default,
-                default_factory,
-                on_error,
                 frozen: field_info.get_as::<bool>(intern!(py, "frozen"))?.unwrap_or(false),
             });
         }
@@ -273,26 +226,18 @@ impl Validator for TypedDictValidator {
                                     fs.push(field.name_pystring.clone_ref(py));
                                 }
                             }
-                            Err(ValError::LineErrors(line_errors)) => match field.on_error {
-                                OnError::Raise => {
-                                    for err in line_errors {
-                                        errors.push(err.with_outer_location(field.name.clone().into()));
-                                    }
-                                }
-                                OnError::Omit => continue,
-                                OnError::FallbackOnDefault => {
-                                    if let Some(default_value) = field.default_value(py)? {
-                                        output_dict.set_item(&field.name_pystring, default_value.as_ref())?;
-                                    }
-                                }
-                            },
+                            Err(ValError::Omit) => continue,
                             Err(err) => return Err(err),
                         }
-                    } else if let Some(default_value) = field.default_value(py)? {
-                        output_dict.set_item(&field.name_pystring, default_value.as_ref())?
-                    } else if !field.required {
                         continue;
-                    } else {
+                    } else if let CombinedValidator::WithDefault(ref validator) = field.validator {
+                        if let Some(value) = validator.default_value(py)? {
+                            output_dict.set_item(&field.name_pystring, value.as_ref())?;
+                            continue;
+                        }
+                    }
+
+                    if field.required {
                         errors.push(ValLineError::new_with_loc(
                             ErrorKind::Missing,
                             input,

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -56,7 +56,7 @@ impl BuildValidator for WithDefaultValidator {
             Some(on_error) => match on_error {
                 "raise" => OnError::Raise,
                 "omit" => OnError::Omit,
-                "fallback_on_default" => {
+                "default" => {
                     if matches!(default, DefaultType::None) {
                         return py_error!("'on_error = {}' requires a `default` or `default_factory`", on_error);
                     }

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -126,3 +126,11 @@ impl WithDefaultValidator {
         matches!(self.on_error, OnError::Omit)
     }
 }
+
+pub fn get_default<'a>(py: Python<'a>, validator: &'a CombinedValidator) -> PyResult<Option<Cow<'a, PyObject>>> {
+    if let CombinedValidator::WithDefault(validator) = validator {
+        validator.default_value(py)
+    } else {
+        Ok(None)
+    }
+}

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -1,0 +1,128 @@
+use std::borrow::Cow;
+
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::build_tools::{py_error, SchemaDict};
+use crate::errors::{ValError, ValResult};
+use crate::input::Input;
+use crate::recursion_guard::RecursionGuard;
+use crate::validators::build_validator;
+
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
+
+#[derive(Debug, Clone)]
+enum DefaultType {
+    None,
+    Default(PyObject),
+    DefaultFactory(PyObject),
+}
+
+#[derive(Debug, Clone)]
+enum OnError {
+    Raise,
+    Omit,
+    FallbackOnDefault,
+}
+
+#[derive(Debug, Clone)]
+pub struct WithDefaultValidator {
+    default: DefaultType,
+    on_error: OnError,
+    validator: Box<CombinedValidator>,
+    name: String,
+}
+
+impl BuildValidator for WithDefaultValidator {
+    const EXPECTED_TYPE: &'static str = "default";
+
+    fn build(
+        schema: &PyDict,
+        config: Option<&PyDict>,
+        build_context: &mut BuildContext,
+    ) -> PyResult<CombinedValidator> {
+        let py = schema.py();
+        let default = match (
+            schema.get_as(intern!(py, "default"))?,
+            schema.get_as(intern!(py, "default_factory"))?,
+        ) {
+            (Some(_), Some(_)) => return py_error!("'default' and 'default_factory' cannot be used together"),
+            (Some(default), None) => DefaultType::Default(default),
+            (None, Some(default_factory)) => DefaultType::DefaultFactory(default_factory),
+            (None, None) => DefaultType::None,
+        };
+        let on_error = match schema.get_as::<&str>(intern!(py, "on_error"))? {
+            Some(on_error) => match on_error {
+                "raise" => OnError::Raise,
+                "omit" => OnError::Omit,
+                "fallback_on_default" => {
+                    if matches!(default, DefaultType::None) {
+                        return py_error!("'on_error = {}' requires a `default` or `default_factory`", on_error);
+                    }
+                    OnError::FallbackOnDefault
+                }
+                _ => unreachable!(),
+            },
+            None => OnError::Raise,
+        };
+
+        let sub_schema: &PyAny = schema.get_as_req(intern!(schema.py(), "schema"))?;
+        let validator = Box::new(build_validator(sub_schema, config, build_context)?);
+        let name = format!("{}[{}]", Self::EXPECTED_TYPE, validator.get_name());
+
+        Ok(Self {
+            default,
+            on_error,
+            validator,
+            name,
+        }
+        .into())
+    }
+}
+
+impl Validator for WithDefaultValidator {
+    fn validate<'s, 'data>(
+        &'s self,
+        py: Python<'data>,
+        input: &'data impl Input<'data>,
+        extra: &Extra,
+        slots: &'data [CombinedValidator],
+        recursion_guard: &'s mut RecursionGuard,
+    ) -> ValResult<'data, PyObject> {
+        match self.validator.validate(py, input, extra, slots, recursion_guard) {
+            Ok(v) => Ok(v),
+            Err(e) => match self.on_error {
+                OnError::Raise => Err(e),
+                OnError::FallbackOnDefault => Ok(self.default_value(py)?.unwrap().as_ref().clone()),
+                OnError::Omit => Err(ValError::Omit),
+            },
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn complete(&mut self, build_context: &BuildContext) -> PyResult<()> {
+        self.validator.complete(build_context)
+    }
+}
+
+impl WithDefaultValidator {
+    pub fn default_value(&self, py: Python) -> PyResult<Option<Cow<PyObject>>> {
+        match self.default {
+            DefaultType::Default(ref default) => Ok(Some(Cow::Borrowed(default))),
+            DefaultType::DefaultFactory(ref default_factory) => Ok(Some(Cow::Owned(default_factory.call0(py)?))),
+            DefaultType::None => Ok(None),
+        }
+    }
+
+    pub fn has_default(&self) -> bool {
+        !matches!(self.default, DefaultType::None)
+    }
+
+    pub fn omit_on_error(&self) -> bool {
+        matches!(self.on_error, OnError::Omit)
+    }
+}

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -131,10 +131,13 @@ def schema(*, strict: bool = False) -> dict:
                             'name': {'schema': 'str'},
                             'sub_branch': {
                                 'schema': {
-                                    'type': 'nullable',
-                                    'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'},
-                                },
-                                'default': None,
+                                    'type': 'default',
+                                    'schema': {
+                                        'type': 'nullable',
+                                        'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'},
+                                    },
+                                    'default': None,
+                                }
                             },
                         },
                     }

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -856,5 +856,5 @@ def test_with_default(benchmark):
 
     @benchmark
     def t():
-        v.validate_python({'name': 42})
+        v.validate_python({'name': 'Foo'})
         v.validate_python({})

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -239,11 +239,8 @@ def test_recursive_model_core(recursive_model_data, benchmark):
                 'fields': {
                     'width': {'schema': {'type': 'int'}},
                     'branch': {
-                        'schema': {
-                            'type': 'default',
-                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
-                            'default': None,
-                        }
+                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
+                        'default': None,
                     },
                 },
             },
@@ -844,3 +841,15 @@ def test_arguments(benchmark):
     assert v.validate_python(((1, 'a', 'true'), {'b': 'bb', 'c': 3})) == ((1, 'a', True), {'b': 'bb', 'c': 3})
 
     benchmark(v.validate_python, ((1, 'a', 'true'), {'b': 'bb', 'c': 3}))
+
+
+@pytest.mark.benchmark(group='defaults')
+def test_with_default(benchmark):
+    v = SchemaValidator(
+        {'type': 'typed-dict', 'fields': {'name': {'schema': {'type': 'default', 'schema': 'str', 'default': 'John'}}}}
+    )
+    assert v.validate_python({'name': 'Foo'}) == {'name': 'Foo'}
+    assert v.validate_python({}) == {'name': 'John'}
+
+    benchmark(v.validate_python, {}, name='with-default')
+    benchmark(v.validate_python, {'name': 'Foo'}, name='with-value')

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -239,8 +239,11 @@ def test_recursive_model_core(recursive_model_data, benchmark):
                 'fields': {
                     'width': {'schema': {'type': 'int'}},
                     'branch': {
-                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
-                        'default': None,
+                        'schema': {
+                            'type': 'default',
+                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
+                            'default': None,
+                        }
                     },
                 },
             },

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -854,5 +854,7 @@ def test_with_default(benchmark):
     assert v.validate_python({'name': 'Foo'}) == {'name': 'Foo'}
     assert v.validate_python({}) == {'name': 'John'}
 
-    benchmark(v.validate_python, {}, name='with-default')
-    benchmark(v.validate_python, {'name': 'Foo'}, name='with-value')
+    @benchmark
+    def t():
+        v.validate_python({'name': 42})
+        v.validate_python({})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,12 +90,6 @@ def tmp_work_path(tmp_path: Path):
 @pytest.fixture
 def import_execute(request, tmp_work_path: Path):
     def _import_execute(source: str, *, custom_module_name: 'str | None' = None):
-        example_bash_file = tmp_work_path / 'example.sh'
-        example_bash_file.write_text('#!/bin/sh\necho testing')
-        example_bash_file.chmod(0o755)
-        (tmp_work_path / 'first/path').mkdir(parents=True, exist_ok=True)
-        (tmp_work_path / 'second/path').mkdir(parents=True, exist_ok=True)
-
         module_name = custom_module_name or request.node.name
 
         module_path = tmp_work_path / f'{module_name}.py'

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -61,8 +61,11 @@ def recursive_schema():
             'fields': {
                 'name': {'schema': {'type': 'str'}},
                 'sub_branch': {
-                    'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
-                    'default': None,
+                    'schema': {
+                        'type': 'default',
+                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
+                        'default': None,
+                    }
                 },
             },
         }

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -64,7 +64,7 @@ def test_schema_typing() -> None:
             'a': {'schema': {'type': 'str'}},
             'b': {'schema': {'type': 'str'}, 'alias': 'foobar'},
             'c': {'schema': {'type': 'str'}, 'alias': [['foobar', 0, 'bar'], ['foo']]},
-            'd': {'schema': {'type': 'str'}, 'default': 'spam'},
+            'd': {'schema': {'type': 'default', 'schema': 'str', 'default': 'spam'}},
         },
     }
     SchemaValidator(schema)
@@ -79,10 +79,13 @@ def test_schema_typing() -> None:
             'name': {'schema': {'type': 'str'}},
             'sub_branch': {
                 'schema': {
-                    'type': 'union',
-                    'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
-                },
-                'default': None,
+                    'type': 'default',
+                    'schema': {
+                        'type': 'union',
+                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
+                    },
+                    'default': None,
+                }
             },
         },
     }

--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -360,7 +360,9 @@ def test_positional_optional(py_and_json: PyAndJson, input_value, expected):
     v = py_and_json(
         {
             'type': 'arguments',
-            'arguments_schema': [{'name': 'a', 'mode': 'positional_only', 'schema': 'int', 'default': 42}],
+            'arguments_schema': [
+                {'name': 'a', 'mode': 'positional_only', 'schema': {'type': 'default', 'schema': 'int', 'default': 42}}
+            ],
         }
     )
     if isinstance(expected, Err):
@@ -387,7 +389,13 @@ def test_p_or_k_optional(py_and_json: PyAndJson, input_value, expected):
     v = py_and_json(
         {
             'type': 'arguments',
-            'arguments_schema': [{'name': 'a', 'mode': 'positional_or_keyword', 'schema': 'int', 'default': 1}],
+            'arguments_schema': [
+                {
+                    'name': 'a',
+                    'mode': 'positional_or_keyword',
+                    'schema': {'type': 'default', 'schema': 'int', 'default': 1},
+                }
+            ],
         }
     )
     if isinstance(expected, Err):
@@ -621,7 +629,11 @@ def test_default_factory(py_and_json: PyAndJson, input_value, expected):
             'type': 'arguments',
             'arguments_schema': [
                 {'name': 'a', 'mode': 'positional_or_keyword', 'schema': 'int'},
-                {'name': 'b', 'mode': 'positional_or_keyword', 'schema': 'int', 'default_factory': lambda: 42},
+                {
+                    'name': 'b',
+                    'mode': 'positional_or_keyword',
+                    'schema': {'type': 'default', 'schema': 'int', 'default_factory': lambda: 42},
+                },
             ],
         }
     )
@@ -634,7 +646,11 @@ def test_repr():
             'type': 'arguments',
             'arguments_schema': [
                 {'name': 'b', 'mode': 'positional_or_keyword', 'schema': 'int'},
-                {'name': 'a', 'mode': 'keyword_only', 'schema': 'int', 'default_factory': lambda: 42},
+                {
+                    'name': 'a',
+                    'mode': 'keyword_only',
+                    'schema': {'type': 'default', 'schema': 'int', 'default_factory': lambda: 42},
+                },
             ],
         }
     )
@@ -642,20 +658,7 @@ def test_repr():
 
 
 def test_build_non_default_follows():
-    with pytest.raises(SchemaError, match='Non-default argument follows default argument'):
-        SchemaValidator(
-            {
-                'type': 'arguments',
-                'arguments_schema': [
-                    {'name': 'a', 'mode': 'positional_or_keyword', 'schema': 'int', 'default_factory': lambda: 42},
-                    {'name': 'b', 'mode': 'positional_or_keyword', 'schema': 'int'},
-                ],
-            }
-        )
-
-
-def test_build_default_and_default_factory():
-    with pytest.raises(SchemaError, match="'default' and 'default_factory' cannot be used together"):
+    with pytest.raises(SchemaError, match="Non-default argument 'b' follows default argument"):
         SchemaValidator(
             {
                 'type': 'arguments',
@@ -663,10 +666,9 @@ def test_build_default_and_default_factory():
                     {
                         'name': 'a',
                         'mode': 'positional_or_keyword',
-                        'schema': 'int',
-                        'default_factory': lambda: 1,
-                        'default': 2,
-                    }
+                        'schema': {'type': 'default', 'schema': 'int', 'default_factory': lambda: 42},
+                    },
+                    {'name': 'b', 'mode': 'positional_or_keyword', 'schema': 'int'},
                 ],
             }
         )
@@ -777,9 +779,9 @@ def validate(function):
             arg_schema = 'any'
 
         if p.kind in mode_lookup:
-            s = {'name': name, 'mode': mode_lookup[p.kind], 'schema': arg_schema}
             if p.default is not p.empty:
-                s['default'] = p.default
+                arg_schema = {'type': 'default', 'schema': arg_schema, 'default': p.default}
+            s = {'name': name, 'mode': mode_lookup[p.kind], 'schema': arg_schema}
             arguments_schema.append(s)
         elif p.kind == Parameter.VAR_POSITIONAL:
             schema['var_args_schema'] = arg_schema

--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -941,3 +941,19 @@ def test_function_args_kwargs():
     assert foobar(1, 2, 3) == ((1, 2, 3), {})
     assert foobar(a=1, b=2, c=3) == ((), {'a': 1, 'b': 2, 'c': 3})
     assert foobar() == ((), {})
+
+
+def test_invalid_schema():
+    with pytest.raises(SchemaError, match="'default' and 'default_factory' cannot be used together"):
+        SchemaValidator(
+            {
+                'type': 'arguments',
+                'arguments_schema': [
+                    {
+                        'name': 'a',
+                        'mode': 'positional_or_keyword',
+                        'schema': {'type': 'default', 'schema': 'int', 'default': 1, 'default_factory': lambda: 2},
+                    }
+                ],
+            }
+        )

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -18,10 +18,13 @@ def test_branch_nullable():
                 'name': {'schema': {'type': 'str'}},
                 'sub_branch': {
                     'schema': {
-                        'type': 'union',
-                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
-                    },
-                    'default': None,
+                        'type': 'default',
+                        'schema': {
+                            'type': 'union',
+                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
+                        },
+                        'default': None,
+                    }
                 },
             },
         }
@@ -46,10 +49,13 @@ def test_nullable_error():
                 'width': {'schema': 'int'},
                 'sub_branch': {
                     'schema': {
-                        'type': 'union',
-                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
-                    },
-                    'default': None,
+                        'type': 'default',
+                        'schema': {
+                            'type': 'union',
+                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
+                        },
+                        'default': None,
+                    }
                 },
             },
         }
@@ -83,8 +89,14 @@ def test_list():
             'fields': {
                 'width': {'schema': 'int'},
                 'branches': {
-                    'schema': {'type': 'list', 'items_schema': {'type': 'recursive-ref', 'schema_ref': 'BranchList'}},
-                    'default': None,
+                    'schema': {
+                        'type': 'default',
+                        'schema': {
+                            'type': 'list',
+                            'items_schema': {'type': 'recursive-ref', 'schema_ref': 'BranchList'},
+                        },
+                        'default': None,
+                    }
                 },
             },
         }
@@ -124,17 +136,23 @@ def test_multiple_intertwined():
                             'width': {'schema': 'int'},
                             'bars': {
                                 'schema': {
-                                    'type': 'list',
-                                    'items_schema': {'type': 'recursive-ref', 'schema_ref': 'Bar'},
-                                },
-                                'default': None,
+                                    'type': 'default',
+                                    'schema': {
+                                        'type': 'list',
+                                        'items_schema': {'type': 'recursive-ref', 'schema_ref': 'Bar'},
+                                    },
+                                    'default': None,
+                                }
                             },
                             'foo': {
                                 'schema': {
-                                    'type': 'union',
-                                    'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Foo'}],
-                                },
-                                'default': None,
+                                    'type': 'default',
+                                    'schema': {
+                                        'type': 'union',
+                                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Foo'}],
+                                    },
+                                    'default': None,
+                                }
                             },
                         },
                     }
@@ -174,10 +192,13 @@ def test_model_class():
                     'width': {'schema': 'int'},
                     'branch': {
                         'schema': {
-                            'type': 'union',
-                            'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
-                        },
-                        'default': None,
+                            'type': 'default',
+                            'schema': {
+                                'type': 'union',
+                                'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'schema_ref': 'Branch'}],
+                            },
+                            'default': None,
+                        }
                     },
                 },
             },
@@ -209,8 +230,14 @@ def test_invalid_schema():
                     'fields': {
                         'width': {'schema': {'type': 'int'}},
                         'branch': {
-                            'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
-                            'default': None,
+                            'schema': {
+                                'type': 'default',
+                                'schema': {
+                                    'type': 'nullable',
+                                    'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'},
+                                },
+                                'default': None,
+                            }
                         },
                     },
                 },
@@ -250,8 +277,11 @@ def test_recursion_branch():
             'fields': {
                 'name': {'schema': {'type': 'str'}},
                 'branch': {
-                    'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
-                    'default': None,
+                    'schema': {
+                        'type': 'default',
+                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 'Branch'}},
+                        'default': None,
+                    }
                 },
             },
         },
@@ -335,8 +365,11 @@ def multiple_tuple_schema() -> SchemaValidator:
                     }
                 },
                 'f2': {
-                    'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 't'}},
-                    'default': None,
+                    'schema': {
+                        'type': 'default',
+                        'schema': {'type': 'nullable', 'schema': {'type': 'recursive-ref', 'schema_ref': 't'}},
+                        'default': None,
+                    }
                 },
             },
         }

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -439,7 +439,10 @@ def test_fields_required_by_default_with_default():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}, 'default': 'bulbi'}},
+            'fields': {
+                'x': {'schema': {'type': 'str'}},
+                'y': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'bulbi'}},
+            },
         }
     )
 
@@ -498,7 +501,12 @@ def test_field_required_and_default():
     """A field cannot be required and have a default value"""
     with pytest.raises(SchemaError, match="Field 'x': a required field cannot have a default value"):
         SchemaValidator(
-            {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'required': True, 'default': 'pika'}}}
+            {
+                'type': 'typed-dict',
+                'fields': {
+                    'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'pika'}, 'required': True}
+                },
+            }
         )
 
 
@@ -1102,24 +1110,16 @@ def test_alias_extra_forbid(py_and_json: PyAndJson):
 
 def test_with_default_factory():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'default_factory': lambda: 'pikachu'}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda: 'pikachu'}}
+            },
+        }
     )
 
     assert v.validate_python({}) == {'x': 'pikachu'}
     assert v.validate_python({'x': 'bulbi'}) == {'x': 'bulbi'}
-
-
-def test_default_and_default_factory():
-    """`default` and `default_factory` should not be set together"""
-    with pytest.raises(SchemaError, match="'default' and 'default_factory' cannot be used together"):
-        SchemaValidator(
-            {
-                'type': 'typed-dict',
-                'fields': {
-                    'x': {'schema': {'type': 'str'}, 'default': 'pikachu', 'default_factory': lambda: 'pikachu'}
-                },
-            }
-        )
 
 
 def test_field_required_and_default_factory():
@@ -1128,7 +1128,12 @@ def test_field_required_and_default_factory():
         SchemaValidator(
             {
                 'type': 'typed-dict',
-                'fields': {'x': {'schema': {'type': 'str'}, 'required': True, 'default_factory': lambda: 'pika'}},
+                'fields': {
+                    'x': {
+                        'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda: 'pika'},
+                        'required': True,
+                    }
+                },
             }
         )
 
@@ -1142,7 +1147,12 @@ def test_field_required_and_default_factory():
 )
 def test_bad_default_factory(default_factory, error_message):
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'default_factory': default_factory}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': default_factory}}
+            },
+        }
     )
     with pytest.raises(TypeError, match=re.escape(error_message)):
         v.validate_python({})
@@ -1151,15 +1161,30 @@ def test_bad_default_factory(default_factory, error_message):
 class TestOnError:
     def test_on_error_bad_name(self):
         with pytest.raises(SchemaError, match="Input should be one of: 'raise', 'omit', 'default'"):
-            SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'rais'}}})
+            SchemaValidator(
+                {
+                    'type': 'typed-dict',
+                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'rais'}}},
+                }
+            )
 
     def test_on_error_bad_omit(self):
         with pytest.raises(SchemaError, match="Field 'x': 'on_error = omit' cannot be set for required fields"):
-            SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'omit'}}})
+            SchemaValidator(
+                {
+                    'type': 'typed-dict',
+                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'}}},
+                }
+            )
 
     def test_on_error_bad_default(self):
         with pytest.raises(SchemaError, match="'on_error = default' requires a `default` or `default_factory`"):
-            SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'default'}}})
+            SchemaValidator(
+                {
+                    'type': 'typed-dict',
+                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'default'}}},
+                }
+            )
 
     def test_on_error_raise_by_default(self, py_and_json: PyAndJson):
         v = py_and_json({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}}})
@@ -1171,7 +1196,12 @@ class TestOnError:
         ]
 
     def test_on_error_raise_explicit(self, py_and_json: PyAndJson):
-        v = py_and_json({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'raise'}}})
+        v = py_and_json(
+            {
+                'type': 'typed-dict',
+                'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'raise'}}},
+            }
+        )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
         with pytest.raises(ValidationError) as exc_info:
             v.validate_test({'x': ['foo']})
@@ -1181,7 +1211,15 @@ class TestOnError:
 
     def test_on_error_omit(self, py_and_json: PyAndJson):
         v = py_and_json(
-            {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'omit', 'required': False}}}
+            {
+                'type': 'typed-dict',
+                'fields': {
+                    'x': {
+                        'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'},
+                        'required': False,
+                    }
+                },
+            }
         )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
         assert v.validate_test({}) == {}
@@ -1191,7 +1229,12 @@ class TestOnError:
         v = py_and_json(
             {
                 'type': 'typed-dict',
-                'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'omit', 'default': 'pika', 'required': False}},
+                'fields': {
+                    'x': {
+                        'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit', 'default': 'pika'},
+                        'required': False,
+                    }
+                },
             }
         )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
@@ -1202,7 +1245,9 @@ class TestOnError:
         v = py_and_json(
             {
                 'type': 'typed-dict',
-                'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'default', 'default': 'pika'}},
+                'fields': {
+                    'x': {'schema': {'type': 'default', 'schema': 'str', 'on_error': 'default', 'default': 'pika'}}
+                },
             }
         )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
@@ -1243,12 +1288,15 @@ class TestOnError:
                 'fields': {
                     'x': {
                         'schema': {
-                            'type': 'function',
-                            'mode': 'wrap',
-                            'function': wrap_function,
-                            'schema': {'type': 'str'},
-                        },
-                        'on_error': 'raise',
+                            'type': 'default',
+                            'on_error': 'raise',
+                            'schema': {
+                                'type': 'function',
+                                'mode': 'wrap',
+                                'function': wrap_function,
+                                'schema': {'type': 'str'},
+                            },
+                        }
                     }
                 },
             }
@@ -1266,7 +1314,7 @@ def test_frozen_field():
             'fields': {
                 'name': {'schema': {'type': 'str'}},
                 'age': {'schema': {'type': 'int'}},
-                'is_developer': {'schema': {'type': 'bool'}, 'default': True, 'frozen': True},
+                'is_developer': {'schema': {'type': 'default', 'schema': 'bool', 'default': True}, 'frozen': True},
             },
         }
     )
@@ -1279,14 +1327,3 @@ def test_frozen_field():
     assert exc_info.value.errors() == [
         {'kind': 'frozen', 'loc': ['is_developer'], 'message': 'Field is frozen', 'input_value': False}
     ]
-
-
-def test_default_schema_with_default():
-    msg = "'default', 'default_factory' and 'on_error' on a field cannot be combined with a schema of type 'default'"
-    with pytest.raises(SchemaError, match=msg):
-        SchemaValidator(
-            {
-                'type': 'typed-dict',
-                'fields': {'name': {'schema': {'type': 'default', 'schema': 'str', 'default': 'F'}, 'default': 'B'}},
-            }
-        )

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -74,7 +74,10 @@ def test_with_default():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}, 'default': 666}},
+            'fields': {
+                'field_a': {'schema': {'type': 'str'}},
+                'field_b': {'schema': {'type': 'default', 'schema': 'int', 'default': 666}},
+            },
         }
     )
 

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -1150,20 +1150,16 @@ def test_bad_default_factory(default_factory, error_message):
 
 class TestOnError:
     def test_on_error_bad_name(self):
-        with pytest.raises(SchemaError, match="Input should be one of: 'raise', 'omit', 'fallback_on_default'"):
+        with pytest.raises(SchemaError, match="Input should be one of: 'raise', 'omit', 'default'"):
             SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'rais'}}})
 
     def test_on_error_bad_omit(self):
         with pytest.raises(SchemaError, match="Field 'x': 'on_error = omit' cannot be set for required fields"):
             SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'omit'}}})
 
-    def test_on_error_bad_fallback_on_default(self):
-        with pytest.raises(
-            SchemaError, match="'on_error = fallback_on_default' requires a `default` or `default_factory`"
-        ):
-            SchemaValidator(
-                {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'fallback_on_default'}}}
-            )
+    def test_on_error_bad_default(self):
+        with pytest.raises(SchemaError, match="'on_error = default' requires a `default` or `default_factory`"):
+            SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'default'}}})
 
     def test_on_error_raise_by_default(self, py_and_json: PyAndJson):
         v = py_and_json({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}}})
@@ -1202,17 +1198,17 @@ class TestOnError:
         assert v.validate_test({}) == {'x': 'pika'}
         assert v.validate_test({'x': ['foo']}) == {}
 
-    def test_on_error_fallback_on_default(self, py_and_json: PyAndJson):
+    def test_on_error_default(self, py_and_json: PyAndJson):
         v = py_and_json(
             {
                 'type': 'typed-dict',
-                'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'fallback_on_default', 'default': 'pika'}},
+                'fields': {'x': {'schema': {'type': 'str'}, 'on_error': 'default', 'default': 'pika'}},
             }
         )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
         assert v.validate_test({'x': ['foo']}) == {'x': 'pika'}
 
-    def test_on_error_fallback_on_default_factory(self, py_and_json: PyAndJson):
+    def test_on_error_default_factory(self, py_and_json: PyAndJson):
         v = py_and_json(
             {
                 'type': 'typed-dict',
@@ -1221,7 +1217,7 @@ class TestOnError:
                         'schema': {
                             'type': 'default',
                             'schema': {'type': 'str'},
-                            'on_error': 'fallback_on_default',
+                            'on_error': 'default',
                             'default_factory': lambda: 'pika',
                         }
                     }

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -138,7 +138,7 @@ class TestModelClassSimilar:
                             'fields': {
                                 'a': {'schema': {'type': 'int'}},
                                 'b': {'schema': {'type': 'str'}},
-                                'c': {'schema': {'type': 'float'}, 'default': 1.0},
+                                'c': {'schema': {'type': 'default', 'schema': {'type': 'float'}, 'default': 1.0}},
                             },
                         },
                     },

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -3,36 +3,133 @@ import pytest
 from pydantic_core import SchemaError, SchemaValidator
 
 
+def test_typed_dict_default():
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'schema': 'str'},
+                'y': {'schema': {'type': 'default', 'schema': 'str', 'default': '[default]'}},
+            },
+        }
+    )
+    assert v.validate_python({'x': 'x', 'y': 'y'}) == {'x': 'x', 'y': 'y'}
+    assert v.validate_python({'x': 'x'}) == {'x': 'x', 'y': '[default]'}
+
+
+def test_typed_dict_omit():
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'schema': 'str'},
+                'y': {'schema': {'type': 'default', 'schema': 'str', 'on_error': 'omit'}, 'required': False},
+            },
+        }
+    )
+    assert v.validate_python({'x': 'x', 'y': 'y'}) == {'x': 'x', 'y': 'y'}
+    assert v.validate_python({'x': 'x'}) == {'x': 'x'}
+    assert v.validate_python({'x': 'x', 'y': 42}) == {'x': 'x'}
+
+
+def test_arguments():
+    v = SchemaValidator(
+        {
+            'type': 'arguments',
+            'arguments_schema': [
+                {
+                    'name': 'a',
+                    'mode': 'positional_or_keyword',
+                    'schema': {'type': 'default', 'schema': 'int', 'default_factory': lambda: 1},
+                }
+            ],
+        }
+    )
+    assert v.validate_python(((), {'a': 2})) == ((), {'a': 2})
+    assert v.validate_python(((2,), {})) == ((2,), {})
+    assert v.validate_python(((), {})) == ((), {'a': 1})
+
+
+def test_arguments_omit():
+    with pytest.raises(SchemaError, match="Parameter 'a': omit_on_error cannot be used with arguments"):
+        SchemaValidator(
+            {
+                'type': 'arguments',
+                'arguments_schema': [
+                    {
+                        'name': 'a',
+                        'mode': 'positional_or_keyword',
+                        'schema': {'type': 'default', 'schema': 'int', 'default': 1, 'on_error': 'omit'},
+                    }
+                ],
+            }
+        )
+
+
+def test_list():
+    v = SchemaValidator({'type': 'list', 'items_schema': {'type': 'default', 'schema': 'int', 'on_error': 'omit'}})
+    assert v.validate_python([1, 2, 3]) == [1, 2, 3]
+    assert v.validate_python([1, '2', 3]) == [1, 2, 3]
+    assert v.validate_python([1, 'wrong', 3]) == [1, 3]
+
+
+def test_set():
+    v = SchemaValidator({'type': 'set', 'items_schema': {'type': 'default', 'schema': 'int', 'on_error': 'omit'}})
+    assert v.validate_python({1, 2, 3}) == {1, 2, 3}
+    assert v.validate_python([1, '2', 3]) == {1, 2, 3}
+    assert v.validate_python([1, 'wrong', 3]) == {1, 3}
+
+
+def test_tuple_variable():
+    v = SchemaValidator({'type': 'tuple', 'items_schema': {'type': 'default', 'schema': 'int', 'on_error': 'omit'}})
+    assert v.validate_python((1, 2, 3)) == (1, 2, 3)
+    assert v.validate_python([1, '2', 3]) == (1, 2, 3)
+    assert v.validate_python([1, 'wrong', 3]) == (1, 3)
+
+
+@pytest.mark.xfail(reason='TODO')
+def test_tuple_positional():
+    v = SchemaValidator(
+        {
+            'type': 'tuple',
+            'mode': 'positional',
+            'items_schema': [{'type': 'int'}, {'type': 'default', 'schema': 'int', 'default': 42}],
+        }
+    )
+    assert v.validate_python((1, '2')) == (1, 2)
+    assert v.validate_python((1,)) == (1, 42)
+
+
 def test_on_error_default():
-    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default': 2, 'on_error': 'default'})
-    assert s.validate_python(42) == 42
-    assert s.validate_python('42') == 42
-    assert s.validate_python('wrong') == 2
+    v = SchemaValidator({'type': 'default', 'schema': 'int', 'default': 2, 'on_error': 'default'})
+    assert v.validate_python(42) == 42
+    assert v.validate_python('42') == 42
+    assert v.validate_python('wrong') == 2
 
 
 def test_on_error_default_not_int():
-    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default': [1, 2, 3], 'on_error': 'default'})
-    assert s.validate_python(42) == 42
-    assert s.validate_python('42') == 42
-    a = s.validate_python('wrong')
+    v = SchemaValidator({'type': 'default', 'schema': 'int', 'default': [1, 2, 3], 'on_error': 'default'})
+    assert v.validate_python(42) == 42
+    assert v.validate_python('42') == 42
+    a = v.validate_python('wrong')
     assert a == [1, 2, 3]
     # default is not copied, so mutating it mutates the default
     a.append(4)
-    assert s.validate_python('wrong') == [1, 2, 3, 4]
+    assert v.validate_python('wrong') == [1, 2, 3, 4]
 
 
 def test_on_error_default_factory():
-    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default_factory': lambda: 17, 'on_error': 'default'})
-    assert s.validate_python(42) == 42
-    assert s.validate_python('42') == 42
-    assert s.validate_python('wrong') == 17
+    v = SchemaValidator({'type': 'default', 'schema': 'int', 'default_factory': lambda: 17, 'on_error': 'default'})
+    assert v.validate_python(42) == 42
+    assert v.validate_python('42') == 42
+    assert v.validate_python('wrong') == 17
 
 
 def test_on_error_omit():
-    s = SchemaValidator({'type': 'default', 'schema': 'int', 'on_error': 'omit'})
-    assert s.validate_python(42) == 42
+    v = SchemaValidator({'type': 'default', 'schema': 'int', 'on_error': 'omit'})
+    assert v.validate_python(42) == 42
     with pytest.raises(ValueError, match='Uncaught Omit error, please check your usage of "default" validators.'):
-        s.validate_python('wrong')
+        v.validate_python('wrong')
 
 
 def test_on_error_wrong():

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -1,0 +1,45 @@
+import pytest
+
+from pydantic_core import SchemaError, SchemaValidator
+
+
+def test_on_error_default():
+    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default': 2, 'on_error': 'default'})
+    assert s.validate_python(42) == 42
+    assert s.validate_python('42') == 42
+    assert s.validate_python('wrong') == 2
+
+
+def test_on_error_default_not_int():
+    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default': [1, 2, 3], 'on_error': 'default'})
+    assert s.validate_python(42) == 42
+    assert s.validate_python('42') == 42
+    a = s.validate_python('wrong')
+    assert a == [1, 2, 3]
+    # default is not copied, so mutating it mutates the default
+    a.append(4)
+    assert s.validate_python('wrong') == [1, 2, 3, 4]
+
+
+def test_on_error_default_factory():
+    s = SchemaValidator({'type': 'default', 'schema': 'int', 'default_factory': lambda: 17, 'on_error': 'default'})
+    assert s.validate_python(42) == 42
+    assert s.validate_python('42') == 42
+    assert s.validate_python('wrong') == 17
+
+
+def test_on_error_omit():
+    s = SchemaValidator({'type': 'default', 'schema': 'int', 'on_error': 'omit'})
+    assert s.validate_python(42) == 42
+    with pytest.raises(ValueError, match='Uncaught Omit error, please check your usage of "default" validators.'):
+        s.validate_python('wrong')
+
+
+def test_on_error_wrong():
+    with pytest.raises(SchemaError, match="'on_error = default' requires a `default` or `default_factory`"):
+        SchemaValidator({'type': 'default', 'schema': 'int', 'on_error': 'default'})
+
+
+def test_build_default_and_default_factory():
+    with pytest.raises(SchemaError, match="'default' and 'default_factory' cannot be used together"):
+        SchemaValidator({'type': 'default', 'schema': 'int', 'default_factory': lambda: 1, 'default': 2})

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -87,7 +87,6 @@ def test_tuple_variable():
     assert v.validate_python([1, 'wrong', 3]) == (1, 3)
 
 
-@pytest.mark.xfail(reason='TODO')
 def test_tuple_positional():
     v = SchemaValidator(
         {
@@ -97,7 +96,25 @@ def test_tuple_positional():
         }
     )
     assert v.validate_python((1, '2')) == (1, 2)
+    assert v.validate_python([1, '2']) == (1, 2)
+    assert v.validate_json('[1, "2"]') == (1, 2)
     assert v.validate_python((1,)) == (1, 42)
+
+
+def test_tuple_positional_omit():
+    v = SchemaValidator(
+        {
+            'type': 'tuple',
+            'mode': 'positional',
+            'items_schema': ['int', 'int'],
+            'extra_schema': {'type': 'default', 'schema': 'int', 'on_error': 'omit'},
+        }
+    )
+    assert v.validate_python((1, '2')) == (1, 2)
+    assert v.validate_python((1, '2', 3, '4')) == (1, 2, 3, 4)
+    assert v.validate_python((1, '2', 'wrong', '4')) == (1, 2, 4)
+    assert v.validate_python((1, '2', 3, 'x4')) == (1, 2, 3)
+    assert v.validate_json('[1, "2", 3, "x4"]') == (1, 2, 3)
 
 
 def test_on_error_default():


### PR DESCRIPTION
continuing from #200, moving default and `on_error` behaviour into separate validator for reuse in other places.

@PrettyWood this is ready to review and will be ready to merge soon. But I know you're busy so I'll probably merge once I'm happy unless anyone brings up problems.

TODO:
* [x] check performance doesn't get worse
* [x] support positional tuples
* [ ] coverage
