### PR TITLE
replace `*_items` -> `*_length`

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -53,8 +53,8 @@ class DictSchema(TypedDict, total=False):
     type: Required[Literal['dict']]
     keys_schema: CoreSchema  # default: AnySchema
     values_schema: CoreSchema  # default: AnySchema
-    min_items: int
-    max_items: int
+    min_length: int
+    max_length: int
     strict: bool
     ref: str
 
@@ -104,8 +104,8 @@ class IntSchema(TypedDict, total=False):
 class ListSchema(TypedDict, total=False):
     type: Required[Literal['list']]
     items_schema: CoreSchema  # default: AnySchema
-    min_items: int
-    max_items: int
+    min_length: int
+    max_length: int
     strict: bool
     ref: str
 
@@ -167,8 +167,8 @@ class RecursiveReferenceSchema(TypedDict):
 class SetSchema(TypedDict, total=False):
     type: Required[Literal['set']]
     items_schema: CoreSchema  # default: AnySchema
-    min_items: int
-    max_items: int
+    min_length: int
+    max_length: int
     strict: bool
     ref: str
 
@@ -176,8 +176,8 @@ class SetSchema(TypedDict, total=False):
 class FrozenSetSchema(TypedDict, total=False):
     type: Required[Literal['frozenset']]
     items_schema: CoreSchema  # default: AnySchema
-    min_items: int
-    max_items: int
+    min_length: int
+    max_length: int
     strict: bool
     ref: str
 
@@ -270,8 +270,8 @@ class TupleVariableSchema(TypedDict, total=False):
     type: Required[Literal['tuple']]
     mode: Literal['variable']
     items_schema: CoreSchema
-    min_items: int
-    max_items: int
+    min_length: int
+    max_length: int
     strict: bool
     ref: str
 

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -84,9 +84,9 @@ impl<'a> GenericCollection<'a> {
         input: &'data impl Input<'data>,
     ) -> ValResult<'data, Option<usize>> {
         let mut length: Option<usize> = None;
-        if let Some((min_items, max_items)) = size_range {
+        if let Some((min_length, max_length)) = size_range {
             let input_length = self.generic_len();
-            if let Some(min_length) = min_items {
+            if let Some(min_length) = min_length {
                 if input_length < min_length {
                     return Err(ValError::new(
                         ErrorKind::TooShort {
@@ -97,7 +97,7 @@ impl<'a> GenericCollection<'a> {
                     ));
                 }
             }
-            if let Some(max_length) = max_items {
+            if let Some(max_length) = max_length {
                 if input_length > max_length {
                     return Err(ValError::new(
                         ErrorKind::TooLong {

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -15,8 +15,8 @@ pub struct DictValidator {
     strict: bool,
     key_validator: Box<CombinedValidator>,
     value_validator: Box<CombinedValidator>,
-    min_items: Option<usize>,
-    max_items: Option<usize>,
+    min_length: Option<usize>,
+    max_length: Option<usize>,
     name: String,
 }
 
@@ -47,8 +47,8 @@ impl BuildValidator for DictValidator {
             strict: is_strict(schema, config)?,
             key_validator,
             value_validator,
-            min_items: schema.get_as(intern!(py, "min_items"))?,
-            max_items: schema.get_as(intern!(py, "max_items"))?,
+            min_length: schema.get_as(intern!(py, "min_length"))?,
+            max_length: schema.get_as(intern!(py, "max_length"))?,
             name,
         }
         .into())
@@ -96,7 +96,7 @@ macro_rules! build_validate {
             recursion_guard: &'s mut RecursionGuard,
         ) -> ValResult<'data, PyObject> {
             let mut op_len: Option<usize> = None;
-            if let Some(min_length) = self.min_items {
+            if let Some(min_length) = self.min_length {
                 let input_length = dict.len();
                 if input_length < min_length {
                     return Err(ValError::new(
@@ -109,7 +109,7 @@ macro_rules! build_validate {
                 }
                 op_len = Some(input_length);
             }
-            if let Some(max_length) = self.max_items {
+            if let Some(max_length) = self.max_length {
                 let input_length = op_len.unwrap_or_else(|| dict.len());
                 if input_length > max_length {
                     return Err(ValError::new(

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -33,13 +33,13 @@ macro_rules! generic_collection_build {
             };
             let inner_name = item_validator.as_ref().map(|v| v.get_name()).unwrap_or("any");
             let name = format!($name_template, $name, inner_name);
-            let min_items = schema.get_as(pyo3::intern!(py, "min_items"))?;
-            let max_items = schema.get_as(pyo3::intern!(py, "max_items"))?;
+            let min_length = schema.get_as(pyo3::intern!(py, "min_length"))?;
+            let max_length = schema.get_as(pyo3::intern!(py, "max_length"))?;
             Ok(Self {
                 strict: crate::build_tools::is_strict(schema, config)?,
                 item_validator,
-                size_range: match min_items.is_some() || max_items.is_some() {
-                    true => Some((min_items, max_items)),
+                size_range: match min_length.is_some() || max_length.is_some() {
+                    true => Some((min_length, max_length)),
                     false => None,
                 },
                 name,

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -37,22 +37,27 @@ def schema(*, strict: bool = False) -> dict:
                 'field_list_any': {'schema': {'type': 'list'}},
                 'field_list_str': {'schema': {'type': 'list', 'items_schema': {'type': 'str'}}},
                 'field_list_str_con': {
-                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}, 'min_items': 3, 'max_items': 42}
+                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}, 'min_length': 3, 'max_length': 42}
                 },
                 'field_set_any': {'schema': {'type': 'set'}},
                 'field_set_int': {'schema': {'type': 'set', 'items_schema': {'type': 'int'}}},
                 'field_set_int_con': {
-                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}, 'min_items': 3, 'max_items': 42}
+                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}, 'min_length': 3, 'max_length': 42}
                 },
                 'field_frozenset_any': {'schema': {'type': 'frozenset'}},
                 'field_frozenset_bytes': {'schema': {'type': 'frozenset', 'items_schema': {'type': 'bytes'}}},
                 'field_frozenset_bytes_con': {
-                    'schema': {'type': 'frozenset', 'items_schema': {'type': 'bytes'}, 'min_items': 3, 'max_items': 42}
+                    'schema': {
+                        'type': 'frozenset',
+                        'items_schema': {'type': 'bytes'},
+                        'min_length': 3,
+                        'max_length': 42,
+                    }
                 },
                 'field_tuple_var_len_any': {'schema': {'type': 'tuple'}},
                 'field_tuple_var_len_float': {'schema': {'type': 'tuple', 'items_schema': {'type': 'float'}}},
                 'field_tuple_var_len_float_con': {
-                    'schema': {'type': 'tuple', 'items_schema': {'type': 'float'}, 'min_items': 3, 'max_items': 42}
+                    'schema': {'type': 'tuple', 'items_schema': {'type': 'float'}, 'min_length': 3, 'max_length': 42}
                 },
                 'field_tuple_fix_len': {
                     'schema': {

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -44,15 +44,15 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: CoreSchema = {'type': 'bytes'}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'list', 'items_schema': {'type': 'str'}, 'min_items': 3}
+    schema: CoreSchema = {'type': 'list', 'items_schema': {'type': 'str'}, 'min_length': 3}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'set', 'items_schema': {'type': 'str'}, 'max_items': 3}
+    schema: CoreSchema = {'type': 'set', 'items_schema': {'type': 'str'}, 'max_length': 3}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'tuple', 'mode': 'variable', 'items_schema': {'type': 'str'}, 'max_items': 3}
+    schema: CoreSchema = {'type': 'tuple', 'mode': 'variable', 'items_schema': {'type': 'str'}, 'max_length': 3}
     SchemaValidator(schema)
     schema: CoreSchema = {'type': 'tuple', 'mode': 'positional', 'items_schema': [{'type': 'str'}, {'type': 'int'}]}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'frozenset', 'items_schema': {'type': 'str'}, 'max_items': 3}
+    schema: CoreSchema = {'type': 'frozenset', 'items_schema': {'type': 'str'}, 'max_length': 3}
     SchemaValidator(schema)
     schema: CoreSchema = {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'any'}}
     SchemaValidator(schema)

--- a/tests/validators/test_dict.py
+++ b/tests/validators/test_dict.py
@@ -196,14 +196,14 @@ def test_mapping_error_yield_1():
     [
         ({}, {'1': 1, '2': 2}, {'1': 1, '2': 2}),
         (
-            {'min_items': 3},
+            {'min_length': 3},
             {'1': 1, '2': 2, '3': 3.0, '4': [1, 2, 3, 4]},
             {'1': 1, '2': 2, '3': 3.0, '4': [1, 2, 3, 4]},
         ),
-        ({'min_items': 3}, {1: '2', 3: '4'}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
-        ({'max_items': 4}, {'1': 1, '2': 2, '3': 3.0}, {'1': 1, '2': 2, '3': 3.0}),
+        ({'min_length': 3}, {1: '2', 3: '4'}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
+        ({'max_length': 4}, {'1': 1, '2': 2, '3': 3.0}, {'1': 1, '2': 2, '3': 3.0}),
         (
-            {'max_items': 3},
+            {'max_length': 3},
             {'1': 1, '2': 2, '3': 3.0, '4': [1, 2, 3, 4]},
             Err('Input should have at most 3 items, got 4 items [kind=too_long,'),
         ),

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -143,10 +143,10 @@ def test_frozenset_multiple_errors():
         ({'strict': True}, (1, 2, 3), Err('Input should be a valid frozenset [kind=frozen_set_type,')),
         ({'strict': True}, {1, 2, 3}, Err('Input should be a valid frozenset [kind=frozen_set_type,')),
         ({'strict': True}, 'abc', Err('Input should be a valid frozenset [kind=frozen_set_type,')),
-        ({'min_items': 3}, {1, 2, 3}, {1, 2, 3}),
-        ({'min_items': 3}, {1, 2}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
-        ({'max_items': 3}, {1, 2, 3}, {1, 2, 3}),
-        ({'max_items': 3}, {1, 2, 3, 4}, Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
+        ({'min_length': 3}, {1, 2, 3}, {1, 2, 3}),
+        ({'min_length': 3}, {1, 2}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
+        ({'max_length': 3}, {1, 2, 3}, {1, 2, 3}),
+        ({'max_length': 3}, {1, 2, 3, 4}, Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
     ],
 )
 def test_frozenset_kwargs_python(kwargs: Dict[str, Any], input_value, expected):
@@ -226,7 +226,7 @@ def test_frozenset_as_dict_keys(py_and_json: PyAndJson):
 
 
 def test_repr():
-    v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_items': 42})
+    v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_length': 42})
     assert plain_repr(v) == (
         'SchemaValidator('
         'name="frozenset[any]",'

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -113,12 +113,12 @@ def test_list_error(input_value, index):
     'kwargs,input_value,expected',
     [
         ({}, [1, 2, 3, 4], [1, 2, 3, 4]),
-        ({'min_items': 3}, [1, 2, 3, 4], [1, 2, 3, 4]),
-        ({'min_items': 3}, [1, 2], Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
-        ({'min_items': 1}, [], Err('Input should have at least 1 item, got 0 items [kind=too_short,')),
-        ({'max_items': 4}, [1, 2, 3, 4], [1, 2, 3, 4]),
-        ({'max_items': 3}, [1, 2, 3, 4], Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
-        ({'max_items': 1}, [1, 2], Err('Input should have at most 1 item, got 2 items [kind=too_long,')),
+        ({'min_length': 3}, [1, 2, 3, 4], [1, 2, 3, 4]),
+        ({'min_length': 3}, [1, 2], Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
+        ({'min_length': 1}, [], Err('Input should have at least 1 item, got 0 items [kind=too_short,')),
+        ({'max_length': 4}, [1, 2, 3, 4], [1, 2, 3, 4]),
+        ({'max_length': 3}, [1, 2, 3, 4], Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
+        ({'max_length': 1}, [1, 2], Err('Input should have at most 1 item, got 2 items [kind=too_long,')),
     ],
 )
 def test_list_length_constraints(kwargs: Dict[str, Any], input_value, expected):
@@ -131,7 +131,7 @@ def test_list_length_constraints(kwargs: Dict[str, Any], input_value, expected):
 
 
 def test_length_ctx():
-    v = SchemaValidator({'type': 'list', 'min_items': 2, 'max_items': 3})
+    v = SchemaValidator({'type': 'list', 'min_length': 2, 'max_length': 3})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python([1])
     assert exc_info.value.errors() == [

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -126,10 +126,10 @@ def test_set_multiple_errors():
         ({'strict': True}, (1, 2, 3), Err('Input should be a valid set [kind=set_type,')),
         ({'strict': True}, frozenset([1, 2, 3]), Err('Input should be a valid set [kind=set_type,')),
         ({'strict': True}, 'abc', Err('Input should be a valid set [kind=set_type,')),
-        ({'min_items': 3}, {1, 2, 3}, {1, 2, 3}),
-        ({'min_items': 3}, {1, 2}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
-        ({'max_items': 3}, {1, 2, 3}, {1, 2, 3}),
-        ({'max_items': 3}, {1, 2, 3, 4}, Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
+        ({'min_length': 3}, {1, 2, 3}, {1, 2, 3}),
+        ({'min_length': 3}, {1, 2}, Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
+        ({'max_length': 3}, {1, 2, 3}, {1, 2, 3}),
+        ({'max_length': 3}, {1, 2, 3, 4}, Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
     ],
 )
 def test_set_kwargs(kwargs: Dict[str, Any], input_value, expected):

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -83,10 +83,10 @@ def test_tuple_strict_fails_without_tuple(wrong_coll_type: Type[Any], mode, item
     'kwargs,input_value,expected',
     [
         ({}, (1, 2, 3, 4), (1, 2, 3, 4)),
-        ({'min_items': 3}, (1, 2, 3, 4), (1, 2, 3, 4)),
-        ({'min_items': 3}, (1, 2), Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
-        ({'max_items': 4}, (1, 2, 3, 4), (1, 2, 3, 4)),
-        ({'max_items': 3}, (1, 2, 3, 4), Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
+        ({'min_length': 3}, (1, 2, 3, 4), (1, 2, 3, 4)),
+        ({'min_length': 3}, (1, 2), Err('Input should have at least 3 items, got 2 items [kind=too_short,')),
+        ({'max_length': 4}, (1, 2, 3, 4), (1, 2, 3, 4)),
+        ({'max_length': 3}, (1, 2, 3, 4), Err('Input should have at most 3 items, got 4 items [kind=too_long,')),
     ],
 )
 def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):


### PR DESCRIPTION
fix #249

On this occasion, the fix was as simple as `fastmod "m(in|ax)_items" 'm${1}_length'` and revert to changes in benchmarks.