### PR TITLE
Implement garbage collection to prevent memory leaks

### DIFF
--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -1,7 +1,9 @@
 use std::fmt::Debug;
 
+use pyo3::gc::PyVisit;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
+use pyo3::PyTraverseError;
 
 use crate::build_context::BuildContext;
 use crate::validators::SelfValidator;
@@ -135,6 +137,21 @@ impl SchemaSerializer {
             "SchemaSerializer(serializer={:#?}, slots={:#?})",
             self.serializer, self.slots
         )
+    }
+
+    #[allow(clippy::single_match)] // presumably this will eventually be a bigger match..
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match &self.serializer {
+            CombinedSerializer::Model(x) => {
+                visit.call(&x.class)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        self.slots.clear()
     }
 }
 

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -150,9 +150,7 @@ impl SchemaSerializer {
         Ok(())
     }
 
-    fn __clear__(&mut self) {
-        self.slots.clear()
-    }
+    fn __clear__(&mut self) {}
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -17,7 +17,7 @@ use super::{
 
 #[derive(Debug, Clone)]
 pub struct ModelSerializer {
-    class: Py<PyType>,
+    pub class: Py<PyType>,
     serializer: Box<CombinedSerializer>,
     name: String,
 }

--- a/tests/test_garbage_collection.py
+++ b/tests/test_garbage_collection.py
@@ -1,0 +1,31 @@
+import gc
+from typing import Any
+from weakref import WeakValueDictionary
+
+from pydantic_core import SchemaSerializer, core_schema
+
+
+def test_gc_schema_serializer() -> None:
+    # test for https://github.com/pydantic/pydantic/issues/5136
+    class BaseModel:
+        __schema__: SchemaSerializer
+
+        def __init_subclass__(cls) -> None:
+            cls.__schema__ = SchemaSerializer(core_schema.model_schema(cls, core_schema.typed_dict_schema({})))
+
+    cache: 'WeakValueDictionary[int, Any]' = WeakValueDictionary()
+
+    for _ in range(10_000):
+
+        class MyModel(BaseModel):
+            pass
+
+        cache[id(MyModel)] = MyModel
+
+        del MyModel
+
+    gc.collect(0)
+    gc.collect(1)
+    gc.collect(2)
+
+    assert len(cache) == 0


### PR DESCRIPTION
Opening this as a draft. This works to resolve the specific issue described in https://github.com/pydantic/pydantic/issues/5136, but probably we'll take a completely different approach before merging that will be cleaner.

Copying some messages out of slack:
> you might be able to add traverse to Validator trait, with default doing nothing
> then implement it for Model
> they way you can just call self.serializer.traverse
> I mean Validator and Serializer

> you mean TypeSerializer?

> probably
> the thing  which enum_dispatch requires all members to implement
> on both serializer and validator



