### PR TITLE
Improve errors

### DIFF
--- a/pydantic_core/__init__.py
+++ b/pydantic_core/__init__.py
@@ -1,4 +1,11 @@
-from ._pydantic_core import PydanticCustomError, SchemaError, SchemaValidator, ValidationError, __version__
+from ._pydantic_core import (
+    PydanticCustomError,
+    PydanticErrorKind,
+    SchemaError,
+    SchemaValidator,
+    ValidationError,
+    __version__,
+)
 from .core_schema import CoreConfig, CoreSchema
 
 __all__ = (
@@ -9,4 +16,5 @@ __all__ = (
     'SchemaError',
     'ValidationError',
     'PydanticCustomError',
+    'PydanticErrorKind',
 )

--- a/pydantic_core/__init__.py
+++ b/pydantic_core/__init__.py
@@ -1,4 +1,4 @@
-from ._pydantic_core import PydanticValueError, SchemaError, SchemaValidator, ValidationError, __version__
+from ._pydantic_core import PydanticCustomError, SchemaError, SchemaValidator, ValidationError, __version__
 from .core_schema import CoreConfig, CoreSchema
 
 __all__ = (
@@ -8,5 +8,5 @@ __all__ = (
     'SchemaValidator',
     'SchemaError',
     'ValidationError',
-    'PydanticValueError',
+    'PydanticCustomError',
 )

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -53,4 +53,4 @@ class PydanticCustomError(ValueError):
 
 class PydanticErrorKind(ValueError):
     kind: str
-    contect: 'dict[str | int]'
+    contect: 'dict[str, str | int] | None'

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -53,4 +53,8 @@ class PydanticCustomError(ValueError):
 
 class PydanticErrorKind(ValueError):
     kind: str
-    contect: 'dict[str, str | int] | None'
+    message_template: str
+    context: 'dict[str, str | int] | None'
+
+    def __init__(self, kind: str, context: 'dict[str, str | int] | None' = None) -> None: ...
+    def message(self) -> str: ...

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -8,7 +8,7 @@ if sys.version_info < (3, 11):
 else:
     from typing import NotRequired
 
-__all__ = '__version__', 'SchemaValidator', 'SchemaError', 'ValidationError', 'PydanticCustomError'
+__all__ = '__version__', 'SchemaValidator', 'SchemaError', 'ValidationError', 'PydanticCustomError', 'PydanticErrorKind'
 __version__: str
 build_profile: str
 
@@ -50,3 +50,7 @@ class PydanticCustomError(ValueError):
 
     def __init__(self, kind: str, message_template: str, context: 'dict[str, str | int] | None' = None) -> None: ...
     def message(self) -> str: ...
+
+class PydanticErrorKind(ValueError):
+    kind: str
+    contect: 'dict[str | int]'

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -8,7 +8,7 @@ if sys.version_info < (3, 11):
 else:
     from typing import NotRequired
 
-__all__ = '__version__', 'SchemaValidator', 'SchemaError', 'ValidationError', 'PydanticValueError'
+__all__ = '__version__', 'SchemaValidator', 'SchemaError', 'ValidationError', 'PydanticCustomError'
 __version__: str
 build_profile: str
 
@@ -43,7 +43,7 @@ class ValidationError(ValueError):
     def error_count(self) -> int: ...
     def errors(self) -> 'list[ErrorDetails]': ...
 
-class PydanticValueError(ValueError):
+class PydanticCustomError(ValueError):
     kind: str
     message_template: str
     context: 'dict[str, str | int] | None'

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -3,7 +3,7 @@ use pyo3::types::PyDict;
 
 use strum::{Display, EnumMessage};
 
-use super::PydanticValueError;
+use super::PydanticCustomError;
 
 /// Definite each validation error.
 /// NOTE: if an error has parameters:
@@ -187,7 +187,7 @@ pub enum ErrorKind {
     #[strum(message = "Input should be a valid number, unable to parse string as an number")]
     FloatParsing,
     #[strum(message = "Input should be a finite number")]
-    FloatFiniteNumber,
+    FiniteNumber,
     #[strum(serialize = "multiple_of", message = "Input should be a multiple of {multiple_of}")]
     FloatMultipleOf {
         multiple_of: f64,
@@ -238,7 +238,7 @@ pub enum ErrorKind {
     },
     // Note: strum message and serialize are not used here
     CustomError {
-        value_error: PydanticValueError,
+        value_error: PydanticCustomError,
     },
     // ---------------------
     // literals

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -13,8 +13,7 @@ use super::PydanticCustomError;
 /// * the variables in the message need to match the enum struct
 /// * you need to add an entry to the `render` enum to render the error message as a template
 /// * you need to add an entry to the `py_dict` enum to generate `ctx` for error messages
-#[derive(Clone, Display, EnumMessage, EnumIter)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Debug, Display, EnumMessage, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum ErrorKind {
     #[strum(message = "Invalid input")]

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -1,9 +1,12 @@
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyString};
 
 use strum::{Display, EnumMessage};
 
-use super::PydanticCustomError;
+use crate::input::Input;
+
+use super::{PydanticCustomError, ValError};
 
 /// Definite each validation error.
 /// NOTE: if an error has parameters:
@@ -239,6 +242,9 @@ pub enum ErrorKind {
     // Note: strum message and serialize are not used here
     CustomError {
         value_error: PydanticCustomError,
+    },
+    PydanticError {
+        value_error: PydanticErrorKind,
     },
     // ---------------------
     // literals
@@ -506,5 +512,77 @@ impl ErrorKind {
             Self::UnionTagNotFound { discriminator } => py_dict!(py, discriminator),
             _ => Ok(None),
         }
+    }
+}
+
+#[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core")]
+#[derive(Debug, Clone)]
+pub struct PydanticErrorKind {
+    kind: String,
+    message_template: String,
+    context: Option<Py<PyDict>>,
+}
+
+#[pymethods]
+impl PydanticErrorKind {
+    #[new]
+    pub fn py_new(py: Python, kind: String, message_template: String, context: Option<&PyDict>) -> Self {
+        Self {
+            kind,
+            message_template,
+            context: context.map(|c| c.into_py(py)),
+        }
+    }
+
+    #[getter]
+    pub fn kind(&self) -> String {
+        self.kind.clone()
+    }
+
+    #[getter]
+    pub fn message_template(&self) -> String {
+        self.message_template.clone()
+    }
+
+    #[getter]
+    pub fn context(&self, py: Python) -> Option<Py<PyDict>> {
+        self.context.as_ref().map(|c| c.clone_ref(py))
+    }
+
+    pub fn message(&self, py: Python) -> PyResult<String> {
+        let mut message = self.message_template.clone();
+        if let Some(ref context) = self.context {
+            for item in context.as_ref(py).items().iter() {
+                let (key, value): (&PyString, &PyAny) = item.extract()?;
+                if let Ok(py_str) = value.cast_as::<PyString>() {
+                    message = message.replace(&format!("{{{}}}", key.to_str()?), py_str.to_str()?);
+                } else if let Ok(value_int) = value.extract::<i64>() {
+                    message = message.replace(&format!("{{{}}}", key.to_str()?), &value_int.to_string());
+                } else {
+                    // fallback for anything else just in case
+                    message = message.replace(&format!("{{{}}}", key.to_str()?), &value.to_string());
+                }
+            }
+        }
+        Ok(message)
+    }
+
+    fn __str__(&self, py: Python) -> PyResult<String> {
+        self.message(py)
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let msg = self.message(py)?;
+        match { self.context.as_ref() } {
+            Some(ctx) => Ok(format!("{} [kind={}, context={}]", msg, self.kind, ctx.as_ref(py))),
+            None => Ok(format!("{} [kind={}, context=None]", msg, self.kind)),
+        }
+    }
+}
+
+impl PydanticErrorKind {
+    pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
+        let kind = ErrorKind::PydanticError { value_error: self };
+        ValError::new(kind, input)
     }
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -10,7 +10,7 @@ pub use self::kinds::ErrorKind;
 pub use self::line_error::{pretty_line_errors, InputValue, ValError, ValLineError, ValResult};
 pub use self::location::LocItem;
 pub use self::validation_exception::ValidationError;
-pub use self::value_exception::PydanticValueError;
+pub use self::value_exception::PydanticCustomError;
 
 pub fn py_err_string(py: Python, err: PyErr) -> String {
     let value = err.value(py);

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,11 +6,11 @@ mod location;
 mod validation_exception;
 mod value_exception;
 
-pub use self::kinds::{ErrorKind, PydanticErrorKind};
+pub use self::kinds::ErrorKind;
 pub use self::line_error::{pretty_line_errors, InputValue, ValError, ValLineError, ValResult};
 pub use self::location::LocItem;
 pub use self::validation_exception::ValidationError;
-pub use self::value_exception::PydanticCustomError;
+pub use self::value_exception::{PydanticCustomError, PydanticErrorKind};
 
 pub fn py_err_string(py: Python, err: PyErr) -> String {
     let value = err.value(py);

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,7 +6,7 @@ mod location;
 mod validation_exception;
 mod value_exception;
 
-pub use self::kinds::ErrorKind;
+pub use self::kinds::{ErrorKind, PydanticErrorKind};
 pub use self::line_error::{pretty_line_errors, InputValue, ValError, ValLineError, ValResult};
 pub use self::location::LocItem;
 pub use self::validation_exception::ValidationError;

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -8,14 +8,14 @@ use super::{ErrorKind, ValError};
 
 #[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core")]
 #[derive(Debug, Clone)]
-pub struct PydanticValueError {
+pub struct PydanticCustomError {
     kind: String,
     message_template: String,
     context: Option<Py<PyDict>>,
 }
 
 #[pymethods]
-impl PydanticValueError {
+impl PydanticCustomError {
     #[new]
     pub fn py_new(py: Python, kind: String, message_template: String, context: Option<&PyDict>) -> Self {
         Self {
@@ -71,7 +71,7 @@ impl PydanticValueError {
     }
 }
 
-impl PydanticValueError {
+impl PydanticCustomError {
     pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
         let kind = ErrorKind::CustomError { value_error: self };
         ValError::new(kind, input)

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -1,4 +1,4 @@
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
@@ -7,7 +7,7 @@ use crate::input::Input;
 use super::{ErrorKind, ValError};
 
 #[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PydanticCustomError {
     kind: String,
     message_template: String,
@@ -75,5 +75,57 @@ impl PydanticCustomError {
     pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
         let kind = ErrorKind::CustomError { value_error: self };
         ValError::new(kind, input)
+    }
+}
+
+#[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core")]
+#[derive(Debug, Clone)]
+pub struct PydanticErrorKind {
+    kind: ErrorKind,
+}
+
+#[pymethods]
+impl PydanticErrorKind {
+    #[new]
+    pub fn py_new(py: Python, kind: &str, context: Option<&PyDict>) -> PyResult<Self> {
+        let kind = ErrorKind::new(py, kind, context).map_err(PyTypeError::new_err)?;
+        Ok(Self { kind })
+    }
+
+    #[getter]
+    pub fn kind(&self) -> String {
+        self.kind.to_string()
+    }
+
+    #[getter]
+    pub fn message_template(&self) -> &'static str {
+        self.kind.message_template()
+    }
+
+    #[getter]
+    pub fn context(&self, py: Python) -> PyResult<Option<Py<PyDict>>> {
+        self.kind.py_dict(py)
+    }
+
+    pub fn message(&self, py: Python) -> PyResult<String> {
+        self.kind.render_message(py)
+    }
+
+    fn __str__(&self, py: Python) -> PyResult<String> {
+        self.message(py)
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let msg = self.message(py)?;
+        match { self.context(py)?.as_ref() } {
+            Some(ctx) => Ok(format!("{} [kind={}, context={}]", msg, self.kind(), ctx.as_ref(py))),
+            None => Ok(format!("{} [kind={}, context=None]", msg, self.kind())),
+        }
+    }
+}
+
+impl PydanticErrorKind {
+    pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
+        ValError::new(self.kind, input)
     }
 }

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -257,7 +257,7 @@ pub fn bytes_as_date<'a>(input: &'a impl Input<'a>, bytes: &[u8]) -> ValResult<'
         Ok(date) => Ok(date.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::DateParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),
@@ -269,7 +269,7 @@ pub fn bytes_as_time<'a>(input: &'a impl Input<'a>, bytes: &[u8]) -> ValResult<'
         Ok(date) => Ok(date.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::TimeParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),
@@ -281,7 +281,7 @@ pub fn bytes_as_datetime<'a, 'b>(input: &'a impl Input<'a>, bytes: &'b [u8]) -> 
         Ok(dt) => Ok(dt.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::DateTimeParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),
@@ -297,7 +297,7 @@ pub fn int_as_datetime<'a>(
         Ok(dt) => Ok(dt.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::DateTimeParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),
@@ -338,7 +338,7 @@ pub fn int_as_time<'a>(
         t if t < 0_i64 => {
             return Err(ValError::new(
                 ErrorKind::TimeParsing {
-                    error: "time in seconds should be positive",
+                    error: "time in seconds should be positive".to_string(),
                 },
                 input,
             ));
@@ -352,7 +352,7 @@ pub fn int_as_time<'a>(
         Ok(dt) => Ok(dt.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::TimeParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),
@@ -370,7 +370,7 @@ pub fn bytes_as_timedelta<'a, 'b>(input: &'a impl Input<'a>, bytes: &'b [u8]) ->
         Ok(dt) => Ok(dt.into()),
         Err(err) => Err(ValError::new(
             ErrorKind::TimeDeltaParsing {
-                error: err.get_documentation().unwrap_or_default(),
+                error: err.get_documentation().unwrap_or_default().to_string(),
             },
             input,
         )),

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -49,16 +49,26 @@ pub fn str_as_int<'s, 'l>(input: &'s impl Input<'s>, str: &'l str) -> ValResult<
 
 pub fn float_as_int<'a>(input: &'a impl Input<'a>, float: f64) -> ValResult<'a, i64> {
     if float == f64::INFINITY {
-        Err(ValError::new(ErrorKind::IntNan { nan_value: "infinity" }, input))
+        Err(ValError::new(
+            ErrorKind::IntNan {
+                nan_value: "infinity".to_string(),
+            },
+            input,
+        ))
     } else if float == f64::NEG_INFINITY {
         Err(ValError::new(
             ErrorKind::IntNan {
-                nan_value: "negative infinity",
+                nan_value: "negative infinity".to_string(),
             },
             input,
         ))
     } else if float.is_nan() {
-        Err(ValError::new(ErrorKind::IntNan { nan_value: "NaN" }, input))
+        Err(ValError::new(
+            ErrorKind::IntNan {
+                nan_value: "NaN".to_string(),
+            },
+            input,
+        ))
     } else if float % 1.0 != 0.0 {
         Err(ValError::new(ErrorKind::IntFromFloat, input))
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod validators;
 
 // required for benchmarks
 pub use build_tools::SchemaError;
-pub use errors::{PydanticCustomError, ValidationError};
+pub use errors::{PydanticCustomError, PydanticErrorKind, ValidationError};
 pub use validators::SchemaValidator;
 
 pub fn get_version() -> String {
@@ -39,5 +39,6 @@ fn _pydantic_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ValidationError>()?;
     m.add_class::<SchemaError>()?;
     m.add_class::<PydanticCustomError>()?;
+    m.add_class::<PydanticErrorKind>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod validators;
 
 // required for benchmarks
 pub use build_tools::SchemaError;
-pub use errors::{PydanticValueError, ValidationError};
+pub use errors::{PydanticCustomError, ValidationError};
 pub use validators::SchemaValidator;
 
 pub fn get_version() -> String {
@@ -38,6 +38,6 @@ fn _pydantic_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SchemaValidator>()?;
     m.add_class::<ValidationError>()?;
     m.add_class::<SchemaError>()?;
-    m.add_class::<PydanticValueError>()?;
+    m.add_class::<PydanticCustomError>()?;
     Ok(())
 }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -52,7 +52,7 @@ impl Validator for FloatValidator {
     ) -> ValResult<'data, PyObject> {
         let float = input.validate_float(extra.strict.unwrap_or(self.strict))?;
         if !self.allow_inf_nan && !float.is_finite() {
-            return Err(ValError::new(ErrorKind::FloatFiniteNumber, input));
+            return Err(ValError::new(ErrorKind::FiniteNumber, input));
         }
         Ok(float.into_py(py))
     }
@@ -84,7 +84,7 @@ impl Validator for ConstrainedFloatValidator {
     ) -> ValResult<'data, PyObject> {
         let float = input.validate_float(extra.strict.unwrap_or(self.strict))?;
         if !self.allow_inf_nan && !float.is_finite() {
-            return Err(ValError::new(ErrorKind::FloatFiniteNumber, input));
+            return Err(ValError::new(ErrorKind::FiniteNumber, input));
         }
         if let Some(multiple_of) = self.multiple_of {
             if float % multiple_of != 0.0 {

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 
 use crate::build_tools::SchemaDict;
-use crate::errors::{ErrorKind, PydanticCustomError, ValError, ValResult, ValidationError};
+use crate::errors::{ErrorKind, PydanticCustomError, PydanticErrorKind, ValError, ValResult, ValidationError};
 use crate::input::Input;
 use crate::questions::Question;
 use crate::recursion_guard::RecursionGuard;
@@ -295,6 +295,8 @@ pub fn convert_err<'a>(py: Python<'a>, err: PyErr, input: &'a impl Input<'a>) ->
     if err.is_instance_of::<PyValueError>(py) {
         if let Ok(pydantic_value_error) = err.value(py).extract::<PydanticCustomError>() {
             pydantic_value_error.into_val_error(input)
+        } else if let Ok(pydantic_error_kind) = err.value(py).extract::<PydanticErrorKind>() {
+            pydantic_error_kind.into_val_error(input)
         } else if let Ok(validation_error) = err.value(py).extract::<ValidationError>() {
             validation_error.into_py(py)
         } else {

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 
 use crate::build_tools::SchemaDict;
-use crate::errors::{ErrorKind, PydanticValueError, ValError, ValResult, ValidationError};
+use crate::errors::{ErrorKind, PydanticCustomError, ValError, ValResult, ValidationError};
 use crate::input::Input;
 use crate::questions::Question;
 use crate::recursion_guard::RecursionGuard;
@@ -289,11 +289,11 @@ macro_rules! py_err_string {
     };
 }
 
-/// Only `ValueError` (including `PydanticValueError` and `ValidationError`) and `AssertionError` are considered
+/// Only `ValueError` (including `PydanticCustomError` and `ValidationError`) and `AssertionError` are considered
 /// as validation errors, `TypeError` is now considered as a runtime error to catch errors in function signatures
 pub fn convert_err<'a>(py: Python<'a>, err: PyErr, input: &'a impl Input<'a>) -> ValError<'a> {
     if err.is_instance_of::<PyValueError>(py) {
-        if let Ok(pydantic_value_error) = err.value(py).extract::<PydanticValueError>() {
+        if let Ok(pydantic_value_error) = err.value(py).extract::<PydanticCustomError>() {
             pydantic_value_error.into_val_error(input)
         } else if let Ok(validation_error) = err.value(py).extract::<ValidationError>() {
             validation_error.into_py(py)

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -8,7 +8,7 @@ use pyo3::types::{PyDict, PyList, PyString};
 use ahash::AHashMap;
 
 use crate::build_tools::{is_strict, schema_or_config, SchemaDict};
-use crate::errors::{ErrorKind, PydanticValueError, ValError, ValLineError, ValResult};
+use crate::errors::{ErrorKind, PydanticCustomError, ValError, ValLineError, ValResult};
 use crate::input::{GenericMapping, Input};
 use crate::lookup_key::LookupKey;
 use crate::questions::Question;
@@ -19,7 +19,7 @@ use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Ex
 #[derive(Debug, Clone)]
 pub struct UnionValidator {
     choices: Vec<CombinedValidator>,
-    custom_error: Option<PydanticValueError>,
+    custom_error: Option<PydanticCustomError>,
     strict: bool,
     name: String,
 }
@@ -51,9 +51,9 @@ impl BuildValidator for UnionValidator {
     }
 }
 
-fn get_custom_error(py: Python, schema: &PyDict) -> PyResult<Option<PydanticValueError>> {
+fn get_custom_error(py: Python, schema: &PyDict) -> PyResult<Option<PydanticCustomError>> {
     match schema.get_as::<&PyDict>(intern!(py, "custom_error"))? {
-        Some(custom_error) => Ok(Some(PydanticValueError::py_new(
+        Some(custom_error) => Ok(Some(PydanticCustomError::py_new(
             py,
             custom_error.get_as_req::<String>(intern!(py, "kind"))?,
             custom_error.get_as_req::<String>(intern!(py, "message"))?,
@@ -200,7 +200,7 @@ pub struct TaggedUnionValidator {
     discriminator: Discriminator,
     from_attributes: bool,
     strict: bool,
-    custom_error: Option<PydanticValueError>,
+    custom_error: Option<PydanticCustomError>,
     tags_repr: String,
     discriminator_repr: String,
     name: String,

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -10,7 +10,7 @@ from typing import Dict, FrozenSet, List, Optional, Set, Union
 
 import pytest
 
-from pydantic_core import PydanticValueError, SchemaValidator, ValidationError, ValidationError as CoreValidationError
+from pydantic_core import PydanticCustomError, SchemaValidator, ValidationError, ValidationError as CoreValidationError
 
 if os.getenv('BENCHMARK_VS_PYDANTIC'):
     try:
@@ -805,7 +805,7 @@ def test_raise_error_value_error(benchmark):
 @pytest.mark.benchmark(group='raise-error')
 def test_raise_error_custom(benchmark):
     def f(input_value, **kwargs):
-        raise PydanticValueError('my_error', 'this is a custom error {foo}', {'foo': 'FOOBAR'})
+        raise PydanticCustomError('my_error', 'this is a custom error {foo}', {'foo': 'FOOBAR'})
 
     v = SchemaValidator({'type': 'function', 'mode': 'plain', 'function': f})
 

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -971,7 +971,7 @@ def generator_gen_python(v, *, validator, **_kwargs):
     try:
         iterable = iter(v)
     except TypeError:
-        raise PydanticValueError('iterable_type', 'Input should be a valid iterable')
+        raise PydanticCustomError('iterable_type', 'Input should be a valid iterable')
     return validate_yield(iterable, validator)
 
 
@@ -990,7 +990,7 @@ def generator_gen_rust(v, *, validator, **_kwargs):
     try:
         generator = iter(v)
     except TypeError:
-        raise PydanticValueError('generator_type', 'Input should be a valid generator')
+        raise PydanticCustomError('generator_type', 'Input should be a valid generator')
     return validator.iter(generator)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,14 +209,14 @@ def test_sub_model_merge():
             {'allow_inf_nan': False},
             {'type': 'float'},
             {'x': 'nan'},
-            Err('Input should be a finite number [kind=float_finite_number,'),
+            Err('Input should be a finite number [kind=finite_number,'),
         ),
         # field `allow_inf_nan` (if set) should have priority over global config
         (
             {'allow_inf_nan': True},
             {'type': 'float', 'allow_inf_nan': False},
             {'x': 'nan'},
-            Err('Input should be a finite number [kind=float_finite_number,'),
+            Err('Input should be a finite number [kind=finite_number,'),
         ),
         (
             {'allow_inf_nan': False},

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -187,34 +187,30 @@ def test_float_key(py_and_json: PyAndJson):
     'input_value,allow_inf_nan,expected',
     [
         ('NaN', True, FunctionCheck(math.isnan)),
-        (
-            'NaN',
-            False,
-            Err("Input should be a finite number [kind=float_finite_number, input_value='NaN', input_type=str]"),
-        ),
+        ('NaN', False, Err("Input should be a finite number [kind=finite_number, input_value='NaN', input_type=str]")),
         ('+inf', True, FunctionCheck(lambda x: math.isinf(x) and x > 0)),
         (
             '+inf',
             False,
-            Err("Input should be a finite number [kind=float_finite_number, input_value='+inf', input_type=str]"),
+            Err("Input should be a finite number [kind=finite_number, input_value='+inf', input_type=str]"),
         ),
         ('+infinity', True, FunctionCheck(lambda x: math.isinf(x) and x > 0)),
         (
             '+infinity',
             False,
-            Err("Input should be a finite number [kind=float_finite_number, input_value='+infinity', input_type=str]"),
+            Err("Input should be a finite number [kind=finite_number, input_value='+infinity', input_type=str]"),
         ),
         ('-inf', True, FunctionCheck(lambda x: math.isinf(x) and x < 0)),
         (
             '-inf',
             False,
-            Err("Input should be a finite number [kind=float_finite_number, input_value='-inf', input_type=str]"),
+            Err("Input should be a finite number [kind=finite_number, input_value='-inf', input_type=str]"),
         ),
         ('-infinity', True, FunctionCheck(lambda x: math.isinf(x) and x < 0)),
         (
             '-infinity',
             False,
-            Err("Input should be a finite number [kind=float_finite_number, input_value='-infinity', input_type=str]"),
+            Err("Input should be a finite number [kind=finite_number, input_value='-infinity', input_type=str]"),
         ),
         ('0.7', True, 0.7),
         ('0.7', False, 0.7),
@@ -253,7 +249,7 @@ def test_non_finite_json_values(py_and_json: PyAndJson, input_value, allow_inf_n
         (
             float('nan'),
             False,
-            Err('Input should be a finite number [kind=float_finite_number, input_value=nan, input_type=float]'),
+            Err('Input should be a finite number [kind=finite_number, input_value=nan, input_type=float]'),
         ),
     ],
 )
@@ -273,7 +269,7 @@ def test_non_finite_float_values(strict, input_value, allow_inf_nan, expected):
         (
             float('+inf'),
             False,
-            Err('Input should be a finite number [kind=float_finite_number, input_value=inf, input_type=float]'),
+            Err('Input should be a finite number [kind=finite_number, input_value=inf, input_type=float]'),
         ),
         (
             float('-inf'),
@@ -283,7 +279,7 @@ def test_non_finite_float_values(strict, input_value, allow_inf_nan, expected):
         (
             float('-inf'),
             False,
-            Err('Input should be a finite number [kind=float_finite_number, input_value=-inf, input_type=float]'),
+            Err('Input should be a finite number [kind=finite_number, input_value=-inf, input_type=float]'),
         ),
     ],
 )

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -5,7 +5,7 @@ from typing import Type
 
 import pytest
 
-from pydantic_core import PydanticCustomError, SchemaError, SchemaValidator, ValidationError
+from pydantic_core import PydanticCustomError, PydanticErrorKind, SchemaError, SchemaValidator, ValidationError
 
 from ..conftest import plain_repr
 
@@ -469,3 +469,484 @@ def test_validator_instance_after():
 
     assert v.validate_python('input value') == 'input value 43'
     assert v.validate_python(b'is bytes') == 'is bytes 43'
+
+
+def test_pydantic_error_kind():
+    e = PydanticErrorKind('invalid_json', {'error': 'Test'})
+    assert e.message() == 'Invalid JSON: Test'
+    assert e.kind == 'invalid_json'
+    assert e.context == {'error': 'Test'}
+    assert str(e) == 'Invalid JSON: Test'
+    assert repr(e) == ("Invalid JSON: Test [kind=invalid_json, context={'error': 'Test'}]")
+
+
+@pytest.mark.parametrize(
+    'kind, message, context, str_e, repr_e',
+    [
+        ('invalid_input', 'Invalid input', None, 'Invalid input', 'Invalid input [kind=invalid_input, context=None]'),
+        (
+            'invalid_json',
+            'Invalid JSON: foobar',
+            {'error': 'foobar'},
+            'Invalid JSON: foobar',
+            "Invalid JSON: foobar [kind=invalid_json, context={'error': 'foobar'}]",
+        ),
+        (
+            'recursion_loop',
+            'Recursion error - cyclic reference detected',
+            None,
+            'Recursion error - cyclic reference detected',
+            'Recursion error - cyclic reference detected [kind=recursion_loop, context=None]',
+        ),
+        (
+            'dict_attributes_type',
+            'Input should be a valid dictionary or instance to extract fields from',
+            None,
+            'Input should be a valid dictionary or instance to extract fields from',
+            'Input should be a valid dictionary or instance to extract fields from [kind=dict_attributes_type, context=None]',  # noqa: E501
+        ),
+        ('missing', 'Field required', None, 'Field required', 'Field required [kind=missing, context=None]'),
+        ('frozen', 'Field is frozen', None, 'Field is frozen', 'Field is frozen [kind=frozen, context=None]'),
+        (
+            'extra_forbidden',
+            'Extra inputs are not permitted',
+            None,
+            'Extra inputs are not permitted',
+            'Extra inputs are not permitted [kind=extra_forbidden, context=None]',
+        ),
+        (
+            'invalid_key',
+            'Keys should be strings',
+            None,
+            'Keys should be strings',
+            'Keys should be strings [kind=invalid_key, context=None]',
+        ),
+        (
+            'get_attribute_error',
+            'Error extracting attribute: foo',
+            {'error': 'foo'},
+            'Error extracting attribute: foo',
+            "Error extracting attribute: foo [kind=get_attribute_error, context={'error': 'foo'}]",
+        ),
+        (
+            'model_class_type',
+            'Input should be an instance of foo',
+            {'class_name': 'foo'},
+            'Input should be an instance of foo',
+            "Input should be an instance of foo [kind=model_class_type, context={'class_name': 'foo'}]",
+        ),
+        (
+            'none_required',
+            'Input should be None/null',
+            None,
+            'Input should be None/null',
+            'Input should be None/null [kind=none_required, context=None]',
+        ),
+        (
+            'bool',
+            'Input should be a valid boolean',
+            None,
+            'Input should be a valid boolean',
+            'Input should be a valid boolean [kind=bool, context=None]',
+        ),
+        (
+            'greater_than',
+            'Input should be greater than 42.1',
+            {'gt': 42.1},
+            'Input should be greater than 42.1',
+            "Input should be greater than 42.1 [kind=greater_than, context={'gt': 42.1}]",
+        ),
+        (
+            'greater_than_equal',
+            'Input should be greater than or equal to 42.1',
+            {'ge': 42.1},
+            'Input should be greater than or equal to 42.1',
+            "Input should be greater than or equal to 42.1 [kind=greater_than_equal, context={'ge': 42.1}]",
+        ),
+        (
+            'less_than',
+            'Input should be less than 42.1',
+            {'lt': 42.1},
+            'Input should be less than 42.1',
+            "Input should be less than 42.1 [kind=less_than, context={'lt': 42.1}]",
+        ),
+        (
+            'less_than_equal',
+            'Input should be less than or equal to 42.1',
+            {'le': 42.1},
+            'Input should be less than or equal to 42.1',
+            "Input should be less than or equal to 42.1 [kind=less_than_equal, context={'le': 42.1}]",
+        ),
+        (
+            'less_than_equal',
+            'Input should be less than or equal to 42.1',
+            {'le': 42.1},
+            'Input should be less than or equal to 42.1',
+            "Input should be less than or equal to 42.1 [kind=less_than_equal, context={'le': 42.1}]",
+        ),
+        (
+            'too_short',
+            'Data should have at least 42 bytes',
+            {'min_length': 42},
+            'Data should have at least 42 bytes',
+            "Data should have at least 42 bytes [kind=too_short, context={'min_length': 42}]",
+        ),
+        (
+            'too_long',
+            'Data should have at most 42 bytes',
+            {'max_length': 42},
+            'Data should have at most 42 bytes',
+            "Data should have at most 42 bytes [kind=too_long, context={'max_length': 42}]",
+        ),
+        (
+            'str_type',
+            'Input should be a valid string',
+            None,
+            'Input should be a valid string',
+            'Input should be a valid string [kind=str_type, context=None]',
+        ),
+        (
+            'str_unicode',
+            'Input should be a valid string, unable to parse raw data as a unicode string',
+            None,
+            'Input should be a valid string, unable to parse raw data as a unicode string',
+            'Input should be a valid string, unable to parse raw data as a unicode string [kind=str_unicode, context=None]',  # noqa: E501
+        ),
+        (
+            'str_pattern_mismatch',
+            "String should match pattern 'foo'",
+            {'pattern': 'foo'},
+            "String should match pattern 'foo'",
+            "String should match pattern 'foo' [kind=str_pattern_mismatch, context={'pattern': 'foo'}]",
+        ),
+        (
+            'dict_type',
+            'Input should be a valid dictionary',
+            None,
+            'Input should be a valid dictionary',
+            'Input should be a valid dictionary [kind=dict_type, context=None]',
+        ),
+        (
+            'dict_from_mapping',
+            'Unable to convert mapping to a dictionary, error: foobar',
+            {'error': 'foobar'},
+            'Unable to convert mapping to a dictionary, error: foobar',
+            "Unable to convert mapping to a dictionary, error: foobar [kind=dict_from_mapping, context={'error': 'foobar'}]",  # noqa: E501
+        ),
+        (
+            'iteration_error',
+            'Error iterating over object',
+            None,
+            'Error iterating over object',
+            'Error iterating over object [kind=iteration_error, context=None]',
+        ),
+        (
+            'list_type',
+            'Input should be a valid list/array',
+            None,
+            'Input should be a valid list/array',
+            'Input should be a valid list/array [kind=list_type, context=None]',
+        ),
+        (
+            'tuple_type',
+            'Input should be a valid tuple',
+            None,
+            'Input should be a valid tuple',
+            'Input should be a valid tuple [kind=tuple_type, context=None]',
+        ),
+        (
+            'set_type',
+            'Input should be a valid set',
+            None,
+            'Input should be a valid set',
+            'Input should be a valid set [kind=set_type, context=None]',
+        ),
+        (
+            'bool_type',
+            'Input should be a valid boolean',
+            None,
+            'Input should be a valid boolean',
+            'Input should be a valid boolean [kind=bool_type, context=None]',
+        ),
+        (
+            'bool_parsing',
+            'Input should be a valid boolean, unable to interpret input',
+            None,
+            'Input should be a valid boolean, unable to interpret input',
+            'Input should be a valid boolean, unable to interpret input [kind=bool_parsing, context=None]',
+        ),
+        (
+            'int_type',
+            'Input should be a valid integer',
+            None,
+            'Input should be a valid integer',
+            'Input should be a valid integer [kind=int_type, context=None]',
+        ),
+        (
+            'int_parsing',
+            'Input should be a valid integer, unable to parse string as an integer',
+            None,
+            'Input should be a valid integer, unable to parse string as an integer',
+            'Input should be a valid integer, unable to parse string as an integer [kind=int_parsing, context=None]',
+        ),
+        (
+            'int_from_float',
+            'Input should be a valid integer, got a number with a fractional part',
+            None,
+            'Input should be a valid integer, got a number with a fractional part',
+            'Input should be a valid integer, got a number with a fractional part [kind=int_from_float, context=None]',
+        ),
+        (
+            'int_nan',
+            'Input should be a valid integer, got foo',
+            {'nan_value': 'foo'},
+            'Input should be a valid integer, got foo',
+            "Input should be a valid integer, got foo [kind=int_nan, context={'nan_value': 'foo'}]",
+        ),
+        (
+            'multiple_of',
+            'Input should be a multiple of 42.1',
+            {'multiple_of': 42.1},
+            'Input should be a multiple of 42.1',
+            "Input should be a multiple of 42.1 [kind=multiple_of, context={'multiple_of': 42.1}]",
+        ),
+        (
+            'greater_than',
+            'Input should be greater than 42.1',
+            {'gt': 42.1},
+            'Input should be greater than 42.1',
+            "Input should be greater than 42.1 [kind=greater_than, context={'gt': 42.1}]",
+        ),
+        (
+            'greater_than_equal',
+            'Input should be greater than or equal to 42.1',
+            {'ge': 42.1},
+            'Input should be greater than or equal to 42.1',
+            "Input should be greater than or equal to 42.1 [kind=greater_than_equal, context={'ge': 42.1}]",
+        ),
+        (
+            'less_than',
+            'Input should be less than 42.1',
+            {'lt': 42.1},
+            'Input should be less than 42.1',
+            "Input should be less than 42.1 [kind=less_than, context={'lt': 42.1}]",
+        ),
+        (
+            'less_than_equal',
+            'Input should be less than or equal to 42.1',
+            {'le': 42.1},
+            'Input should be less than or equal to 42.1',
+            "Input should be less than or equal to 42.1 [kind=less_than_equal, context={'le': 42.1}]",
+        ),
+        (
+            'float_type',
+            'Input should be a valid number',
+            None,
+            'Input should be a valid number',
+            'Input should be a valid number [kind=float_type, context=None]',
+        ),
+        (
+            'float_parsing',
+            'Input should be a valid number, unable to parse string as an number',
+            None,
+            'Input should be a valid number, unable to parse string as an number',
+            'Input should be a valid number, unable to parse string as an number [kind=float_parsing, context=None]',
+        ),
+        (
+            'finite_number',
+            'Input should be a finite number',
+            None,
+            'Input should be a finite number',
+            'Input should be a finite number [kind=finite_number, context=None]',
+        ),
+        (
+            'bytes_type',
+            'Input should be a valid bytes',
+            None,
+            'Input should be a valid bytes',
+            'Input should be a valid bytes [kind=bytes_type, context=None]',
+        ),
+        (
+            'value_error',
+            'Value error, foobar',
+            {'error': 'foobar'},
+            'Value error, foobar',
+            "Value error, foobar [kind=value_error, context={'error': 'foobar'}]",
+        ),
+        (
+            'assertion_error',
+            'Assertion failed, foobar',
+            {'error': 'foobar'},
+            'Assertion failed, foobar',
+            "Assertion failed, foobar [kind=assertion_error, context={'error': 'foobar'}]",
+        ),
+        (
+            'literal_error',
+            'Input should be one of: foo',
+            {'expected': 'foo'},
+            'Input should be one of: foo',
+            "Input should be one of: foo [kind=literal_error, context={'expected': 'foo'}]",
+        ),
+        (
+            'date_type',
+            'Input should be a valid date',
+            None,
+            'Input should be a valid date',
+            'Input should be a valid date [kind=date_type, context=None]',
+        ),
+        (
+            'date_parsing',
+            'Input should be a valid date in the format YYYY-MM-DD, foobar',
+            {'error': 'foobar'},
+            'Input should be a valid date in the format YYYY-MM-DD, foobar',
+            "Input should be a valid date in the format YYYY-MM-DD, foobar [kind=date_parsing, context={'error': 'foobar'}]",  # noqa: E501
+        ),
+        (
+            'date_from_datetime_parsing',
+            'Input should be a valid date or datetime, foobar',
+            {'error': 'foobar'},
+            'Input should be a valid date or datetime, foobar',
+            "Input should be a valid date or datetime, foobar [kind=date_from_datetime_parsing, context={'error': 'foobar'}]",  # noqa: E501
+        ),
+        (
+            'date_from_datetime_inexact',
+            'Datetimes provided to dates should have zero time - e.g. be exact dates',
+            None,
+            'Datetimes provided to dates should have zero time - e.g. be exact dates',
+            'Datetimes provided to dates should have zero time - e.g. be exact dates [kind=date_from_datetime_inexact, context=None]',  # noqa: E501
+        ),
+        (
+            'time_type',
+            'Input should be a valid time',
+            None,
+            'Input should be a valid time',
+            'Input should be a valid time [kind=time_type, context=None]',
+        ),
+        (
+            'time_parsing',
+            'Input should be in a valid time format, foobar',
+            {'error': 'foobar'},
+            'Input should be in a valid time format, foobar',
+            "Input should be in a valid time format, foobar [kind=time_parsing, context={'error': 'foobar'}]",
+        ),
+        (
+            'datetime_type',
+            'Input should be a valid datetime',
+            None,
+            'Input should be a valid datetime',
+            'Input should be a valid datetime [kind=datetime_type, context=None]',
+        ),
+        (
+            'datetime_parsing',
+            'Input should be a valid datetime, foobar',
+            {'error': 'foobar'},
+            'Input should be a valid datetime, foobar',
+            "Input should be a valid datetime, foobar [kind=datetime_parsing, context={'error': 'foobar'}]",
+        ),
+        (
+            'datetime_object_invalid',
+            'Invalid datetime object, got foobar',
+            {'error': 'foobar'},
+            'Invalid datetime object, got foobar',
+            "Invalid datetime object, got foobar [kind=datetime_object_invalid, context={'error': 'foobar'}]",
+        ),
+        (
+            'time_delta_type',
+            'Input should be a valid timedelta',
+            None,
+            'Input should be a valid timedelta',
+            'Input should be a valid timedelta [kind=time_delta_type, context=None]',
+        ),
+        (
+            'time_delta_parsing',
+            'Input should be a valid timedelta, foobar',
+            {'error': 'foobar'},
+            'Input should be a valid timedelta, foobar',
+            "Input should be a valid timedelta, foobar [kind=time_delta_parsing, context={'error': 'foobar'}]",
+        ),
+        (
+            'frozen_set_type',
+            'Input should be a valid frozenset',
+            None,
+            'Input should be a valid frozenset',
+            'Input should be a valid frozenset [kind=frozen_set_type, context=None]',
+        ),
+        (
+            'is_instance_of',
+            'Input should be an instance of Foo',
+            {'class': 'Foo'},
+            'Input should be an instance of Foo',
+            "Input should be an instance of Foo [kind=is_instance_of, context={'class': 'Foo'}]",
+        ),
+        (
+            'callable_type',
+            'Input should be callable',
+            None,
+            'Input should be callable',
+            'Input should be callable [kind=callable_type, context=None]',
+        ),
+        (
+            'union_tag_invalid',
+            "Input tag 'foo' found using bar does not match any of the expected tags: baz",
+            {'discriminator': 'bar', 'tag': 'foo', 'expected_tags': 'baz'},
+            "Input tag 'foo' found using bar does not match any of the expected tags: baz",
+            "Input tag 'foo' found using bar does not match any of the expected tags: baz [kind=union_tag_invalid, context={'discriminator': 'bar', 'tag': 'foo', 'expected_tags': 'baz'}]",  # noqa: E501
+        ),
+        (
+            'union_tag_not_found',
+            'Unable to extract tag using discriminator foo',
+            {'discriminator': 'foo'},
+            'Unable to extract tag using discriminator foo',
+            "Unable to extract tag using discriminator foo [kind=union_tag_not_found, context={'discriminator': 'foo'}]",  # noqa: E501
+        ),
+        (
+            'arguments_type',
+            'Arguments must be a tuple of (positional arguments, keyword arguments) or a plain dict',
+            None,
+            'Arguments must be a tuple of (positional arguments, keyword arguments) or a plain dict',
+            'Arguments must be a tuple of (positional arguments, keyword arguments) or a plain dict [kind=arguments_type, context=None]',  # noqa: E501
+        ),
+        (
+            'unexpected_keyword_argument',
+            'Unexpected keyword argument',
+            None,
+            'Unexpected keyword argument',
+            'Unexpected keyword argument [kind=unexpected_keyword_argument, context=None]',
+        ),
+        (
+            'missing_keyword_argument',
+            'Missing required keyword argument',
+            None,
+            'Missing required keyword argument',
+            'Missing required keyword argument [kind=missing_keyword_argument, context=None]',
+        ),
+        (
+            'unexpected_positional_argument',
+            'Unexpected positional argument',
+            None,
+            'Unexpected positional argument',
+            'Unexpected positional argument [kind=unexpected_positional_argument, context=None]',
+        ),
+        (
+            'missing_positional_argument',
+            'Missing required positional argument',
+            None,
+            'Missing required positional argument',
+            'Missing required positional argument [kind=missing_positional_argument, context=None]',
+        ),
+        (
+            'multiple_argument_values',
+            'Got multiple values for argument',
+            None,
+            'Got multiple values for argument',
+            'Got multiple values for argument [kind=multiple_argument_values, context=None]',
+        ),
+    ],
+)
+def test_error_kind(kind, message, context, str_e, repr_e):
+    e = PydanticErrorKind(kind, context)
+    assert e.message() == message
+    assert e.kind == kind
+    assert e.context == context
+    assert str(e) == str_e
+    assert repr(e) == repr_e

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -5,7 +5,7 @@ from typing import Type
 
 import pytest
 
-from pydantic_core import PydanticValueError, SchemaError, SchemaValidator, ValidationError
+from pydantic_core import PydanticCustomError, SchemaError, SchemaValidator, ValidationError
 
 from ..conftest import plain_repr
 
@@ -357,7 +357,7 @@ def test_raise_type_error():
 
 
 def test_pydantic_value_error():
-    e = PydanticValueError(
+    e = PydanticCustomError(
         'my_error', 'this is a custom error {missed} {foo} {bar} {spam}', {'foo': 'X', 'bar': 42, 'spam': []}
     )
     assert e.message() == 'this is a custom error {missed} X 42 []'
@@ -371,7 +371,7 @@ def test_pydantic_value_error():
 
 
 def test_pydantic_value_error_none():
-    e = PydanticValueError('my_error', 'this is a custom error {missed}')
+    e = PydanticCustomError('my_error', 'this is a custom error {missed}')
     assert e.message() == 'this is a custom error {missed}'
     assert e.message_template == 'this is a custom error {missed}'
     assert e.kind == 'my_error'
@@ -382,7 +382,7 @@ def test_pydantic_value_error_none():
 
 def test_pydantic_value_error_usage():
     def f(input_value, **kwargs):
-        raise PydanticValueError('my_error', 'this is a custom error {foo} {bar}', {'foo': 'FOOBAR', 'bar': 42})
+        raise PydanticCustomError('my_error', 'this is a custom error {foo} {bar}', {'foo': 'FOOBAR', 'bar': 42})
 
     v = SchemaValidator({'type': 'function', 'mode': 'plain', 'function': f})
 
@@ -402,7 +402,7 @@ def test_pydantic_value_error_usage():
 
 def test_pydantic_value_error_invalid_dict():
     def f(input_value, **kwargs):
-        raise PydanticValueError('my_error', 'this is a custom error {foo}', {(): 'foobar'})
+        raise PydanticCustomError('my_error', 'this is a custom error {foo}', {(): 'foobar'})
 
     v = SchemaValidator({'type': 'function', 'mode': 'plain', 'function': f})
 
@@ -420,7 +420,7 @@ def test_pydantic_value_error_invalid_dict():
 
 def test_pydantic_value_error_invalid_type():
     def f(input_value, **kwargs):
-        raise PydanticValueError('my_error', 'this is a custom error {foo}', [('foo', 123)])
+        raise PydanticCustomError('my_error', 'this is a custom error {foo}', [('foo', 123)])
 
     v = SchemaValidator({'type': 'function', 'mode': 'plain', 'function': f})
 

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -125,7 +125,7 @@ field_b
         (
             {'allow_inf_nan': False},
             {'a': '123', 'b': 'nan'},
-            Err('Input should be a finite number [kind=float_finite_number,'),
+            Err('Input should be a finite number [kind=finite_number,'),
         ),
     ],
     ids=repr,


### PR DESCRIPTION
Closes #267

> add new PydanticErrorKind(kind: str, **context: int | str): which uses an existing error kind

For this part I wasn't clear on what is needed. Does this literally mean create a new error type called `PydanticErrorKind`? And for "use an existing error kind" I assume you have a specific one to use in mind?