### PR TITLE
Support include/exclude arguments with `__contains__`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 #![cfg_attr(has_no_coverage, feature(no_coverage))]
 #![allow(clippy::borrow_deref_ref)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 #![cfg_attr(has_no_coverage, feature(no_coverage))]
 #![allow(clippy::borrow_deref_ref)]
 

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -124,7 +124,9 @@ trait FilterLogic<T: Eq + Copy> {
     ) -> PyResult<Option<(Option<&'py PyAny>, Option<&'py PyAny>)>> {
         let mut next_exclude: Option<&PyAny> = None;
         if let Some(exclude) = exclude {
-            if let Ok(exclude_dict) = exclude.downcast::<PyDict>() {
+            if exclude.is_none() {
+                // Do nothing; place this check at the top for performance in the common case
+            } else if let Ok(exclude_dict) = exclude.downcast::<PyDict>() {
                 let op_exc_value = merge_all_value(exclude_dict, py_key)?;
                 if let Some(exc_value) = op_exc_value {
                     if is_ellipsis_like(exc_value) {
@@ -149,13 +151,15 @@ trait FilterLogic<T: Eq + Copy> {
                 {
                     return Ok(None);
                 }
-            } else if !exclude.is_none() {
+            } else {
                 return Err(PyTypeError::new_err("`exclude` argument must be a set or dict."));
             }
         }
 
         if let Some(include) = include {
-            if let Ok(include_dict) = include.downcast::<PyDict>() {
+            if include.is_none() {
+                // Do nothing; place this check at the top for performance in the common case
+            } else if let Ok(include_dict) = include.downcast::<PyDict>() {
                 let op_inc_value = merge_all_value(include_dict, py_key)?;
 
                 if let Some(inc_value) = op_inc_value {
@@ -190,7 +194,7 @@ trait FilterLogic<T: Eq + Copy> {
                     // this index should be omitted
                     return Ok(None);
                 }
-            } else if !include.is_none() {
+            } else {
                 return Err(PyTypeError::new_err("`include` argument must be a set or dict."));
             }
         }

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -139,7 +139,7 @@ trait FilterLogic<T: Eq + Copy> {
                     }
                 }
             } else if let Ok(exclude_set) = exclude.downcast::<PySet>() {
-                if exclude_set.contains(py_key)? || exclude_set.contains(intern!(exclude.py(), "__all__"))? {
+                if exclude_set.contains(py_key)? || exclude_set.contains(intern!(exclude_set.py(), "__all__"))? {
                     // index is in the exclude set, we return Ok(None) to omit this index
                     return Ok(None);
                 }
@@ -171,7 +171,7 @@ trait FilterLogic<T: Eq + Copy> {
                     return Ok(None);
                 }
             } else if let Ok(include_set) = include.downcast::<PySet>() {
-                if include_set.contains(py_key)? || include_set.contains(intern!(include.py(), "__all__"))? {
+                if include_set.contains(py_key)? || include_set.contains(intern!(include_set.py(), "__all__"))? {
                     return Ok(Some((None, next_exclude)));
                 } else if !self.explicit_include(int_key) {
                     // if the index is not in include, include exists, AND it's not in schema include,

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -124,7 +124,6 @@ trait FilterLogic<T: Eq + Copy> {
     ) -> PyResult<Option<(Option<&'py PyAny>, Option<&'py PyAny>)>> {
         let mut next_exclude: Option<&PyAny> = None;
         if let Some(exclude) = exclude {
-            let py = exclude.py();
             if exclude.is_none() {
                 // Do nothing; place this check at the top for performance in the common case
             } else if let Ok(exclude_dict) = exclude.downcast::<PyDict>() {
@@ -140,12 +139,12 @@ trait FilterLogic<T: Eq + Copy> {
                     }
                 }
             } else if let Ok(exclude_set) = exclude.downcast::<PySet>() {
-                if exclude_set.contains(py_key)? || exclude_set.contains(intern!(py, "__all__"))? {
+                if exclude_set.contains(py_key)? || exclude_set.contains(intern!(exclude.py(), "__all__"))? {
                     // index is in the exclude set, we return Ok(None) to omit this index
                     return Ok(None);
                 }
-            } else if let Ok(contains_method) = exclude.getattr(intern!(py, "__contains__")) && let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
-                if result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()? {
+            } else if let Some(contains) = check_contains(exclude, py_key)? {
+                if contains {
                     return Ok(None);
                 }
             } else {
@@ -154,7 +153,6 @@ trait FilterLogic<T: Eq + Copy> {
         }
 
         if let Some(include) = include {
-            let py = include.py();
             if include.is_none() {
                 // Do nothing; place this check at the top for performance in the common case
             } else if let Ok(include_dict) = include.downcast::<PyDict>() {
@@ -173,15 +171,15 @@ trait FilterLogic<T: Eq + Copy> {
                     return Ok(None);
                 }
             } else if let Ok(include_set) = include.downcast::<PySet>() {
-                if include_set.contains(py_key)? || include_set.contains(intern!(py, "__all__"))? {
+                if include_set.contains(py_key)? || include_set.contains(intern!(include.py(), "__all__"))? {
                     return Ok(Some((None, next_exclude)));
                 } else if !self.explicit_include(int_key) {
                     // if the index is not in include, include exists, AND it's not in schema include,
                     // this index should be omitted
                     return Ok(None);
                 }
-            } else if let Ok(contains_method) = include.getattr(intern!(py, "__contains__")) && let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
-                if result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()? {
+            } else if let Some(contains) = check_contains(include, py_key)? {
+                if contains {
                     return Ok(Some((None, next_exclude)));
                 } else if !self.explicit_include(int_key) {
                     // if the index is not in include, include exists, AND it's not in schema include,
@@ -249,6 +247,24 @@ impl AnyFilter {
         exclude: Option<&'py PyAny>,
     ) -> PyResult<Option<(Option<&'py PyAny>, Option<&'py PyAny>)>> {
         self.filter(index, index, include, exclude)
+    }
+}
+
+/// if a `__contains__` method exists, call it with the key and `__all__`, and return the result
+/// if it doesn't exist, or calling it fails (e.g. it's not a function), return `None`
+fn check_contains(obj: &PyAny, py_key: impl ToPyObject + Copy) -> PyResult<Option<bool>> {
+    let py = obj.py();
+    match obj.getattr(intern!(py, "__contains__")) {
+        Ok(contains_method) => {
+            if let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
+                Ok(Some(
+                    result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()?,
+                ))
+            } else {
+                Ok(None)
+            }
+        }
+        Err(_) => Ok(None),
     }
 }
 

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -144,10 +144,8 @@ trait FilterLogic<T: Eq + Copy> {
                     // index is in the exclude set, we return Ok(None) to omit this index
                     return Ok(None);
                 }
-            } else if let Ok(contains_method) = exclude.getattr(intern!(py, "__contains__")) {
-                if contains_method.call1((py_key.to_object(py),))?.is_true()?
-                    || contains_method.call1((intern!(py, "__all__"),))?.is_true()?
-                {
+            } else if let Ok(contains_method) = exclude.getattr(intern!(py, "__contains__")) && let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
+                if result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()? {
                     return Ok(None);
                 }
             } else {
@@ -182,10 +180,8 @@ trait FilterLogic<T: Eq + Copy> {
                     // this index should be omitted
                     return Ok(None);
                 }
-            } else if let Ok(contains_method) = include.getattr(intern!(py, "__contains__")) {
-                if contains_method.call1((py_key.to_object(py),))?.is_true()?
-                    || contains_method.call1((intern!(py, "__all__"),))?.is_true()?
-                {
+            } else if let Ok(contains_method) = include.getattr(intern!(py, "__contains__")) && let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
+                if result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()? {
                     return Ok(Some((None, next_exclude)));
                 } else if !self.explicit_include(int_key) {
                     // if the index is not in include, include exists, AND it's not in schema include,

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -136,6 +136,20 @@ def test_filter_runtime():
     assert v.to_python([0, 1, 2, 3], include={1, 2}) == [1, 2]
 
 
+class ImplicitContains:
+    def __iter__(self):
+        return iter([1, 2, 5])
+
+
+class ExplicitContains(ImplicitContains):
+    def __contains__(self, item):
+        return item in {2, 5}
+
+
+class RemovedContains(ImplicitContains):
+    __contains__ = None  # This might be done to explicitly force the `x in RemovedContains()` check to not be allowed
+
+
 @pytest.mark.parametrize(
     'include_value,error_msg',
     [
@@ -143,6 +157,9 @@ def test_filter_runtime():
         ({'a': 'dict'}, 'Input should be a valid set'),
         ({4.2}, 'Input should be a valid integer, got a number with a fractional part'),
         ({'a'}, 'Input should be a valid integer, unable to parse string as an integer'),
+        (ImplicitContains(), re.compile('.*Invalid Schema:.*Input should be a valid set.*', re.DOTALL)),
+        (ExplicitContains(), re.compile('.*Invalid Schema:.*Input should be a valid set.*', re.DOTALL)),
+        (RemovedContains(), re.compile('.*Invalid Schema:.*Input should be a valid set.*', re.DOTALL)),
     ],
 )
 @pytest.mark.parametrize('schema_func', [core_schema.list_schema, core_schema.tuple_variable_schema])
@@ -154,12 +171,40 @@ def test_include_error(schema_func, include_value, error_msg):
 
 
 @pytest.mark.parametrize(
+    'include,exclude,expected',
+    [
+        ({1, 3}, None, ['b', 'd']),
+        ({1, 3, 5}, {5}, ['b', 'd']),
+        ({2: None, 3: None, 5: None}.keys(), {5}, ['c', 'd']),
+        (ExplicitContains(), set(), ['c', 'f']),
+        (ExplicitContains(), {5}, ['c']),
+        ({2, 3}, ExplicitContains(), ['d']),
+    ],
+)
+def test_filter_runtime_more(include, exclude, expected):
+    v = SchemaSerializer(core_schema.list_schema(core_schema.any_schema()))
+    assert v.to_python(list('abcdefgh'), include=include, exclude=exclude) == expected
+
+
+@pytest.mark.parametrize(
     'schema_func,seq_f', [(core_schema.list_schema, as_list), (core_schema.tuple_variable_schema, as_tuple)]
 )
-def test_include_error_call_time(schema_func, seq_f):
+@pytest.mark.parametrize(
+    'include,exclude',
+    [
+        (ImplicitContains(), None),
+        (RemovedContains(), None),
+        (1, None),
+        (None, ImplicitContains()),
+        (None, RemovedContains()),
+        (None, 1),
+    ],
+)
+def test_include_error_call_time(schema_func, seq_f, include, exclude):
+    kind = 'include' if include is not None else 'exclude'
     v = SchemaSerializer(schema_func(core_schema.any_schema()))
-    with pytest.raises(TypeError, match='`include` argument must be a set or dict.'):
-        v.to_python(seq_f(0, 1, 2, 3), include=1)
+    with pytest.raises(TypeError, match=f'`{kind}` argument must be a set or dict.'):
+        v.to_python(seq_f(0, 1, 2, 3), include=include, exclude=exclude)
 
 
 def test_tuple_fallback():

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -179,6 +179,7 @@ def test_include_error(schema_func, include_value, error_msg):
         (ExplicitContains(), set(), ['c', 'f']),
         (ExplicitContains(), {5}, ['c']),
         ({2, 3}, ExplicitContains(), ['d']),
+        ([1, 2, 3], [2, 3], ['b']),
     ],
 )
 def test_filter_runtime_more(include, exclude, expected):

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -158,8 +158,8 @@ def test_include_error(schema_func, include_value, error_msg):
 )
 def test_include_error_call_time(schema_func, seq_f):
     v = SchemaSerializer(schema_func(core_schema.any_schema()))
-    with pytest.raises(TypeError, match='`include` argument must a set or dict.'):
-        v.to_python(seq_f(0, 1, 2, 3), include=[1, 3, 5])
+    with pytest.raises(TypeError, match='`include` argument must be a set or dict.'):
+        v.to_python(seq_f(0, 1, 2, 3), include=1)
 
 
 def test_tuple_fallback():


### PR DESCRIPTION
In pydantic v1, we allow `AbstractSet`s to be used as the argument for `include` or `exclude`. (See `tests.test_edge_cases.test_include_exclude_defaults`.)

This change makes those tests pass.

However, note that in v1, you _had_ to be an `AbstractSet` subclass, not just implement `__contains__`. With this change, anything that implements `__contains__` will work, including `list`. My thought is that we can implement this here but still keep the type annotation in python as `set | dict | None` (or whatever it is, and possibly adding `AbstractSet` if appropriate) to discourage the use of things that don't implement `__contains__` in a performant way.

I added an empty check for `.is_none()` at the top of each pass to make it more performant in the normal case of getting `None`. Maybe I'm misunderstanding how pyo3 works; we can go back to the way it was if that's preferable, it just looked to me like the original approach would result in the `py_key.to_object(include.py())` getting called on the "happy path" of having `include is None` (and similar for `exclude`), which seemed like it could cause a performance regression.

It seems to me the only thing that is slower with this change would be the case where you are going to raise the TypeError, which I don't think should be performance sensitive anyway.

(I am also 100% happy to close this PR if the behavior isn't desired, or there is a plan to rework include/exclude, especially if there's something better we could do for checking if the object is a subclass of AbstractSet or similar. This approach seemed like it would be simpler and faster than checking against AbstractSet, which is why I thought it might be worthwhile.)

NOTE: There is also a fix to a typo in the error messages in this PR that should probably be merged even if we drop the other changes.