### PR TITLE
utf8 error fixed on pypy with pyo3 0.18

### DIFF
--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -147,14 +147,10 @@ impl BytesMode {
 }
 
 pub fn utf8_py_error(py: Python, err: Utf8Error, data: &[u8]) -> PyErr {
-    #[cfg(not(PyPy))]
-    return match pyo3::exceptions::PyUnicodeDecodeError::new_utf8(py, data, err) {
+    match pyo3::exceptions::PyUnicodeDecodeError::new_utf8(py, data, err) {
         Ok(decode_err) => PyErr::from_value(decode_err),
         Err(err) => err,
-    };
-    // See https://github.com/PyO3/pyo3/issues/2770
-    #[cfg(PyPy)]
-    pyo3::exceptions::PyValueError::new_err(err.to_string())
+    }
 }
 
 fn py_bytes_to_str(py_bytes: &PyBytes) -> PyResult<&str> {

--- a/tests/serializers/test_bytes.py
+++ b/tests/serializers/test_bytes.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import platform
 from enum import Enum
 
 import pytest
@@ -30,16 +29,8 @@ def test_bytes_invalid_all():
         s.to_json(b'\x81')
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy', reason='see PyO3/pyo3#2770')
-def test_bytes_invalid_pypy():
-    s = SchemaSerializer(core_schema.bytes_schema())
-
-    with pytest.raises(ValueError, match='invalid utf-8 sequence of 1 bytes from index 0'):
-        s.to_python(b'\x81', mode='json')
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'CPython', reason='see PyO3/pyo3#2770')
 def test_bytes_invalid_cpython():
+    # PyO3/pyo3#2770 is now fixed
     s = SchemaSerializer(core_schema.bytes_schema())
 
     with pytest.raises(UnicodeDecodeError, match="'utf-8' codec can't decode byte 0x81 in position 0: invalid utf-8"):


### PR DESCRIPTION
Should work now https://github.com/PyO3/pyo3/issues/2770 is fixed and released with pyo3 v0.18.