### PR TITLE
Expose `from_attributes` field of TaggedUnionSchema in python

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1808,6 +1808,7 @@ class TaggedUnionSchema(TypedDict, total=False):
     custom_error_message: str
     custom_error_context: Dict[str, Union[str, int, float]]
     strict: bool
+    from_attributes: bool
     ref: str
     metadata: Any
     serialization: SerSchema
@@ -1821,6 +1822,7 @@ def tagged_union_schema(
     custom_error_message: str | None = None,
     custom_error_context: dict[str, int | str | float] | None = None,
     strict: bool | None = None,
+    from_attributes: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
     serialization: SerSchema | None = None,
@@ -1873,6 +1875,7 @@ def tagged_union_schema(
         custom_error_message=custom_error_message,
         custom_error_context=custom_error_context,
         strict=strict,
+        from_attributes=from_attributes,
         ref=ref,
         metadata=metadata,
         serialization=serialization,

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -14,6 +14,16 @@ use super::{
     Input, JsonArgs, JsonInput, JsonType,
 };
 
+impl JsonInput {
+    pub fn laxer_str(&self) -> ValResult<String> {
+        match self {
+            JsonInput::String(s) => Ok(s.as_str().into()),
+            JsonInput::Int(i) => Ok(i.to_string()),
+            _ => Err(ValError::new(ErrorType::StringType, self)),
+        }
+    }
+}
+
 impl<'a> Input<'a> for JsonInput {
     fn get_type(&self) -> &'static InputType {
         &InputType::Json


### PR DESCRIPTION
This allows me to set `from_attributes=True` in the tagged union schema I generate for discriminators, which allows me to read the discriminator as an attribute from a model. (Right now using a tagged union of models doesn't seem to work in pydantic because they fail to be converted to dict when validating as python).

I don't _necessarily_ think that is the right solution in pydantic — might be better to make it dump a model instance to a dict prior to trying to read the discriminator, since that may work better for `__root__` etc., though there may be performance implications — but even if not, I don't really see any reason not to expose this field, and I suspect it was just an oversight.

(I noticed this field is exposed on some other schema variants.)

@samuelcolvin let me know if I need to add a test for this; if so, it would help if you could point me at something analogous.