### PR TITLE
Logic for instances of subclasses of strings

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1036,6 +1036,7 @@ ErrorKind = Literal[
     'iterable_type',
     'iteration_error',
     'string_type',
+    'string_sub_type',
     'string_unicode',
     'string_too_short',
     'string_too_long',

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -131,6 +131,8 @@ pub enum ErrorKind {
     // string errors
     #[strum(message = "Input should be a valid string")]
     StringType,
+    #[strum(message = "Input should be a string, not an instance of a subclass of str")]
+    StringSubType,
     #[strum(message = "Input should be a valid string, unable to parse raw data as a unicode string")]
     StringUnicode,
     #[strum(message = "String should have at least {min_length} characters")]

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -10,7 +10,7 @@ use pyo3::types::{
 };
 #[cfg(not(PyPy))]
 use pyo3::types::{PyDictItems, PyDictKeys, PyDictValues};
-use pyo3::{intern, AsPyPointer};
+use pyo3::{intern, AsPyPointer, PyTypeInfo};
 
 use crate::errors::{py_err_string, ErrorKind, InputValue, LocItem, ValError, ValResult};
 
@@ -142,7 +142,7 @@ impl<'a> Input<'a> for PyAny {
 
     fn strict_str(&'a self) -> ValResult<EitherString<'a>> {
         if let Ok(py_str) = self.cast_as::<PyString>() {
-            if py_str.get_type().is(intern!(self.py(), "s").get_type()) {
+            if is_builtin_str(py_str) {
                 Ok(py_str.into())
             } else {
                 Err(ValError::new(ErrorKind::StringSubType, self))
@@ -154,7 +154,13 @@ impl<'a> Input<'a> for PyAny {
 
     fn lax_str(&'a self) -> ValResult<EitherString<'a>> {
         if let Ok(py_str) = self.cast_as::<PyString>() {
-            Ok(py_str.into())
+            if is_builtin_str(py_str) {
+                Ok(py_str.into())
+            } else {
+                // force to a rust string to make sure behaviour is consistent whether or not we go via a
+                // rust string in StrConstrainedValidator - e.g. to_lower
+                Ok(py_string_str(py_str)?.into())
+            }
         } else if let Ok(bytes) = self.cast_as::<PyBytes>() {
             let str = match from_utf8(bytes.as_bytes()) {
                 Ok(s) => s,
@@ -675,4 +681,8 @@ fn is_deque(v: &PyAny) -> bool {
 fn import_type(py: Python, module: &str, attr: &str) -> PyResult<Py<PyType>> {
     let obj = py.import(module)?.getattr(attr)?;
     Ok(obj.cast_as::<PyType>()?.into())
+}
+
+fn is_builtin_str(py_str: &PyString) -> bool {
+    py_str.get_type().is(PyString::type_object(py_str.py()))
 }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -142,7 +142,11 @@ impl<'a> Input<'a> for PyAny {
 
     fn strict_str(&'a self) -> ValResult<EitherString<'a>> {
         if let Ok(py_str) = self.cast_as::<PyString>() {
-            Ok(py_str.into())
+            if py_str.get_type().is(intern!(self.py(), "s").get_type()) {
+                Ok(py_str.into())
+            } else {
+                Err(ValError::new(ErrorKind::StringSubType, self))
+            }
         } else {
             Err(ValError::new(ErrorKind::StringType, self))
         }

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -212,10 +212,22 @@ def test_small_class_core_model(benchmark):
 
 @pytest.mark.benchmark(group='string')
 def test_core_string_lax(benchmark):
-    validator = SchemaValidator({'type': 'str'})
+    validator = SchemaValidator(core_schema.string_schema())
     input_str = 'Hello ' * 20
 
+    assert validator.validate_python(input_str) == input_str
+
     benchmark(validator.validate_python, input_str)
+
+
+@pytest.mark.benchmark(group='string')
+def test_core_string_strict(benchmark):
+    validator = SchemaValidator(core_schema.string_schema(strict=True))
+    input_str = 'Hello ' * 20
+
+    assert validator.validate_python(input_str) == input_str
+
+    benchmark(validator.validate_python, 'foo')
 
 
 @pytest.fixture

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -186,3 +186,23 @@ def test_regex_error():
 def test_default_validator():
     v = SchemaValidator(core_schema.string_schema(strict=True, to_lower=False), {'str_strip_whitespace': False})
     assert plain_repr(v) == 'SchemaValidator(name="str",validator=Str(StrValidator{strict:true}),slots=[])'
+
+
+@pytest.fixture(scope='session', name='FruitEnum')
+def fruit_enum_fixture():
+    from enum import Enum
+
+    class FruitEnum(str, Enum):
+        pear = 'pear'
+        banana = 'banana'
+
+    return FruitEnum
+
+
+def test_strict_subclass(FruitEnum):
+    v = SchemaValidator(core_schema.string_schema(strict=True))
+    assert v.validate_python('foobar') == 'foobar'
+    with pytest.raises(ValidationError, match='kind=string_type,'):
+        v.validate_python(b'foobar')
+    with pytest.raises(ValidationError, match='kind=string_type,'):
+        v.validate_python(FruitEnum.pear)

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -199,8 +199,9 @@ def fruit_enum_fixture():
     return FruitEnum
 
 
-def test_strict_subclass(FruitEnum):
-    v = SchemaValidator(core_schema.string_schema(strict=True))
+@pytest.mark.parametrize('kwargs', [{}, {'to_lower': True}], ids=repr)
+def test_strict_subclass(FruitEnum, kwargs):
+    v = SchemaValidator(core_schema.string_schema(strict=True, **kwargs))
     assert v.validate_python('foobar') == 'foobar'
     with pytest.raises(ValidationError, match='kind=string_type,'):
         v.validate_python(b'foobar')


### PR DESCRIPTION
* for strict string fields, subclasses of `str` now raise an error
* for lax string fields, the subclass is always converted to a builtin str type, rather than sometimes.

See [this twitter survey](https://twitter.com/pydantic/status/1581619276834017282)