### PR TITLE
Update repr of SchemaValidator

### DIFF
--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -205,7 +205,7 @@ impl SchemaValidator {
 
     pub fn __repr__(&self, py: Python) -> String {
         format!(
-            "SchemaValidator(name={:?}, validator={:#?}, slots={:#?})",
+            "SchemaValidator(title={:?}, validator={:#?}, slots={:#?})",
             self.title.extract::<&str>(py).unwrap(),
             self.validator,
             self.slots,

--- a/tests/validators/test_bool.py
+++ b/tests/validators/test_bool.py
@@ -76,9 +76,9 @@ def test_bool_error():
 
 def test_bool_repr():
     v = SchemaValidator({'type': 'bool'})
-    assert plain_repr(v) == 'SchemaValidator(name="bool",validator=Bool(BoolValidator{strict:false}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="bool",validator=Bool(BoolValidator{strict:false}),slots=[])'
     v = SchemaValidator({'type': 'bool', 'strict': True})
-    assert plain_repr(v) == 'SchemaValidator(name="bool",validator=Bool(BoolValidator{strict:true}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="bool",validator=Bool(BoolValidator{strict:true}),slots=[])'
 
 
 def test_bool_key(py_and_json: PyAndJson):

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -15,7 +15,7 @@ def test_list_with_def():
     assert v.validate_python([1, 2, '3']) == [1, 2, 3]
     assert v.validate_json(b'[1, 2, "3"]') == [1, 2, 3]
     r = plain_repr(v)
-    assert r.startswith('SchemaValidator(name="list[int]",')
+    assert r.startswith('SchemaValidator(title="list[int]",')
     # definitions aren't used in slots
     assert r.endswith('slots=[])')
 
@@ -28,7 +28,7 @@ def test_ignored_def():
     )
     assert v.validate_python([1, 2, '3']) == [1, 2, 3]
     r = plain_repr(v)
-    assert r.startswith('SchemaValidator(name="list[int]",')
+    assert r.startswith('SchemaValidator(title="list[int]",')
     # definitions aren't used in slots
     assert r.endswith('slots=[])')
 

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -29,7 +29,9 @@ def test_branch_nullable():
     assert 'return_fields_set:false' in plain_repr(v)
 
     assert v.validate_python({'name': 'root'}) == {'name': 'root', 'sub_branch': None}
-    assert plain_repr(v).startswith('SchemaValidator(name="typed-dict",validator=DefinitionRef(DefinitionRefValidator{')
+    assert plain_repr(v).startswith(
+        'SchemaValidator(title="typed-dict",validator=DefinitionRef(DefinitionRefValidator{'
+    )
     assert ',slots=[TypedDict(TypedDictValidator{' in plain_repr(v)
 
     assert v.validate_python({'name': 'root', 'sub_branch': {'name': 'b1'}}) == (
@@ -85,7 +87,7 @@ def test_unused_ref():
             'fields': {'name': {'schema': {'type': 'str'}}, 'other': {'schema': {'type': 'int'}}},
         }
     )
-    assert plain_repr(v).startswith('SchemaValidator(name="typed-dict",validator=TypedDict(TypedDictValidator')
+    assert plain_repr(v).startswith('SchemaValidator(title="typed-dict",validator=TypedDict(TypedDictValidator')
     assert v.validate_python({'name': 'root', 'other': '4'}) == {'name': 'root', 'other': 4}
     assert ',slots=[]' in plain_repr(v)
 

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -172,15 +172,15 @@ def test_float_repr():
     v = SchemaValidator({'type': 'float'})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(name="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),slots=[])'
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),slots=[])'
     )
     v = SchemaValidator({'type': 'float', 'strict': True})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(name="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),slots=[])'
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),slots=[])'
     )
     v = SchemaValidator({'type': 'float', 'multiple_of': 7})
-    assert plain_repr(v).startswith('SchemaValidator(name="constrained-float",validator=ConstrainedFloat(')
+    assert plain_repr(v).startswith('SchemaValidator(title="constrained-float",validator=ConstrainedFloat(')
 
 
 @pytest.mark.parametrize('input_value,expected', [(Decimal('1.23'), 1.23), (Decimal('1'), 1.0)])

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -259,7 +259,7 @@ def test_repr():
     v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_length': 42})
     assert plain_repr(v) == (
         'SchemaValidator('
-        'name="frozenset[any]",'
+        'title="frozenset[any]",'
         'validator=FrozenSet(FrozenSetValidator{'
         'strict:true,item_validator:None,min_length:Some(42),max_length:None,generator_max_length:None,'
         'name:"frozenset[any]"'

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -199,11 +199,11 @@ def test_union_int_simple(py_and_json: PyAndJson):
 
 def test_int_repr():
     v = SchemaValidator({'type': 'int'})
-    assert plain_repr(v) == 'SchemaValidator(name="int",validator=Int(IntValidator{strict:false}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="int",validator=Int(IntValidator{strict:false}),slots=[])'
     v = SchemaValidator({'type': 'int', 'strict': True})
-    assert plain_repr(v) == 'SchemaValidator(name="int",validator=Int(IntValidator{strict:true}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="int",validator=Int(IntValidator{strict:true}),slots=[])'
     v = SchemaValidator({'type': 'int', 'multiple_of': 7})
-    assert plain_repr(v).startswith('SchemaValidator(name="constrained-int",validator=ConstrainedInt(')
+    assert plain_repr(v).startswith('SchemaValidator(title="constrained-int",validator=ConstrainedInt(')
 
 
 def test_long_int(py_and_json: PyAndJson):

--- a/tests/validators/test_literal.py
+++ b/tests/validators/test_literal.py
@@ -168,7 +168,7 @@ def test_literal_none():
     assert v.isinstance_python(0) is False
     assert v.isinstance_json('null') is True
     assert v.isinstance_json('""') is False
-    assert plain_repr(v) == 'SchemaValidator(name="none",validator=None(NoneValidator),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="none",validator=None(NoneValidator),slots=[])'
 
 
 def test_union():

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -26,7 +26,7 @@ def test_model_class():
         }
     )
     assert 'expect_fields_set:true' in plain_repr(v)
-    assert repr(v).startswith('SchemaValidator(name="MyModel", validator=Model(\n')
+    assert repr(v).startswith('SchemaValidator(title="MyModel", validator=Model(\n')
     m = v.validate_python({'field_a': 'test', 'field_b': 12})
     assert isinstance(m, MyModel)
     assert m.field_a == 'test'

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -185,7 +185,7 @@ def test_regex_error():
 
 def test_default_validator():
     v = SchemaValidator(core_schema.str_schema(strict=True, to_lower=False), {'str_strip_whitespace': False})
-    assert plain_repr(v) == 'SchemaValidator(name="str",validator=Str(StrValidator{strict:true}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="str",validator=Str(StrValidator{strict:true}),slots=[])'
 
 
 @pytest.fixture(scope='session', name='FruitEnum')

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -619,7 +619,8 @@ def test_aliases_debug():
             'fields': {'field_a': {'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3]], 'schema': {'type': 'int'}}},
         }
     )
-    assert repr(v).startswith('SchemaValidator(name="typed-dict", validator=TypedDict(')
+    print(repr(v))
+    assert repr(v).startswith('SchemaValidator(title="typed-dict", validator=TypedDict(')
     assert 'PathChoices(' in repr(v)
 
 

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -242,7 +242,7 @@ def test_empty_choices():
 
 def test_one_choice():
     v = SchemaValidator({'type': 'union', 'choices': [{'type': 'str'}]})
-    assert plain_repr(v) == 'SchemaValidator(name="str",validator=Str(StrValidator{strict:false}),slots=[])'
+    assert plain_repr(v) == 'SchemaValidator(title="str",validator=Str(StrValidator{strict:false}),slots=[])'
     assert v.validate_python('hello') == 'hello'
 
 


### PR DESCRIPTION
Was bothering me that the repr of SchemaValidator shows `name=...` when it comes from a field on the `SchemaValidator` struct called `title`. I did some git blame spelunking and found that it was originally grabbed from some python method with the word `name` in it; that seemed to be replaced fairly quickly after it was introduced but the `name=` remained.

I don't see any reason not to change this, but @samuelcolvin maybe there's a reason? It did briefly confused me when I first was trying to figure out how the name was getting set, which is why I wanted to change it.