### PR TITLE
Implement datetime timezone constraints

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -276,6 +276,7 @@ class DatetimeSchema(TypedDict, total=False):
     lt: datetime
     gt: datetime
     now_op: Literal['past', 'future']
+    tz_constraint: Literal['aware', 'naive']
     # defaults to current local utc offset from `time.localtime().tm_gmtoff`
     # value is restricted to -86_400 < offset < 86_400 by bounds in generate_self_schema.py
     now_utc_offset: int
@@ -291,6 +292,7 @@ def datetime_schema(
     lt: datetime | None = None,
     gt: datetime | None = None,
     now_op: Literal['past', 'future'] | None = None,
+    tz_constraint: Literal['aware', 'naive'] | None = None,
     now_utc_offset: int | None = None,
     ref: str | None = None,
     extra: Any = None,
@@ -303,6 +305,7 @@ def datetime_schema(
         lt=lt,
         gt=gt,
         now_op=now_op,
+        tz_constraint=tz_constraint,
         now_utc_offset=now_utc_offset,
         ref=ref,
         extra=extra,
@@ -1226,6 +1229,8 @@ ErrorType = Literal[
     'datetime_object_invalid',
     'datetime_past',
     'datetime_future',
+    'datetime_aware',
+    'datetime_naive',
     'time_delta_type',
     'time_delta_parsing',
     'frozen_set_type',

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -261,6 +261,10 @@ pub enum ErrorType {
     DatetimePast,
     #[strum(message = "Datetime should be in the future")]
     DatetimeFuture,
+    #[strum(message = "Datetime should have timezone info")]
+    DatetimeAware,
+    #[strum(message = "Datetime should not have timezone info")]
+    DatetimeNaive,
     // ---------------------
     // timedelta errors
     #[strum(message = "Input should be a valid timedelta")]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -235,6 +235,8 @@ all_errors = [
     ('datetime_object_invalid', 'Invalid datetime object, got foobar', {'error': 'foobar'}),
     ('datetime_past', 'Datetime should be in the past', None),
     ('datetime_future', 'Datetime should be in the future', None),
+    ('datetime_aware', 'Datetime should have timezone info', None),
+    ('datetime_naive', 'Datetime should not have timezone info', None),
     ('time_delta_type', 'Input should be a valid timedelta', None),
     ('time_delta_parsing', 'Input should be a valid timedelta, foobar', {'error': 'foobar'}),
     ('frozen_set_type', 'Input should be a valid frozenset', None),


### PR DESCRIPTION
Alright, so I got something together that is seemingly working. Please let me know if you think something should be done differently, or structured in another way.

This implements support for constraining datetime objects based on them having or not having timezone info. The aware kind constrains to objects that have timezone info, and symmetrically, the naive kind constrains to objects that do not have timezone info.

Closes #266.