### PR TITLE
Use `ChoiceKey` in `TaggedUnionValidator` for int keys

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -129,11 +129,14 @@ def type_dict_schema(typed_dict) -> dict[str, Any]:  # noqa: C901
                     schema = {'type': 'list', 'items_schema': schema_ref_validator}
                 elif fr_arg == 'Dict[str, CoreSchema]':
                     schema = {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': schema_ref_validator}
-                elif fr_arg == 'Dict[str, Union[str, CoreSchema]]':
+                elif fr_arg == 'Dict[Union[str, int], Union[str, int, CoreSchema]]':
                     schema = {
                         'type': 'dict',
-                        'keys_schema': {'type': 'str'},
-                        'values_schema': {'type': 'union', 'choices': [{'type': 'str'}, schema_ref_validator]},
+                        'keys_schema': {'type': 'union', 'choices': [{'type': 'str'}, {'type': 'int'}]},
+                        'values_schema': {
+                            'type': 'union',
+                            'choices': [{'type': 'str'}, {'type': 'int'}, schema_ref_validator],
+                        },
                     }
                 else:
                     raise ValueError(f'Unknown Schema forward ref: {fr_arg}')

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1805,7 +1805,7 @@ def union_schema(
 
 class TaggedUnionSchema(TypedDict, total=False):
     type: Required[Literal['tagged-union']]
-    choices: Required[Dict[str, Union[str, CoreSchema]]]
+    choices: Required[Dict[Union[str, int], Union[str, int, CoreSchema]]]
     discriminator: Required[
         Union[str, List[Union[str, int]], List[List[Union[str, int]]], Callable[[Any], Optional[str]]]
     ]

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1813,6 +1813,7 @@ class TaggedUnionSchema(TypedDict, total=False):
     custom_error_message: str
     custom_error_context: Dict[str, Union[str, int, float]]
     strict: bool
+    from_attributes: bool  # default: True
     ref: str
     metadata: Any
     serialization: SerSchema
@@ -1826,6 +1827,7 @@ def tagged_union_schema(
     custom_error_message: str | None = None,
     custom_error_context: dict[str, int | str | float] | None = None,
     strict: bool | None = None,
+    from_attributes: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
     serialization: SerSchema | None = None,
@@ -1873,6 +1875,7 @@ def tagged_union_schema(
         custom_error_message: The custom error message to use if the validation fails
         custom_error_context: The custom error context to use if the validation fails
         strict: Whether the underlying schemas should be validated with strict mode
+        from_attributes: Whether to use the attributes of the object to retrieve the discriminator value
         ref: See [TODO] for details
         metadata: See [TODO] for details
         serialization: Custom serialization schema
@@ -1885,6 +1888,7 @@ def tagged_union_schema(
         custom_error_message=custom_error_message,
         custom_error_context=custom_error_context,
         strict=strict,
+        from_attributes=from_attributes,
         ref=ref,
         metadata=metadata,
         serialization=serialization,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1819,7 +1819,7 @@ class TaggedUnionSchema(TypedDict, total=False):
 
 
 def tagged_union_schema(
-    choices: Dict[str, str | CoreSchema],
+    choices: Dict[Union[int, str], int | str | CoreSchema],
     discriminator: str | list[str | int] | list[list[str | int]] | Callable[[Any], str | None],
     *,
     custom_error_type: str | None = None,

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -11,8 +11,12 @@ use pyo3::types::PyTuple;
 pub enum LocItem {
     /// string type key, used to identify items from a dict or anything that implements `__getitem__`
     S(String),
-    /// integer key, used to get items from a list, tuple OR a dict with int keys `Dict[int, ...]` (python only)
-    I(usize),
+    /// integer key, used to get:
+    ///   * items from a list
+    ///   * items from a tuple
+    ///   * dict with int keys `Dict[int, ...]` (python only)
+    ///   * with integer keys in tagged unions
+    I(i64),
 }
 
 impl fmt::Display for LocItem {
@@ -36,9 +40,15 @@ impl From<&str> for LocItem {
     }
 }
 
-impl From<usize> for LocItem {
-    fn from(i: usize) -> Self {
+impl From<i64> for LocItem {
+    fn from(i: i64) -> Self {
         Self::I(i)
+    }
+}
+
+impl From<usize> for LocItem {
+    fn from(u: usize) -> Self {
+        Self::I(u as i64)
     }
 }
 

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -23,7 +23,7 @@ impl<'a> Input<'a> for JsonInput {
     #[cfg_attr(has_no_coverage, no_coverage)]
     fn as_loc_item(&self) -> LocItem {
         match self {
-            JsonInput::Int(i) => LocItem::I(*i as usize),
+            JsonInput::Int(i) => (*i).into(),
             JsonInput::String(s) => s.as_str().into(),
             v => format!("{v:?}").into(),
         }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -75,7 +75,8 @@ impl Validator for LiteralSingleStringValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let either_str = input.strict_str()?;
+        let strict = if let Some(s) = _extra.strict { s } else { false };
+        let either_str = input.validate_str(strict)?;
         if either_str.as_cow()?.as_ref() == self.expected.as_str() {
             Ok(input.to_object(py))
         } else {
@@ -117,8 +118,9 @@ impl Validator for LiteralSingleIntValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let str = input.strict_int()?;
-        if str == self.expected {
+        let strict = if let Some(s) = _extra.strict { s } else { false };
+        let int = input.validate_int(strict)?;
+        if int == self.expected {
             Ok(input.to_object(py))
         } else {
             Err(ValError::new(
@@ -172,7 +174,8 @@ impl Validator for LiteralMultipleStringsValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let either_str = input.strict_str()?;
+        let strict = if let Some(s) = _extra.strict { s } else { false };
+        let either_str = input.validate_str(strict)?;
         if self.expected.contains(either_str.as_cow()?.as_ref()) {
             Ok(input.to_object(py))
         } else {
@@ -227,7 +230,8 @@ impl Validator for LiteralMultipleIntsValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let int = input.strict_int()?;
+        let strict = if let Some(s) = _extra.strict { s } else { false };
+        let int = input.validate_int(strict)?;
         if self.expected.contains(&int) {
             Ok(input.to_object(py))
         } else {
@@ -291,15 +295,16 @@ impl Validator for LiteralGeneralValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
+        let strict = if let Some(s) = _extra.strict { s } else { false };
         if !self.expected_int.is_empty() {
-            if let Ok(int) = input.strict_int() {
+            if let Ok(int) = input.validate_int(strict) {
                 if self.expected_int.contains(&int) {
                     return Ok(input.to_object(py));
                 }
             }
         }
         if !self.expected_str.is_empty() {
-            if let Ok(either_str) = input.strict_str() {
+            if let Ok(either_str) = input.validate_str(strict) {
                 if self.expected_str.contains(either_str.as_cow()?.as_ref()) {
                     return Ok(input.to_object(py));
                 }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -71,12 +71,11 @@ impl Validator for LiteralSingleStringValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
+        extra: &Extra,
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let strict = if let Some(s) = _extra.strict { s } else { false };
-        let either_str = input.validate_str(strict)?;
+        let either_str = input.validate_str(extra.strict.unwrap_or(false))?;
         if either_str.as_cow()?.as_ref() == self.expected.as_str() {
             Ok(input.to_object(py))
         } else {
@@ -114,12 +113,11 @@ impl Validator for LiteralSingleIntValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
+        extra: &Extra,
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let strict = if let Some(s) = _extra.strict { s } else { false };
-        let int = input.validate_int(strict)?;
+        let int = input.validate_int(extra.strict.unwrap_or(false))?;
         if int == self.expected {
             Ok(input.to_object(py))
         } else {
@@ -170,12 +168,11 @@ impl Validator for LiteralMultipleStringsValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
+        extra: &Extra,
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let strict = if let Some(s) = _extra.strict { s } else { false };
-        let either_str = input.validate_str(strict)?;
+        let either_str = input.validate_str(extra.strict.unwrap_or(false))?;
         if self.expected.contains(either_str.as_cow()?.as_ref()) {
             Ok(input.to_object(py))
         } else {
@@ -226,12 +223,11 @@ impl Validator for LiteralMultipleIntsValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
+        extra: &Extra,
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let strict = if let Some(s) = _extra.strict { s } else { false };
-        let int = input.validate_int(strict)?;
+        let int = input.validate_int(extra.strict.unwrap_or(false))?;
         if self.expected.contains(&int) {
             Ok(input.to_object(py))
         } else {
@@ -291,11 +287,11 @@ impl Validator for LiteralGeneralValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
+        extra: &Extra,
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let strict = if let Some(s) = _extra.strict { s } else { false };
+        let strict = extra.strict.unwrap_or(false);
         if !self.expected_int.is_empty() {
             if let Ok(int) = input.validate_int(strict) {
                 if self.expected_int.contains(&int) {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -295,7 +295,7 @@ impl BuildValidator for TaggedUnionValidator {
         };
 
         let key = intern!(py, "from_attributes");
-        let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(true);
+        let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(false);
 
         let descr = match discriminator {
             Discriminator::SelfSchema => "self-schema".to_string(),

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -295,7 +295,7 @@ impl BuildValidator for TaggedUnionValidator {
         };
 
         let key = intern!(py, "from_attributes");
-        let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(false);
+        let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(true);
 
         let descr = match discriminator {
             Discriminator::SelfSchema => "self-schema".to_string(),

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -203,7 +203,7 @@ impl ChoiceKey {
         } else if let Ok(py_str) = raw.downcast::<PyString>() {
             Ok(Self::Str(py_str.to_str()?.to_string()))
         } else {
-            py_err!(format!("Expected int or str, got {}", raw.get_type().name()?))
+            py_err!(PyTypeError; "Expected int or str, got {}", raw.get_type().name().unwrap_or("<unknown python object>"))
         }
     }
 }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -250,11 +250,7 @@ impl BuildValidator for TaggedUnionValidator {
         let mut descr = String::with_capacity(50);
 
         for (key, value) in schema_choices {
-            let tag = if let Ok(choice_key) = ChoiceKey::from_py(key) {
-                choice_key
-            } else {
-                return py_err!("Keys of schema must be int or string but got: {}", key);
-            };
+            let tag = choice_key ChoiceKey::from_py(key)?;
 
             if let Ok(repeat_tag) = ChoiceKey::from_py(value) {
                 repeat_choices_vec.push((tag, repeat_tag));

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -471,7 +471,7 @@ impl TaggedUnionValidator {
                 return match validator.validate(py, input, extra, slots, recursion_guard) {
                     Ok(res) => Ok(res),
                     Err(err) => match tag.as_ref() {
-                        ChoiceKey::Str(s) => Err(err.with_outer_location((*s).clone().into())),
+                        ChoiceKey::Str(s) => Err(err.with_outer_location(s.into())),
                         ChoiceKey::Int(i) => Err(err.with_outer_location((*i).clone().to_string().into())),
                     },
                 };

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -207,6 +207,13 @@ impl ChoiceKey {
             py_err!(PyTypeError; "Expected int or str, got {}", raw.get_type().name().unwrap_or("<unknown python object>"))
         }
     }
+
+    fn repr(&self) -> String {
+        match self {
+            Self::Int(i) => i.to_string(),
+            Self::Str(s) => format!("'{s}'"),
+        }
+    }
 }
 
 impl fmt::Display for ChoiceKey {
@@ -259,12 +266,13 @@ impl BuildValidator for TaggedUnionValidator {
             }
 
             let validator = build_validator(value, config, build_context)?;
+            let tag_repr = tag.repr();
             if first {
                 first = false;
-                write!(tags_repr, "'{tag}'").unwrap();
+                write!(tags_repr, "{tag_repr}").unwrap();
                 descr.push_str(validator.get_name());
             } else {
-                write!(tags_repr, ", '{tag}'").unwrap();
+                write!(tags_repr, ", {tag_repr}").unwrap();
                 // no spaces in get_name() output to make loc easy to read
                 write!(descr, ",{}", validator.get_name()).unwrap();
             }
@@ -278,7 +286,8 @@ impl BuildValidator for TaggedUnionValidator {
             for (tag, repeat_tag) in repeat_choices_vec {
                 match choices.get(&repeat_tag) {
                     Some(validator) => {
-                        write!(tags_repr, ", '{tag}'").unwrap();
+                        let tag_repr = tag.repr();
+                        write!(tags_repr, ", {tag_repr}").unwrap();
                         write!(descr, ",{}", validator.get_name()).unwrap();
                         repeat_choices.insert(tag, repeat_tag);
                     }

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -8,6 +8,8 @@ from pydantic_core import SchemaValidator, ValidationError
 
 from ..conftest import Err, PyAndJson, plain_repr
 
+i64_max = 9_223_372_036_854_775_807
+
 
 @pytest.mark.parametrize(
     'input_value,expected',
@@ -24,6 +26,7 @@ from ..conftest import Err, PyAndJson, plain_repr
         ('123456789.0', 123_456_789),
         ('123456789123456.00001', 123_456_789_123_456),
         (int(1e10), int(1e10)),
+        (i64_max, i64_max),
         pytest.param(
             12.5,
             Err('Input should be a valid integer, got a number with a fractional part [type=int_from_float'),
@@ -54,6 +57,9 @@ def test_int_py_and_json(py_and_json: PyAndJson, input_value, expected):
     [
         (Decimal('1'), 1),
         (Decimal('1.0'), 1),
+        (i64_max, i64_max),
+        (i64_max + 1, i64_max),
+        (i64_max * 2, i64_max),
         pytest.param(
             Decimal('1.001'),
             Err(

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -121,7 +121,7 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
                 [
                     {
                         'type': 'int_parsing',
-                        'loc': ('123', 'bar'),
+                        'loc': (123, 'bar'),
                         'msg': 'Input should be a valid integer, unable to parse string as an integer',
                         'input': 'wrong',
                     }

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -138,10 +138,10 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
                         'loc': (),
                         'msg': (
                             "Input tag '1234567' found using 'foo' does not match any of the "
-                            "expected tags: '123', 'banana'"
+                            "expected tags: 123, 'banana'"
                         ),
                         'input': {'foo': 1234567, 'bar': '123'},
-                        'ctx': {'discriminator': "'foo'", 'tag': '1234567', 'expected_tags': "'123', 'banana'"},
+                        'ctx': {'discriminator': "'foo'", 'tag': '1234567', 'expected_tags': "123, 'banana'"},
                     }
                 ],
             ),
@@ -214,9 +214,9 @@ def test_enum_keys():
         {
             'type': 'union_tag_invalid',
             'loc': (),
-            'msg': "Input tag 'apple' found using 'foo' does not match any of the expected tags: '1', 'banana'",
+            'msg': "Input tag 'apple' found using 'foo' does not match any of the expected tags: 1, 'banana'",
             'input': {'foo': FooEnum.APPLE, 'spam': [1, 2, '3']},
-            'ctx': {'discriminator': "'foo'", 'tag': 'apple', 'expected_tags': "'1', 'banana'"},
+            'ctx': {'discriminator': "'foo'", 'tag': 'apple', 'expected_tags': "1, 'banana'"},
         }
     ]
 
@@ -523,13 +523,13 @@ def test_tag_repeated(py_and_json: PyAndJson):
             'loc': (),
             'msg': (
                 "Input tag 'wrong' found using 'food' does not match any of the expected tags: "
-                "'apple', 'banana', '1', 'cherry', 'durian', '2'"
+                "'apple', 'banana', 1, 'cherry', 'durian', 2"
             ),
             'input': {'food': 'wrong'},
             'ctx': {
                 'discriminator': "'food'",
                 'tag': 'wrong',
-                'expected_tags': "'apple', 'banana', '1', 'cherry', 'durian', '2'",
+                'expected_tags': "'apple', 'banana', 1, 'cherry', 'durian', 2",
             },
         }
     ]

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -82,6 +82,7 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
         {
             'type': 'tagged-union',
             'discriminator': 'foo',
+            'from_attributes': False,
             'choices': {
                 'apple': {
                     'type': 'typed-dict',

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -271,8 +271,16 @@ def test_use_ref():
 
 def test_downcast_error():
     v = SchemaValidator({'type': 'tagged-union', 'discriminator': lambda x: 123, 'choices': {'str': {'type': 'str'}}})
-    with pytest.raises(TypeError, match="'int' object cannot be converted to 'PyString'"):
+    with pytest.raises(ValidationError) as exc_info:
         v.validate_python('x')
+        assert exc_info.value.errors() == [
+            {
+                'type': 'union_tag_invalid',
+                'loc': (),
+                'msg': "Input tag '123' found using <lambda>() does not match any of the expected tags: 'str'",
+                'input': 'x',
+            }
+        ]
 
 
 def test_custom_error():

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -135,7 +135,7 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
                         'loc': (),
                         'msg': (
                             "Input tag '1234567' found using 'foo' does not match any of the "
-                            "expected tags: '123', 'banana'",
+                            "expected tags: '123', 'banana'"
                         ),
                         'input': {'foo': 1234567, 'bar': '123'},
                         'ctx': {'discriminator': "'foo'", 'tag': '1234567', 'expected_tags': "'123', 'banana'"},

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -498,14 +498,21 @@ def test_tag_repeated(py_and_json: PyAndJson):
                 },
                 'cherry': 'banana',
                 'durian': 'apple',
+                1: {
+                    'type': 'typed-dict',
+                    'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'int'}}},
+                },
+                2: 1,
             },
         }
     )
     assert v.validate_test({'food': 'apple', 'a': 'ap', 'b': '13'}) == {'a': 'ap', 'b': 13}
     assert v.validate_test({'food': 'durian', 'a': 'ap', 'b': '13'}) == {'a': 'ap', 'b': 13}
+    assert v.validate_test({'food': 1, 'a': 123, 'b': '13'}) == {'a': 123, 'b': 13}
 
     assert v.validate_test({'food': 'banana', 'c': 'C', 'd': [1, '2']}) == {'c': 'C', 'd': [1, 2]}
     assert v.validate_test({'food': 'cherry', 'c': 'C', 'd': [1, '2']}) == {'c': 'C', 'd': [1, 2]}
+    assert v.validate_test({'food': 2, 'a': 123, 'b': '13'}) == {'a': 123, 'b': 13}
     with pytest.raises(ValidationError) as exc_info:
         v.validate_test({'food': 'wrong'})
     # insert_assert(exc_info.value.errors())
@@ -515,13 +522,13 @@ def test_tag_repeated(py_and_json: PyAndJson):
             'loc': (),
             'msg': (
                 "Input tag 'wrong' found using 'food' does not match any of the expected tags: "
-                "'apple', 'banana', 'cherry', 'durian'"
+                "'apple', 'banana', '1', 'cherry', 'durian', '2'"
             ),
             'input': {'food': 'wrong'},
             'ctx': {
                 'discriminator': "'food'",
                 'tag': 'wrong',
-                'expected_tags': "'apple', 'banana', 'cherry', 'durian'",
+                'expected_tags': "'apple', 'banana', '1', 'cherry', 'durian', '2'",
             },
         }
     ]


### PR DESCRIPTION
Used for supporting Discriminated Unions for https://github.com/pydantic/pydantic/issues/4675

As per https://github.com/pydantic/pydantic/issues/4675#issuecomment-1415443982, supporting int and string keys should use an Enum.