### PR TITLE
fix `JsonType` copy

### DIFF
--- a/src/input/parse_json.rs
+++ b/src/input/parse_json.rs
@@ -7,7 +7,7 @@ use serde::de::{Deserialize, DeserializeSeed, Error as SerdeError, MapAccess, Se
 
 use crate::build_tools::py_error;
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum JsonType {
     Null = 0b10000000,
     Bool = 0b01000000,


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/102389.

Maturin is still using rust 1.63 while the stable CI run is using 1.64, hence this is failing on main but didn't fail on #278.