### PR TITLE
Fix the Compile time RNG seed when running the benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,6 +47,8 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - run: pip install . -v
+        env:
+          CONST_RANDOM_SEED: 0 # Fix the compile time RNG seed
 
       # this is required so that pytest uses the installed package
       - run: rm tests/__init__.py

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -42,6 +42,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - run: pip install . -v
+        env:
+          CONST_RANDOM_SEED: 0 # Fix the compile time RNG seed
 
       # this is required so that pytest uses the installed package
       - run: rm tests/__init__.py


### PR DESCRIPTION
As mentioned in https://github.com/pydantic/pydantic-core/pull/330#issuecomment-1323921067

I'm not sure it's the only source of randomness though but it should help in the result consistency.