### PR TITLE
Serialize improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.18.0"
-source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
+source = "git+ssh://git@github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.18.0"
-source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
+source = "git+ssh://git@github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "pyo3-ffi"
 version = "0.18.0"
-source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
+source = "git+ssh://git@github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.18.0"
-source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
+source = "git+ssh://git@github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.18.0"
-source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
+source = "git+ssh://git@github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,8 +248,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd4149c8c3975099622b4e1962dac27565cf5663b76452c3e2b66e0b6824277"
+source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -265,8 +264,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd09fe469834db21ee60e0051030339e5d361293d8cb5ec02facf7fdcf52dbf"
+source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -275,8 +273,7 @@ dependencies = [
 [[package]]
 name = "pyo3-ffi"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c427c9a96b9c5b12156dbc11f76b14f49e9aae8905ca783ea87c249044ef137"
+source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -285,8 +282,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b822bbba9d60630a44d2109bc410489bb2f439b33e3a14ddeb8a40b378a7c4"
+source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -297,8 +293,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae898104f7c99db06231160770f3e40dad6eb9021daddc0fedfa3e41dff10a"
+source = "git+https://github.com/samuelcolvin/pyo3?branch=ellipsis#f328679d77cbfc5888887d6c6ba05fd7b2314e66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ include = [
 ]
 
 [dependencies]
-pyo3 = "0.18.0"
+# required since `Py_Ellipsis` fails on windows, see https://github.com/PyO3/pyo3/pull/2911
+pyo3 = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+#pyo3 = "0.18.0"
 regex = "1.6.0"
 strum = { version = "0.24.1", features = ["derive"] }
 strum_macros = "0.24.3"
@@ -65,4 +67,6 @@ strip = true
 [build-dependencies]
 version_check = "0.9.4"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = "0.18.0"
+# FIXME change when `pyo3` above is updated
+pyo3-build-config = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+#pyo3 = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 
 [dependencies]
 # required since `Py_Ellipsis` fails on windows, see https://github.com/PyO3/pyo3/pull/2911
-pyo3 = { git = "ssh://git@github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+pyo3 = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
 #pyo3 = "0.18.0"
 regex = "1.6.0"
 strum = { version = "0.24.1", features = ["derive"] }
@@ -68,5 +68,5 @@ strip = true
 version_check = "0.9.4"
 # used where logic has to be version/distribution specific, e.g. pypy
 # FIXME change when `pyo3` above is updated
-pyo3-build-config = { git = "ssh://git@github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+pyo3-build-config = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
 #pyo3 = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 
 [dependencies]
 # required since `Py_Ellipsis` fails on windows, see https://github.com/PyO3/pyo3/pull/2911
-pyo3 = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+pyo3 = { git = "ssh://git@github.com/samuelcolvin/pyo3", branch = "ellipsis" }
 #pyo3 = "0.18.0"
 regex = "1.6.0"
 strum = { version = "0.24.1", features = ["derive"] }
@@ -68,5 +68,5 @@ strip = true
 version_check = "0.9.4"
 # used where logic has to be version/distribution specific, e.g. pypy
 # FIXME change when `pyo3` above is updated
-pyo3-build-config = { git = "https://github.com/samuelcolvin/pyo3", branch = "ellipsis" }
+pyo3-build-config = { git = "ssh://git@github.com/samuelcolvin/pyo3", branch = "ellipsis" }
 #pyo3 = "0.18.0"

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -184,7 +184,10 @@ impl CollectWarnings {
     }
 
     pub fn on_fallback_py(&self, field_type: &str, value: &PyAny, extra: &Extra) -> PyResult<()> {
-        if extra.check.enabled() {
+        // special case for None as it's very common e.g. as a default value
+        if value.is_none() {
+            Ok(())
+        } else if extra.check.enabled() {
             Err(PydanticSerializationUnexpectedValue::new_err(None))
         } else {
             self.fallback_warning(field_type, value);
@@ -198,7 +201,10 @@ impl CollectWarnings {
         value: &PyAny,
         extra: &Extra,
     ) -> Result<(), S::Error> {
-        if extra.check.enabled() {
+        // special case for None as it's very common e.g. as a default value
+        if value.is_none() {
+            Ok(())
+        } else if extra.check.enabled() {
             // note: I think this should never actually happen since we use `to_python(..., mode='json')` during
             // JSON serialisation to "try" union branches, but it's here for completeness/correctness
             // in particular, in future we could allow errors instead of warnings on fallback

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -49,7 +49,7 @@ impl ModelSerializer {
         match extra.check {
             SerCheck::Strict => value.get_type().eq(self.class.as_ref(value.py())),
             SerCheck::Lax => value.is_instance(self.class.as_ref(value.py())),
-            SerCheck::None => Ok(true),
+            SerCheck::None => value.hasattr(intern!(value.py(), "__dict__")),
         }
     }
 }

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
+from enum import Enum
 
 import pytest
 from dirty_equals import IsList
@@ -248,3 +249,24 @@ def test_unknown_type(any_serializer):
 
     with pytest.raises(PydanticSerializationError, match='Unable to serialize unknown type: <Foobar repr>'):
         any_serializer.to_json(f)
+
+
+def test_enum(any_serializer):
+    class MyEnum(Enum):
+        a = 1
+        b = 'b'
+
+    assert any_serializer.to_python(MyEnum.a) == MyEnum.a
+    assert any_serializer.to_python(MyEnum.b) == MyEnum.b
+    assert any_serializer.to_python({MyEnum.a: 42}) == {MyEnum.a: 42}
+    assert any_serializer.to_python({MyEnum.b: 42}) == {MyEnum.b: 42}
+
+    assert any_serializer.to_python(MyEnum.a, mode='json') == 1
+    assert any_serializer.to_python(MyEnum.b, mode='json') == 'b'
+    assert any_serializer.to_python({MyEnum.a: 42}, mode='json') == {'1': 42}
+    assert any_serializer.to_python({MyEnum.b: 42}, mode='json') == {'b': 42}
+
+    assert any_serializer.to_json(MyEnum.a) == b'1'
+    assert any_serializer.to_json(MyEnum.b) == b'"b"'
+    assert any_serializer.to_json({MyEnum.a: 42}) == b'{"1":42}'
+    assert any_serializer.to_json({MyEnum.b: 42}) == b'{"b":42}'

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -223,12 +223,12 @@ def test_exclude_unset(any_serializer):
     assert any_serializer.to_python(m, exclude_unset=True) == {'bar': 2, 'spam': 3}
     assert any_serializer.to_python(m, exclude=None, exclude_unset=True) == {'bar': 2, 'spam': 3}
     assert any_serializer.to_python(m, exclude={'bar'}, exclude_unset=True) == {'spam': 3}
-    assert any_serializer.to_python(m, exclude={'bar': None}, exclude_unset=True) == {'spam': 3}
+    assert any_serializer.to_python(m, exclude={'bar': ...}, exclude_unset=True) == {'spam': 3}
     assert any_serializer.to_python(m, exclude={'bar': {}}, exclude_unset=True) == {'bar': 2, 'spam': 3}
 
     assert any_serializer.to_json(m, exclude=None, exclude_unset=True) == b'{"bar":2,"spam":3}'
     assert any_serializer.to_json(m, exclude={'bar'}, exclude_unset=True) == b'{"spam":3}'
-    assert any_serializer.to_json(m, exclude={'bar': None}, exclude_unset=True) == b'{"spam":3}'
+    assert any_serializer.to_json(m, exclude={'bar': ...}, exclude_unset=True) == b'{"spam":3}'
     assert any_serializer.to_json(m, exclude={'bar': {}}, exclude_unset=True) == b'{"bar":2,"spam":3}'
 
     m2 = FieldsSetModel(foo=1, bar=2, spam=3, __fields_set__={'bar', 'spam', 'missing'})

--- a/tests/serializers/test_dict.py
+++ b/tests/serializers/test_dict.py
@@ -105,9 +105,7 @@ def test_filter_args(params):
         ),
         dict(include=None, exclude={'__all__': {'__all__'}}, expected={'0': [], '1': [], '2': [], '3': []}),
         dict(include=None, exclude={'__all__': {0}}, expected={'0': [], '1': [1], '2': [1, 2], '3': [1, 2, 3]}),
-        dict(
-            include=None, exclude={'__all__': {0}, '3': {1}}, expected={'0': [], '1': [1], '2': [1, 2], '3': [0, 2, 3]}
-        ),
+        dict(include=None, exclude={'__all__': {0}, '3': {1}}, expected={'0': [], '1': [1], '2': [1, 2], '3': [2, 3]}),
     ],
 )
 def test_filter_args_nested(params):

--- a/tests/serializers/test_dict.py
+++ b/tests/serializers/test_dict.py
@@ -48,13 +48,14 @@ def test_exclude():
     assert s.to_json({'a': 1, 'b': 2, 'c': 3, 'd': 4}) == b'{"b":2,"d":4}'
 
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d'}) == {'b': 2}
+    assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'__all__'}) == {}
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d': None}) == {'b': 2}
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d': {1}}) == {'b': 2, 'd': 4}
 
     assert s.to_json({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d'}) == b'{"b":2}'
 
 
-def test_include_exclude():
+def test_filter():
     s = SchemaSerializer(
         core_schema.dict_schema(
             serialization=core_schema.filter_dict_schema(include={'1', '3', '5'}, exclude={'5', '6'})
@@ -78,9 +79,10 @@ def test_include_exclude():
         dict(include={'0', '1'}, exclude={'3': {1}}, expected={'0': 0, '1': 1}),
         dict(include={'0', '1'}, exclude={'1': {1}}, expected={'0': 0, '1': 1}),
         dict(include={'0', '1'}, exclude={'1': None}, expected={'0': 0}),
+        dict(include=None, exclude={'__all__'}, expected={}),
     ],
 )
-def test_include_exclude_args(params):
+def test_filter_args(params):
     s = SchemaSerializer(core_schema.dict_schema())
 
     # user IsStrictDict to check dict order
@@ -97,9 +99,18 @@ def test_include_exclude_args(params):
         dict(include=None, exclude=None, expected={'0': [0], '1': [0, 1], '2': [0, 1, 2], '3': [0, 1, 2, 3]}),
         dict(include=None, exclude={'1': {0}}, expected={'0': [0], '1': [1], '2': [0, 1, 2], '3': [0, 1, 2, 3]}),
         dict(include={'1': {0}}, exclude=None, expected={'1': [0]}),
+        dict(include={'__all__': {0}}, exclude=None, expected={'0': [0], '1': [0], '2': [0], '3': [0]}),
+        dict(
+            include=None, exclude={'0': {'__all__'}}, expected={'0': [], '1': [0, 1], '2': [0, 1, 2], '3': [0, 1, 2, 3]}
+        ),
+        dict(include=None, exclude={'__all__': {'__all__'}}, expected={'0': [], '1': [], '2': [], '3': []}),
+        dict(include=None, exclude={'__all__': {0}}, expected={'0': [], '1': [1], '2': [1, 2], '3': [1, 2, 3]}),
+        dict(
+            include=None, exclude={'__all__': {0}, '3': {1}}, expected={'0': [], '1': [1], '2': [1, 2], '3': [0, 2, 3]}
+        ),
     ],
 )
-def test_include_exclude_args_nested(params):
+def test_filter_args_nested(params):
     s = SchemaSerializer(core_schema.dict_schema(core_schema.string_schema(), core_schema.list_schema()))
 
     include, exclude, expected = params['include'], params['exclude'], params['expected']
@@ -109,7 +120,7 @@ def test_include_exclude_args_nested(params):
     assert json.loads(s.to_json(value, include=include, exclude=exclude)) == expected
 
 
-def test_include_exclude_int():
+def test_filter_int():
     s = SchemaSerializer(
         core_schema.dict_schema(
             core_schema.any_schema(), serialization=core_schema.filter_dict_schema(include={1, 3, 5}, exclude={5, 6})
@@ -119,7 +130,7 @@ def test_include_exclude_int():
     assert s.to_python({0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7}) == {1: 1, 3: 3}
 
 
-def test_include_exclude_runtime():
+def test_filter_runtime():
     s = SchemaSerializer(
         core_schema.dict_schema(
             core_schema.any_schema(), serialization=core_schema.filter_dict_schema(exclude={'0', '1'})
@@ -129,7 +140,7 @@ def test_include_exclude_runtime():
     assert s.to_python({'0': 0, '1': 1, '2': 2, '3': 3}, include={'1', '2'}, exclude={'2', '3'}) == {'1': 1}
 
 
-def test_include_exclude_runtime_int():
+def test_filter_runtime_int():
     s = SchemaSerializer(
         core_schema.dict_schema(core_schema.any_schema(), serialization=core_schema.filter_dict_schema(exclude={0, 1}))
     )

--- a/tests/serializers/test_dict.py
+++ b/tests/serializers/test_dict.py
@@ -49,7 +49,7 @@ def test_exclude():
 
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d'}) == {'b': 2}
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'__all__'}) == {}
-    assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d': None}) == {'b': 2}
+    assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d': ...}) == {'b': 2}
     assert s.to_python({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d': {1}}) == {'b': 2, 'd': 4}
 
     assert s.to_json({'a': 1, 'b': 2, 'c': 3, 'd': 4}, exclude={'d'}) == b'{"b":2}'
@@ -70,15 +70,15 @@ def test_filter():
     [
         dict(include=None, exclude=None, expected={'0': 0, '1': 1, '2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude=None, expected={'0': 0, '1': 1}),
-        dict(include={'0': None, '1': None}, exclude=None, expected={'0': 0, '1': 1}),
+        dict(include={'0': ..., '1': ...}, exclude=None, expected={'0': 0, '1': 1}),
         dict(include={'0': {1}, '1': {1}}, exclude=None, expected={'0': 0, '1': 1}),
         dict(include=None, exclude={'0', '1'}, expected={'2': 2, '3': 3}),
-        dict(include=None, exclude={'0': None, '1': None}, expected={'2': 2, '3': 3}),
+        dict(include=None, exclude={'0': ..., '1': ...}, expected={'2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude={'1', '2'}, expected={'0': 0}),
         dict(include=None, exclude={'3': {1}}, expected={'0': 0, '1': 1, '2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude={'3': {1}}, expected={'0': 0, '1': 1}),
         dict(include={'0', '1'}, exclude={'1': {1}}, expected={'0': 0, '1': 1}),
-        dict(include={'0', '1'}, exclude={'1': None}, expected={'0': 0}),
+        dict(include={'0', '1'}, exclude={'1': ...}, expected={'0': 0}),
         dict(include=None, exclude={'__all__'}, expected={}),
     ],
 )

--- a/tests/serializers/test_format.py
+++ b/tests/serializers/test_format.py
@@ -27,6 +27,7 @@ def test_format(value, formatting_string, expected_python, expected_json):
 
 def test_format_error():
     s = SchemaSerializer(core_schema.any_schema(serialization=core_schema.format_ser_schema('^5d')))
+    assert s.to_python(123) == ' 123 '
 
     # the actual error message differs slightly between cpython and pypy
     msg = "Error calling `format(value, '^5d')`: ValueError:"
@@ -42,3 +43,14 @@ def test_dict_keys():
         core_schema.dict_schema(core_schema.float_schema(serialization=core_schema.format_ser_schema('0.4f')))
     )
     assert s.to_python({1: True}) == {'1.0000': True}
+
+
+def test_format_fallback():
+    s = SchemaSerializer(core_schema.any_schema(serialization=core_schema.format_ser_schema('^5s')))
+    assert s.to_python('abc') == ' abc '
+    assert s.to_python('abc', mode='json') == ' abc '
+    assert s.to_json('abc') == b'" abc "'
+
+    assert s.to_python(None) is None
+    assert s.to_python(None, mode='json') is None
+    assert s.to_json(None) == b'null'

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -193,6 +193,7 @@ def test_tuple_fallback():
         dict(include=None, exclude=None, expected=['0', '1', '2', '3']),
         dict(include={0, 1}, exclude=None, expected=['0', '1']),
         dict(include={0: ..., 1: ...}, exclude=None, expected=['0', '1']),
+        dict(include={0: True, 1: True}, exclude=None, expected=['0', '1']),
         dict(include={0: {1}, 1: {1}}, exclude=None, expected=['0', '1']),
         dict(include=None, exclude={0, 1}, expected=['2', '3']),
         dict(include=None, exclude={0: ..., 1: ...}, expected=['2', '3']),
@@ -224,6 +225,7 @@ def test_filter_args(params):
         dict(include=None, exclude=None, expected=[[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]),
         dict(include=None, exclude={1: {0}}, expected=[[0], [1], [0, 1, 2], [0, 1, 2, 3]]),
         dict(include=None, exclude={1: {0}, 2: ...}, expected=[[0], [1], [0, 1, 2, 3]]),
+        dict(include=None, exclude={1: {0}, 2: True}, expected=[[0], [1], [0, 1, 2, 3]]),
         dict(include={1: {0}}, exclude=None, expected=[[0]]),
     ],
 )

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -118,7 +118,7 @@ def test_exclude(schema_func, seq_f):
     assert v.to_json(seq_f('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'), exclude={6}) == b'["a","c","e","h"]'
 
 
-def test_include_exclude():
+def test_filter():
     v = SchemaSerializer(
         core_schema.list_schema(
             core_schema.any_schema(), serialization=core_schema.filter_seq_schema(include={1, 3, 5}, exclude={5, 6})
@@ -127,7 +127,7 @@ def test_include_exclude():
     assert v.to_python([0, 1, 2, 3, 4, 5, 6, 7]) == [1, 3]
 
 
-def test_include_exclude_runtime():
+def test_filter_runtime():
     v = SchemaSerializer(
         core_schema.list_schema(core_schema.any_schema(), serialization=core_schema.filter_seq_schema(exclude={0, 1}))
     )
@@ -201,9 +201,14 @@ def test_tuple_fallback():
         dict(include={0, 1}, exclude={3: {1}}, expected=['0', '1']),
         dict(include={0, 1}, exclude={1: {1}}, expected=['0', '1']),
         dict(include={0, 1}, exclude={1: None}, expected=['0']),
+        dict(include={1}, exclude={1}, expected=[]),
+        dict(include={0}, exclude={1}, expected=['0']),
+        dict(include={'__all__'}, exclude={1}, expected=['0', '2', '3']),
+        dict(include=None, exclude={1}, expected=['0', '2', '3']),
+        dict(include=None, exclude={'__all__'}, expected=[]),
     ],
 )
-def test_include_exclude_args(params):
+def test_filter_args(params):
     s = SchemaSerializer(core_schema.list_schema())
 
     include, exclude, expected = params['include'], params['exclude'], params['expected']
@@ -221,7 +226,7 @@ def test_include_exclude_args(params):
         dict(include={1: {0}}, exclude=None, expected=[[0]]),
     ],
 )
-def test_include_exclude_args_nested(params):
+def test_filter_args_nested(params):
     s = SchemaSerializer(core_schema.list_schema(core_schema.list_schema()))
 
     include, exclude, expected = params['include'], params['exclude'], params['expected']
@@ -229,6 +234,26 @@ def test_include_exclude_args_nested(params):
     assert s.to_python(value, include=include, exclude=exclude) == expected
     assert s.to_python(value, mode='json', include=include, exclude=exclude) == expected
     assert json.loads(s.to_json(value, include=include, exclude=exclude)) == expected
+
+
+def test_filter_list_of_dicts():
+    s = SchemaSerializer(core_schema.list_schema(core_schema.dict_schema()))
+    v = [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]
+    assert s.to_python(v) == v
+    assert s.to_python(v, exclude={0: {'a'}}) == [{'b': 2}, {'a': 3, 'b': 4}]
+    assert s.to_python(v, exclude={0: {'__all__'}}) == [{}, {'a': 3, 'b': 4}]
+    assert s.to_python(v, exclude={'__all__': {'a'}}) == [{'b': 2}, {'b': 4}]
+
+    assert s.to_json(v) == b'[{"a":1,"b":2},{"a":3,"b":4}]'
+    assert s.to_json(v, exclude={0: {'a'}}) == b'[{"b":2},{"a":3,"b":4}]'
+    assert s.to_json(v, exclude={0: {'__all__'}}) == b'[{},{"a":3,"b":4}]'
+    assert s.to_json(v, exclude={'__all__': {'a'}}) == b'[{"b":2},{"b":4}]'
+
+    assert s.to_python(v, include={0: {'a'}, 1: None}) == [{'a': 1}, {'a': 3, 'b': 4}]
+    assert s.to_python(v, include={'__all__': {'a'}}) == [{'a': 1}, {'a': 3}]
+
+    assert s.to_json(v, include={0: {'a'}, 1: None}) == b'[{"a":1},{"a":3,"b":4}]'
+    assert s.to_json(v, include={'__all__': {'a'}}) == b'[{"a":1},{"a":3}]'
 
 
 def test_positional_tuple():

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -192,15 +192,15 @@ def test_tuple_fallback():
     [
         dict(include=None, exclude=None, expected=['0', '1', '2', '3']),
         dict(include={0, 1}, exclude=None, expected=['0', '1']),
-        dict(include={0: None, 1: None}, exclude=None, expected=['0', '1']),
+        dict(include={0: ..., 1: ...}, exclude=None, expected=['0', '1']),
         dict(include={0: {1}, 1: {1}}, exclude=None, expected=['0', '1']),
         dict(include=None, exclude={0, 1}, expected=['2', '3']),
-        dict(include=None, exclude={0: None, 1: None}, expected=['2', '3']),
+        dict(include=None, exclude={0: ..., 1: ...}, expected=['2', '3']),
         dict(include={0, 1}, exclude={1, 2}, expected=['0']),
         dict(include=None, exclude={3: {1}}, expected=['0', '1', '2', '3']),
         dict(include={0, 1}, exclude={3: {1}}, expected=['0', '1']),
         dict(include={0, 1}, exclude={1: {1}}, expected=['0', '1']),
-        dict(include={0, 1}, exclude={1: None}, expected=['0']),
+        dict(include={0, 1}, exclude={1: ...}, expected=['0']),
         dict(include={1}, exclude={1}, expected=[]),
         dict(include={0}, exclude={1}, expected=['0']),
         dict(include={'__all__'}, exclude={1}, expected=['0', '2', '3']),
@@ -223,6 +223,7 @@ def test_filter_args(params):
     [
         dict(include=None, exclude=None, expected=[[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]),
         dict(include=None, exclude={1: {0}}, expected=[[0], [1], [0, 1, 2], [0, 1, 2, 3]]),
+        dict(include=None, exclude={1: {0}, 2: ...}, expected=[[0], [1], [0, 1, 2, 3]]),
         dict(include={1: {0}}, exclude=None, expected=[[0]]),
     ],
 )

--- a/tests/serializers/test_none.py
+++ b/tests/serializers/test_none.py
@@ -1,0 +1,39 @@
+import pytest
+
+from pydantic_core import SchemaSerializer, core_schema
+
+all_scalars = (
+    'int',
+    'bool',
+    'float',
+    'none',
+    'str',
+    'bytes',
+    'datetime',
+    'date',
+    'time',
+    'timedelta',
+    'url',
+    'multi-host-url',
+)
+all_types = all_scalars + ('list', 'tuple', 'dict', 'set', 'frozenset')
+
+
+@pytest.mark.parametrize('schema_type', all_types)
+def test_none_fallback(schema_type):
+    s = SchemaSerializer({'type': schema_type})
+    assert s.to_python(None) is None
+
+    assert s.to_python(None, mode='json') is None
+
+    assert s.to_json(None) == b'null'
+
+
+@pytest.mark.parametrize('schema_type', all_scalars)
+def test_none_fallback_key(schema_type):
+    s = SchemaSerializer(core_schema.dict_schema({'type': schema_type}, core_schema.int_schema()))
+    assert s.to_python({None: 1}) == {None: 1}
+
+    assert s.to_python({None: 1}, mode='json') == {'None': 1}
+
+    assert s.to_json({None: 1}) == b'{"None":1}'

--- a/tests/serializers/test_string.py
+++ b/tests/serializers/test_string.py
@@ -25,6 +25,9 @@ def test_str():
 
 def test_str_fallback():
     s = SchemaSerializer(core_schema.string_schema())
+    assert s.to_python(None) is None
+    assert s.to_python(None, mode='json') is None
+    assert s.to_json(None) == b'null'
     with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
         assert s.to_python(123) == 123
     with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):

--- a/tests/serializers/test_typed_dict.py
+++ b/tests/serializers/test_typed_dict.py
@@ -46,15 +46,15 @@ def test_typed_dict_allow_extra():
     [
         dict(include=None, exclude=None, expected={'0': 0, '1': 1, '2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude=None, expected={'0': 0, '1': 1}),
-        dict(include={'0': None, '1': None}, exclude=None, expected={'0': 0, '1': 1}),
+        dict(include={'0': ..., '1': ...}, exclude=None, expected={'0': 0, '1': 1}),
         dict(include={'0': {1}, '1': {1}}, exclude=None, expected={'0': 0, '1': 1}),
         dict(include=None, exclude={'0', '1'}, expected={'2': 2, '3': 3}),
-        dict(include=None, exclude={'0': None, '1': None}, expected={'2': 2, '3': 3}),
+        dict(include=None, exclude={'0': ..., '1': ...}, expected={'2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude={'1', '2'}, expected={'0': 0}),
         dict(include=None, exclude={'3': {1}}, expected={'0': 0, '1': 1, '2': 2, '3': 3}),
         dict(include={'0', '1'}, exclude={'3': {1}}, expected={'0': 0, '1': 1}),
         dict(include={'0', '1'}, exclude={'1': {1}}, expected={'0': 0, '1': 1}),
-        dict(include={'0', '1'}, exclude={'1': None}, expected={'0': 0}),
+        dict(include={'0', '1'}, exclude={'1': ...}, expected={'0': 0}),
     ],
 )
 def test_include_exclude_args(params):


### PR DESCRIPTION
* serializing enums, including workaround for https://github.com/PyO3/pyo3/issues/2905
* no fallback warning if the input is `None`
* no `format` if the input is `None`
* fallback not error on wrong type to `model`, no warning on fallback with `None`
* use ellipsis, not  `None` in filtering.
* support for `'__all__'` special key value