### PR TITLE
Add min-length support for GeneratorSchema

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1288,6 +1288,7 @@ def frozenset_schema(
 class GeneratorSchema(TypedDict, total=False):
     type: Required[Literal['generator']]
     items_schema: CoreSchema
+    min_length: int
     max_length: int
     ref: str
     extra: Any
@@ -1297,6 +1298,7 @@ class GeneratorSchema(TypedDict, total=False):
 def generator_schema(
     items_schema: CoreSchema | None = None,
     *,
+    min_length: int | None = None,
     max_length: int | None = None,
     ref: str | None = None,
     extra: Any = None,
@@ -1319,6 +1321,7 @@ def generator_schema(
 
     Args:
         items_schema: The value must be a generator with items that match this schema
+        min_length: The value must be a generator that yields at least this many items
         max_length: The value must be a generator that yields at most this many items
         ref: See [TODO] for details
         extra: See [TODO] for details
@@ -1327,6 +1330,7 @@ def generator_schema(
     return dict_not_none(
         type='generator',
         items_schema=items_schema,
+        min_length=min_length,
         max_length=max_length,
         ref=ref,
         extra=extra,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1319,6 +1319,10 @@ def generator_schema(
     v.validate_python(gen())
     ```
 
+    Unlike other types, validated generators do not raise ValidationErrors eagerly,
+    but instead will raise a ValidationError when a violating value is actually read from the generator.
+    This is to ensure that "validated" generators retain the benefit of lazy evaluation.
+
     Args:
         items_schema: The value must be a generator with items that match this schema
         min_length: The value must be a generator that yields at least this many items

--- a/tests/validators/test_generator.py
+++ b/tests/validators/test_generator.py
@@ -114,3 +114,21 @@ def test_too_long(py_and_json: PyAndJson):
             'ctx': {'field_type': 'Generator', 'max_length': 2, 'actual_length': 3},
         }
     ]
+
+
+def test_too_short(py_and_json: PyAndJson):
+    v = py_and_json({'type': 'generator', 'items_schema': {'type': 'int'}, 'min_length': 2})
+    assert list(v.validate_test([1, 2, 3])) == [1, 2, 3]
+    assert list(v.validate_test([1, 2])) == [1, 2]
+    with pytest.raises(ValidationError) as exc_info:
+        list(v.validate_test([1]))
+    # insert_assert(exc_info.value.errors())
+    assert exc_info.value.errors() == [
+        {
+            'type': 'too_short',
+            'loc': (),
+            'msg': 'Generator should have at least 2 items after validation, not 1',
+            'input': [1],
+            'ctx': {'field_type': 'Generator', 'min_length': 2, 'actual_length': 1},
+        }
+    ]

--- a/tests/validators/test_generator.py
+++ b/tests/validators/test_generator.py
@@ -147,8 +147,8 @@ def test_generator_too_long():
     validating_iterator = v.validate_python(gen())
 
     # Ensure the error happens at exactly the right step:
-    next(validating_iterator)
-    next(validating_iterator)
+    assert next(validating_iterator) == 1
+    assert next(validating_iterator) == 2
     with pytest.raises(ValidationError) as exc_info:
         next(validating_iterator)
 
@@ -171,9 +171,9 @@ def test_generator_too_short():
     validating_iterator = v.validate_python(gen())
 
     # Ensure the error happens at exactly the right step:
-    next(validating_iterator)
-    next(validating_iterator)
-    next(validating_iterator)
+    assert next(validating_iterator) == 1
+    assert next(validating_iterator) == 2
+    assert next(validating_iterator) == 3
     with pytest.raises(ValidationError) as exc_info:
         next(validating_iterator)
 

--- a/tests/validators/test_generator.py
+++ b/tests/validators/test_generator.py
@@ -1,5 +1,4 @@
 import re
-from typing import Iterator
 
 import pytest
 
@@ -138,7 +137,7 @@ def test_too_short(py_and_json: PyAndJson):
 def test_generator_too_long():
     v = SchemaValidator({'type': 'generator', 'items_schema': {'type': 'int'}, 'max_length': 2})
 
-    def gen() -> Iterator[int]:
+    def gen():
         yield 1
         yield 2
         yield 3
@@ -168,7 +167,7 @@ def test_generator_too_long():
 def test_generator_too_short():
     v = SchemaValidator({'type': 'generator', 'items_schema': {'type': 'int'}, 'min_length': 4})
 
-    def gen() -> Iterator[int]:
+    def gen():
         yield 1
         yield 2
         yield 3


### PR DESCRIPTION
Adds `min_length` to the `GeneratorSchema`.

Closes #392 