### PR TITLE
Short circuit non-tagged unions

### DIFF
--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -64,9 +64,16 @@ fn validate_iter_to_vec<'a, 's>(
         match validator.validate(py, item, extra, slots, recursion_guard) {
             Ok(item) => output.push(item),
             Err(ValError::LineErrors(line_errors)) => {
+                if !extra.exhaustive {
+                    return Err(ValError::Omit);
+                }
                 errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index.into())));
             }
-            Err(ValError::Omit) => (),
+            Err(ValError::Omit) => {
+                if !extra.exhaustive {
+                    return Err(ValError::Omit);
+                }
+            }
             Err(err) => return Err(err),
         }
     }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -239,6 +239,7 @@ impl InternalValidator {
             field: self.field.as_deref(),
             strict: self.strict,
             context: self.context.as_ref().map(|data| data.as_ref(py)),
+            exhaustive: true,
         };
         self.validator
             .validate(py, input, &extra, &self.slots, &mut self.recursion_guard)

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -196,6 +196,7 @@ impl SchemaValidator {
             field: Some(field.as_str()),
             strict,
             context,
+            exhaustive: true,
         };
         let r = self
             .validator
@@ -450,6 +451,8 @@ pub struct Extra<'a> {
     pub strict: Option<bool>,
     /// context used in validator functions
     pub context: Option<&'a PyAny>,
+    // if we should do exhaustive validation
+    pub exhaustive: bool,
 }
 
 impl<'a> Extra<'a> {
@@ -457,6 +460,7 @@ impl<'a> Extra<'a> {
         Extra {
             strict,
             context,
+            exhaustive: true,
             ..Default::default()
         }
     }
@@ -469,6 +473,16 @@ impl<'a> Extra<'a> {
             field: self.field,
             strict: Some(true),
             context: self.context,
+            exhaustive: self.exhaustive,
+        }
+    }
+    pub fn with_exhaustiveness(&self, exhaustive: bool) -> Self {
+        Self {
+            data: self.data,
+            field: self.field,
+            strict: Some(true),
+            context: self.context,
+            exhaustive,
         }
     }
 }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -188,6 +188,7 @@ impl Validator for TypedDictValidator {
             field: None,
             strict: extra.strict,
             context: extra.context,
+            exhaustive: true,
         };
 
         macro_rules! process {

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -837,6 +837,20 @@ class TestBenchmarkUnion:
 
         benchmark(v.validate_python, 1)
 
+    @pytest.mark.benchmark(group='smart-union')
+    def test_smart_union_deep(self, benchmark):
+        v = SchemaValidator(
+            {
+                'type': 'union',
+                'choices': [
+                    {'type': 'list', 'items_schema': {'type': 'str'}},
+                    {'type': 'list', 'items_schema': {'type': 'int'}},
+                ],
+            }
+        )
+        data = [1] * 1_000
+        benchmark(v.validate_python, data)
+
     @skip_pydantic
     @pytest.mark.benchmark(group='smart-union')
     def test_smart_union_pyd(self, benchmark):


### PR DESCRIPTION
The idea here is to do a first pass where we do not do exhaustive validation and instead try to optimistically find a match. Then if we don't find one we go back and do exhaustive validation so that we can build up the errors and such. In the example benchmark (which I know is a list but I think is representative of more complex objects) this is a 2x speedup (and it would be a 100x speedup if there were 100 options in the union).

The penalty of this is the same as doing the strict mode pass first (although I understand there's non-performance reasons to do that): we have to re-validate in an exhaustive match later. I think it would be interesting to explore some sort of "state cache" in the future that can be used for this as well as the strict mode first pass so that a validator can "pick up where it left off". I think the easiest way to do this would be to convert:

```rust
fn validate(...) -> ValResult<...>
```

Into something like:

```rust
fn validate(..., state: Option<ValStateToken>) -> (Option<ValStateToken>, ValResult<...>)
```

And then each Validator can come up with it's own state to store if it makes sense for it. I think the only ones that would make sense are lists and typed-dict where it'd be trivial to store "the last field/index that passed validation" or something like that.