### PR TITLE
Fix strip whitespace ordering

### DIFF
--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -92,6 +92,9 @@ impl Validator for StrConstrainedValidator {
         let either_str = input.validate_str(extra.strict.unwrap_or(self.strict))?;
         let cow = either_str.as_cow()?;
         let mut str = cow.as_ref();
+        if self.strip_whitespace {
+            str = str.trim();
+        }
         if let Some(min_length) = self.min_length {
             if str.len() < min_length {
                 // return py_error!("{} is shorter than {}", str, min_length);
@@ -112,10 +115,6 @@ impl Validator for StrConstrainedValidator {
                     input,
                 ));
             }
-        }
-
-        if self.strip_whitespace {
-            str = str.trim();
         }
 
         let py_string = if self.to_lower {

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -79,7 +79,7 @@ def test_str_not_json(input_value, expected):
         ({'pattern': r'\d+$'}, 'foobar 123', 'foobar 123'),
         ({'pattern': r'^\d+$'}, '12345a', Err("String should match pattern '^\\d+$' [kind=str_pattern_mismatch")),
         # strip comes after length check
-        ({'max_length': 5, 'strip_whitespace': True}, '1234  ', Err('String should have at most 5 characters')),
+        ({'max_length': 5, 'strip_whitespace': True}, '1234  ', '1234'),
         # to_upper and strip comes after pattern check
         ({'to_upper': True, 'pattern': 'abc'}, 'abc', 'ABC'),
         ({'strip_whitespace': True, 'pattern': r'\d+$'}, 'foobar 123 ', Err("String should match pattern '\\d+$'")),

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -82,7 +82,7 @@ def test_str_not_json(input_value, expected):
         ({'max_length': 5, 'strip_whitespace': True}, '1234  ', '1234'),
         # to_upper and strip comes after pattern check
         ({'to_upper': True, 'pattern': 'abc'}, 'abc', 'ABC'),
-        ({'strip_whitespace': True, 'pattern': r'\d+$'}, 'foobar 123 ', Err("String should match pattern '\\d+$'")),
+        ({'strip_whitespace': True, 'pattern': r'\d+$'}, 'foobar 123 ', 'foobar 123'),
         ({'min_length': 1}, '🐈 Hello', '🐈 Hello'),
     ],
 )


### PR DESCRIPTION
1. Moved the `if self.strip_whitespace {}` code to before the minimum and maximum length checks.
2. Changed the logic of string length test's expected value from `Err('String should have at most 5 characters')` to `'1234'` for input `'1234  '`, since the `strip_whitespace` code will now remove the spaces before the input gets to the length checks, changing the input string to 4 characters instead of 6 characters. Therefore, the input should now pass the length validation instead of throwing an error. 
3. Changed the expected value of pattern test `({'strip_whitespace': True, 'pattern': r'\d+$'}, 'foobar 123 ', Err("String should match pattern '\\d+$'"))` to `'foobar 123'` since the `strip_whitespace` now removes the trailing `' '`, so the input should pass the pattern validation since a digit will be the last character in the string. 