### PR TITLE
add `strip = true` to release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ name = "pydantic_core._pydantic_core"
 lto = "fat"
 codegen-units = 1
 panic = "abort"
+strip = true
 
 [build-dependencies]
 version_check = "0.9.4"


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/issues/2276 for related discussion on binary sizes for pydantic before v2.

Comparing binary sizes I get:

```
(env38) gitpod /workspace/pydantic-core (main) $ ls -lh dist-main/
total 1.7M
-rw-r--r-- 1 gitpod gitpod 1.5M Dec 21 14:03 pydantic_core-0.7.1-cp38-cp38-linux_x86_64.whl
-rw-r--r-- 1 gitpod gitpod 167K Dec 21 14:02 pydantic_core-0.7.1.tar.gz
(env38) gitpod /workspace/pydantic-core (main) $ ls -lh dist-strip/
total 1.2M
-rw-r--r-- 1 gitpod gitpod 1.1M Dec 21 14:05 pydantic_core-0.7.1-cp38-cp38-linux_x86_64.whl
-rw-r--r-- 1 gitpod gitpod 167K Dec 21 14:04 pydantic_core-0.7.1.tar.gz
```

I think that's worthwhile vs. uglier tracebacks for crashes.