### PR TITLE
Add `type` to `TypedDictField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,20 @@ v = SchemaValidator({
     'type': 'typed-dict',
     'fields': {
         'name': {
+            'type': 'typed-dict-field',
             'schema': {
                 'type': 'str',
             },
         },
         'age': {
+            'type': 'typed-dict-field',
             'schema': {
                 'type': 'int',
                 'ge': 18,
             },
         },
         'is_developer': {
+            'type': 'typed-dict-field',
             'schema': {
                 'type': 'default',
                 'schema': {'type': 'bool'},

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -322,16 +322,16 @@ fn typed_dict_json(bench: &mut Bencher) {
           'type': 'typed-dict',
           'extra_behavior': 'ignore',
           'fields': {
-            'a': {'schema': {'type': 'int'}},
-            'b': {'schema': {'type': 'int'}},
-            'c': {'schema': {'type': 'int'}},
-            'd': {'schema': {'type': 'int'}},
-            'e': {'schema': {'type': 'int'}},
-            'f': {'schema': {'type': 'int'}},
-            'g': {'schema': {'type': 'int'}},
-            'h': {'schema': {'type': 'int'}},
-            'i': {'schema': {'type': 'int'}},
-            'j': {'schema': {'type': 'int'}},
+            'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'c': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'd': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'e': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'f': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'g': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'h': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'i': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'j': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
           },
         }"#,
         );
@@ -351,16 +351,16 @@ fn typed_dict_python(bench: &mut Bencher) {
           'type': 'typed-dict',
           'extra_behavior': 'ignore',
           'fields': {
-            'a': {'schema': {'type': 'int'}},
-            'b': {'schema': {'type': 'int'}},
-            'c': {'schema': {'type': 'int'}},
-            'd': {'schema': {'type': 'int'}},
-            'e': {'schema': {'type': 'int'}},
-            'f': {'schema': {'type': 'int'}},
-            'g': {'schema': {'type': 'int'}},
-            'h': {'schema': {'type': 'int'}},
-            'i': {'schema': {'type': 'int'}},
-            'j': {'schema': {'type': 'int'}},
+            'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'c': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'd': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'e': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'f': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'g': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'h': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'i': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            'j': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
           },
         }"#,
         );
@@ -383,16 +383,18 @@ fn typed_dict_deep_error(bench: &mut Bencher) {
             r#"{
             'type': 'typed-dict',
             'fields': {
-                'field_a': {'schema': {'type': 'str'}},
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'field_b': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'typed-dict',
                         'fields': {
-                            'field_c': {'schema': {'type': 'str'}},
+                            'field_c': {'type': 'typed-dict-field','schema': {'type': 'str'}},
                             'field_d': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'typed-dict',
-                                    'fields': {'field_e': {'schema': {'type': 'str'}}, 'field_f': {'schema': {'type': 'int'}}},
+                                    'fields': {'field_e': {'type': 'typed-dict-field','schema': {'type': 'str'}}, 'field_f': {'type': 'typed-dict-field','schema': {'type': 'int'}}},
                                 }
                             },
                         },

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2365,6 +2365,7 @@ def lax_or_strict_schema(
 
 
 class TypedDictField(TypedDict, total=False):
+    type: Required[Literal['typed-dict-field']]
     schema: Required[CoreSchema]
     required: bool
     validation_alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
@@ -2401,6 +2402,7 @@ def typed_dict_field(
         frozen: Whether the field is frozen
     """
     return dict_not_none(
+        type='typed-dict-field',
         schema=schema,
         required=required,
         validation_alias=validation_alias,
@@ -3183,6 +3185,7 @@ CoreSchema = Union[
     MultiHostUrlSchema,
     DefinitionsSchema,
     DefinitionReferenceSchema,
+    TypedDictField,
 ]
 
 # to update this, call `pytest -k test_core_schema_type_literal` and copy the output
@@ -3231,6 +3234,7 @@ CoreSchemaType = Literal[
     'multi-host-url',
     'definitions',
     'definition-ref',
+    'typed-dict-field',
 ]
 
 

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2556,6 +2556,7 @@ def model_schema(
 
 
 class DataclassField(TypedDict, total=False):
+    type: Required[Literal['dataclass-field']]
     name: Required[str]
     schema: Required[CoreSchema]
     kw_only: bool  # default: True
@@ -2596,6 +2597,7 @@ def dataclass_field(
         serialization_exclude: Whether to exclude the field when serializing
     """
     return dict_not_none(
+        type='dataclass-field',
         name=name,
         schema=schema,
         kw_only=kw_only,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -3185,7 +3185,6 @@ CoreSchema = Union[
     MultiHostUrlSchema,
     DefinitionsSchema,
     DefinitionReferenceSchema,
-    TypedDictField,
 ]
 
 # to update this, call `pytest -k test_core_schema_type_literal` and copy the output
@@ -3234,7 +3233,6 @@ CoreSchemaType = Literal[
     'multi-host-url',
     'definitions',
     'definition-ref',
-    'typed-dict-field',
 ]
 
 

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -17,72 +17,123 @@ def schema(*, strict: bool = False) -> dict:
             'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
-                'field_str': {'schema': {'type': 'str'}},
-                'field_str_con': {'schema': {'type': 'str', 'min_length': 3, 'max_length': 5, 'pattern': '^[a-z]+$'}},
-                'field_int': {'schema': {'type': 'int'}},
-                'field_int_con': {'schema': {'type': 'int', 'gt': 1, 'lt': 10, 'multiple_of': 2}},
-                'field_float': {'schema': {'type': 'float'}},
-                'field_float_con': {'schema': {'type': 'float', 'ge': 1.0, 'le': 10.0, 'multiple_of': 0.5}},
-                'field_bool': {'schema': {'type': 'bool'}},
-                'field_bytes': {'schema': {'type': 'bytes'}},
-                'field_bytes_con': {'schema': {'type': 'bytes', 'min_length': 6, 'max_length': 1000}},
-                'field_date': {'schema': {'type': 'date'}},
-                'field_date_con': {'schema': {'type': 'date', 'ge': '2020-01-01', 'lt': '2020-01-02'}},
-                'field_time': {'schema': {'type': 'time'}},
-                'field_time_con': {'schema': {'type': 'time', 'ge': '06:00:00', 'lt': '12:13:14'}},
-                'field_datetime': {'schema': {'type': 'datetime'}},
+                'field_str': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_str_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'str', 'min_length': 3, 'max_length': 5, 'pattern': '^[a-z]+$'},
+                },
+                'field_int': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'field_int_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int', 'gt': 1, 'lt': 10, 'multiple_of': 2},
+                },
+                'field_float': {'type': 'typed-dict-field', 'schema': {'type': 'float'}},
+                'field_float_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'float', 'ge': 1.0, 'le': 10.0, 'multiple_of': 0.5},
+                },
+                'field_bool': {'type': 'typed-dict-field', 'schema': {'type': 'bool'}},
+                'field_bytes': {'type': 'typed-dict-field', 'schema': {'type': 'bytes'}},
+                'field_bytes_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'bytes', 'min_length': 6, 'max_length': 1000},
+                },
+                'field_date': {'type': 'typed-dict-field', 'schema': {'type': 'date'}},
+                'field_date_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'date', 'ge': '2020-01-01', 'lt': '2020-01-02'},
+                },
+                'field_time': {'type': 'typed-dict-field', 'schema': {'type': 'time'}},
+                'field_time_con': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'time', 'ge': '06:00:00', 'lt': '12:13:14'},
+                },
+                'field_datetime': {'type': 'typed-dict-field', 'schema': {'type': 'datetime'}},
                 'field_datetime_con': {
-                    'schema': {'type': 'datetime', 'ge': '2000-01-01T06:00:00', 'lt': '2020-01-02T12:13:14'}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'datetime', 'ge': '2000-01-01T06:00:00', 'lt': '2020-01-02T12:13:14'},
                 },
-                'field_list_any': {'schema': {'type': 'list'}},
-                'field_list_str': {'schema': {'type': 'list', 'items_schema': {'type': 'str'}}},
+                'field_list_any': {'type': 'typed-dict-field', 'schema': {'type': 'list'}},
+                'field_list_str': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}},
+                },
                 'field_list_str_con': {
-                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}, 'min_length': 3, 'max_length': 42}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}, 'min_length': 3, 'max_length': 42},
                 },
-                'field_set_any': {'schema': {'type': 'set'}},
-                'field_set_int': {'schema': {'type': 'set', 'items_schema': {'type': 'int'}}},
+                'field_set_any': {'type': 'typed-dict-field', 'schema': {'type': 'set'}},
+                'field_set_int': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}},
+                },
                 'field_set_int_con': {
-                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}, 'min_length': 3, 'max_length': 42}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}, 'min_length': 3, 'max_length': 42},
                 },
-                'field_frozenset_any': {'schema': {'type': 'frozenset'}},
-                'field_frozenset_bytes': {'schema': {'type': 'frozenset', 'items_schema': {'type': 'bytes'}}},
+                'field_frozenset_any': {'type': 'typed-dict-field', 'schema': {'type': 'frozenset'}},
+                'field_frozenset_bytes': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'frozenset', 'items_schema': {'type': 'bytes'}},
+                },
                 'field_frozenset_bytes_con': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'frozenset',
                         'items_schema': {'type': 'bytes'},
                         'min_length': 3,
                         'max_length': 42,
-                    }
+                    },
                 },
-                'field_tuple_var_len_any': {'schema': {'type': 'tuple-variable'}},
-                'field_tuple_var_len_float': {'schema': {'type': 'tuple-variable', 'items_schema': {'type': 'float'}}},
+                'field_tuple_var_len_any': {'type': 'typed-dict-field', 'schema': {'type': 'tuple-variable'}},
+                'field_tuple_var_len_float': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'tuple-variable', 'items_schema': {'type': 'float'}},
+                },
                 'field_tuple_var_len_float_con': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'tuple-variable',
                         'items_schema': {'type': 'float'},
                         'min_length': 3,
                         'max_length': 42,
-                    }
+                    },
                 },
                 'field_tuple_fix_len': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'tuple-positional',
                         'items_schema': [{'type': 'str'}, {'type': 'int'}, {'type': 'float'}, {'type': 'bool'}],
-                    }
+                    },
                 },
-                'field_dict_any': {'schema': {'type': 'dict'}},
+                'field_dict_any': {'type': 'typed-dict-field', 'schema': {'type': 'dict'}},
                 'field_dict_str_float': {
-                    'schema': {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'float'}}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'float'}},
                 },
-                'field_literal_1_int': {'schema': {'type': 'literal', 'expected': [1]}},
-                'field_literal_1_str': {'schema': {'type': 'literal', 'expected': ['foobar']}},
-                'field_literal_mult_int': {'schema': {'type': 'literal', 'expected': [1, 2, 3]}},
-                'field_literal_mult_str': {'schema': {'type': 'literal', 'expected': ['foo', 'bar', 'baz']}},
-                'field_literal_assorted': {'schema': {'type': 'literal', 'expected': [1, 'foo', True]}},
+                'field_literal_1_int': {'type': 'typed-dict-field', 'schema': {'type': 'literal', 'expected': [1]}},
+                'field_literal_1_str': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'literal', 'expected': ['foobar']},
+                },
+                'field_literal_mult_int': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'literal', 'expected': [1, 2, 3]},
+                },
+                'field_literal_mult_str': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'literal', 'expected': ['foo', 'bar', 'baz']},
+                },
+                'field_literal_assorted': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'literal', 'expected': [1, 'foo', True]},
+                },
                 'field_list_nullable_int': {
-                    'schema': {'type': 'list', 'items_schema': {'type': 'nullable', 'schema': {'type': 'int'}}}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'list', 'items_schema': {'type': 'nullable', 'schema': {'type': 'int'}}},
                 },
                 'field_union': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'union',
                         'choices': [
@@ -90,63 +141,70 @@ def schema(*, strict: bool = False) -> dict:
                             {
                                 'type': 'typed-dict',
                                 'fields': {
-                                    'field_str': {'schema': {'type': 'str'}},
-                                    'field_int': {'schema': {'type': 'int'}},
-                                    'field_float': {'schema': {'type': 'float'}},
+                                    'field_str': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                                    'field_int': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                    'field_float': {'type': 'typed-dict-field', 'schema': {'type': 'float'}},
                                 },
                             },
                             {
                                 'type': 'typed-dict',
                                 'fields': {
-                                    'field_float': {'schema': {'type': 'float'}},
-                                    'field_bytes': {'schema': {'type': 'bytes'}},
-                                    'field_date': {'schema': {'type': 'date'}},
+                                    'field_float': {'type': 'typed-dict-field', 'schema': {'type': 'float'}},
+                                    'field_bytes': {'type': 'typed-dict-field', 'schema': {'type': 'bytes'}},
+                                    'field_date': {'type': 'typed-dict-field', 'schema': {'type': 'date'}},
                                 },
                             },
                         ],
-                    }
+                    },
                 },
                 'field_functions_model': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'typed-dict',
                         'fields': {
                             'field_before': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-before',
                                     'function': {'type': 'general', 'function': append_func},
                                     'schema': {'type': 'str'},
-                                }
+                                },
                             },
                             'field_after': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-after',
                                     'function': {'type': 'general', 'function': append_func},
                                     'schema': {'type': 'str'},
-                                }
+                                },
                             },
                             'field_wrap': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-wrap',
                                     'function': {'type': 'general', 'function': wrap_function},
                                     'schema': {'type': 'str'},
-                                }
+                                },
                             },
                             'field_plain': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-plain',
                                     'function': {'type': 'general', 'function': append_func},
-                                }
+                                },
                             },
                         },
-                    }
+                    },
                 },
                 'field_recursive': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'ref': 'Branch',
                         'type': 'typed-dict',
                         'fields': {
-                            'name': {'schema': {'type': 'str'}},
+                            'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                             'sub_branch': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'default',
                                     'schema': {
@@ -154,10 +212,10 @@ def schema(*, strict: bool = False) -> dict:
                                         'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'},
                                     },
                                     'default': None,
-                                }
+                                },
                             },
                         },
-                    }
+                    },
                 },
             },
         },

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -53,15 +53,19 @@ class TestBenchmarkSimpleModel:
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
-                        'name': {'schema': {'type': 'str'}},
-                        'age': {'schema': {'type': 'int'}},
-                        'friends': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        'friends': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                         'settings': {
+                            'type': 'typed-dict-field',
                             'schema': {
                                 'type': 'dict',
                                 'keys_schema': {'type': 'str'},
                                 'values_schema': {'type': 'float'},
-                            }
+                            },
                         },
                     },
                 },
@@ -80,15 +84,19 @@ class TestBenchmarkSimpleModel:
                 'schema': {
                     'type': 'typed-dict',
                     'fields': {
-                        'name': {'schema': {'type': 'str'}},
-                        'age': {'schema': {'type': 'int'}},
-                        'friends': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        'friends': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                         'settings': {
+                            'type': 'typed-dict-field',
                             'schema': {
                                 'type': 'dict',
                                 'keys_schema': {'type': 'str'},
                                 'values_schema': {'type': 'float'},
-                            }
+                            },
                         },
                     },
                 },
@@ -154,7 +162,9 @@ class TestModelLarge:
                     'return_fields_set': True,
                     'extra_behavior': 'allow',
                     'total': False,
-                    'fields': {f'field_{i}': {'schema': {'type': 'int'}} for i in range(100)},
+                    'fields': {
+                        f'field_{i}': {'type': 'typed-dict-field', 'schema': {'type': 'int'}} for i in range(100)
+                    },
                 },
             }
         )
@@ -224,7 +234,10 @@ def test_small_class_pyd(benchmark):
 def test_small_class_core_dict(benchmark):
     model_schema = {
         'type': 'typed-dict',
-        'fields': {'name': {'schema': {'type': 'str'}}, 'age': {'schema': {'type': 'int'}}},
+        'fields': {
+            'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+            'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+        },
     }
     dict_schema_validator = SchemaValidator(model_schema)
     benchmark(dict_schema_validator.validate_python, small_class_data)
@@ -246,7 +259,10 @@ def test_small_class_core_model(benchmark):
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'name': {'schema': {'type': 'str'}}, 'age': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -379,8 +395,9 @@ def test_definition_model_core(definition_model_data, benchmark):
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {
-                    'width': {'schema': {'type': 'int'}},
+                    'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                     'branch': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'schema': {
@@ -388,7 +405,7 @@ def test_definition_model_core(definition_model_data, benchmark):
                                 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'},
                             },
                             'default': None,
-                        }
+                        },
                     },
                 },
             },
@@ -413,7 +430,13 @@ def test_list_of_dict_models_pyd(benchmark):
 @pytest.mark.benchmark(group='List[TypedDict]')
 def test_list_of_dict_models_core(benchmark):
     v = SchemaValidator(
-        {'type': 'list', 'items_schema': {'type': 'typed-dict', 'fields': {'width': {'schema': {'type': 'int'}}}}}
+        {
+            'type': 'list',
+            'items_schema': {
+                'type': 'typed-dict',
+                'fields': {'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+            },
+        }
     )
 
     data = [{'width': i} for i in range(100)]
@@ -643,7 +666,10 @@ def test_many_models_pyd(benchmark):
 def test_many_models_core_dict(benchmark):
     model_schema = {
         'type': 'list',
-        'items_schema': {'type': 'typed-dict', 'fields': {'age': {'schema': {'type': 'int'}}}},
+        'items_schema': {
+            'type': 'typed-dict',
+            'fields': {'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+        },
     }
     v = SchemaValidator(model_schema)
     benchmark(v.validate_python, many_models_data)
@@ -663,7 +689,7 @@ def test_many_models_core_model(benchmark):
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'age': {'schema': {'type': 'int'}}},
+                    'fields': {'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
                 },
             },
         }
@@ -729,7 +755,7 @@ class TestBenchmarkDateTime:
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'dt': {'schema': {'type': 'datetime'}}},
+                    'fields': {'dt': {'type': 'typed-dict-field', 'schema': {'type': 'datetime'}}},
                 },
             }
         )
@@ -1015,7 +1041,12 @@ def test_with_default(benchmark):
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'name': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'John'}}},
+            'fields': {
+                'name': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'John'},
+                }
+            },
         }
     )
     assert v.validate_python({'name': 'Foo'}) == {'name': 'Foo'}

--- a/tests/benchmarks/test_serialization_micro.py
+++ b/tests/benchmarks/test_serialization_micro.py
@@ -32,11 +32,15 @@ class TestBenchmarkSimpleModel:
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {
-                    'name': {'schema': {'type': 'str'}},
-                    'age': {'schema': {'type': 'int'}},
-                    'friends': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                    'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    'friends': {
+                        'type': 'typed-dict-field',
+                        'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                    },
                     'settings': {
-                        'schema': {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'float'}}
+                        'type': 'typed-dict-field',
+                        'schema': {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'float'}},
                     },
                 },
             },

--- a/tests/serializers/test_definitions_recursive.py
+++ b/tests/serializers/test_definitions_recursive.py
@@ -9,9 +9,10 @@ def test_branch_nullable():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'sub_branch': {
-                    'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}},
                 },
             },
         }
@@ -32,9 +33,10 @@ def test_cyclic_recursion():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'sub_branch': {
-                    'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}}
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}},
                 },
             },
         }
@@ -55,8 +57,9 @@ def test_custom_ser():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'sub_branch': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'nullable',
                         'schema': {
@@ -64,7 +67,7 @@ def test_custom_ser():
                             'schema_ref': 'Branch',
                             'serialization': {'type': 'to-string', 'when_used': 'always'},
                         },
-                    }
+                    },
                 },
             },
         }

--- a/tests/serializers/test_typed_dict.py
+++ b/tests/serializers/test_typed_dict.py
@@ -24,6 +24,12 @@ def test_typed_dict():
     assert v.to_json({'bar': b'more', 'foo': 1, 'c': 3}) == b'{"bar":"more","foo":1}'
 
 
+def test_typed_dict_fields_has_type():
+    typed_dict_field = core_schema.typed_dict_field(core_schema.bytes_schema())
+
+    assert typed_dict_field['type'] == 'typed-dict-field'
+
+
 def test_typed_dict_allow_extra():
     v = SchemaSerializer(
         core_schema.typed_dict_schema(

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -46,8 +46,9 @@ def model_serializer() -> SchemaSerializer:
                         'type': 'typed-dict',
                         'return_fields_set': True,
                         'fields': {
-                            'a': {'schema': {'type': 'bytes'}},
+                            'a': {'type': 'typed-dict-field', 'schema': {'type': 'bytes'}},
                             'b': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'float',
                                     'serialization': {
@@ -55,7 +56,7 @@ def model_serializer() -> SchemaSerializer:
                                         'formatting_string': '0.1f',
                                         'when_used': 'unless-none',
                                     },
-                                }
+                                },
                             },
                         },
                     },
@@ -67,8 +68,9 @@ def model_serializer() -> SchemaSerializer:
                         'type': 'typed-dict',
                         'return_fields_set': True,
                         'fields': {
-                            'c': {'schema': {'type': 'bytes'}},
+                            'c': {'type': 'typed-dict-field', 'schema': {'type': 'bytes'}},
                             'd': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'float',
                                     'serialization': {
@@ -76,7 +78,7 @@ def model_serializer() -> SchemaSerializer:
                                         'formatting_string': '0.2f',
                                         'when_used': 'unless-none',
                                     },
-                                }
+                                },
                             },
                         },
                     },

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -60,7 +60,10 @@ def test_schema_definition_error():
 def test_not_schema_definition_error():
     schema = {
         'type': 'typed-dict',
-        'fields': {f'f_{i}': {'schema': {'type': 'nullable', 'schema': {'type': 'int'}}} for i in range(101)},
+        'fields': {
+            f'f_{i}': {'type': 'typed-dict-field', 'schema': {'type': 'nullable', 'schema': {'type': 'int'}}}
+            for i in range(101)
+        },
     }
     v = SchemaValidator(schema)
     assert repr(v).count('TypedDictField') == 101

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,11 @@ def test_on_model_class():
             'type': 'model',
             'cls': MyModel,
             'config': {'str_max_length': 5},
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
         }
     )
     assert 'max_length:Some(5)' in plain_repr(v)
@@ -60,7 +64,7 @@ def test_field_priority_model():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'f': {'schema': {'type': 'str', 'max_length': 5}}},
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'max_length': 5}}},
             },
         }
     )
@@ -74,7 +78,11 @@ def test_parent_priority():
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
             'config': {'str_min_length': 2, 'str_max_length': 10},
         },
         {'str_max_length': 5, 'config_choose_priority': 1},
@@ -92,7 +100,11 @@ def test_child_priority():
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
             'config': {'str_max_length': 5, 'config_choose_priority': 1},
         },
         {'str_min_length': 2, 'str_max_length': 10},
@@ -110,7 +122,11 @@ def test_merge_child_wins():
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
             'config': {'str_max_length': 5},
         },
         {'str_min_length': 2, 'str_max_length': 10},
@@ -128,7 +144,11 @@ def test_merge_parent_wins():
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
             'config': {'str_max_length': 5},
         },
         {'str_min_length': 2, 'str_max_length': 10, 'config_merge_priority': 1},
@@ -152,18 +172,19 @@ def test_sub_model_merge():
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {
-                    'f': {'schema': {'type': 'str'}},
+                    'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                     'sub_model': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'model',
                             'cls': MyModel,
                             'schema': {
                                 'type': 'typed-dict',
                                 'return_fields_set': True,
-                                'fields': {'f': {'schema': {'type': 'str'}}},
+                                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                             },
                             'config': {'str_max_length': 6, 'str_to_upper': True},
-                        }
+                        },
                     },
                 },
             },
@@ -231,7 +252,10 @@ def test_allow_inf_nan(config: CoreConfig, float_field_schema, input_value, expe
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'fields': {'x': {'schema': float_field_schema}}},
+            'schema': {
+                'type': 'typed-dict',
+                'fields': {'x': {'type': 'typed-dict-field', 'schema': float_field_schema}},
+            },
             'config': config,
         }
     )

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -62,13 +62,14 @@ def definition_schema():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'sub_branch': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}},
                         'default': None,
-                    }
+                    },
                 },
             },
         }

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -53,7 +53,11 @@ def test_internal_error():
         {
             'type': 'model',
             'cls': int,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'int'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+            },
         }
     )
     with pytest.raises(AttributeError, match="'int' object has no attribute '__dict__'"):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -95,7 +95,10 @@ def test_model():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         }
     )
 
@@ -114,7 +117,9 @@ def test_error_loc():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'list', 'items_schema': {'type': 'int'}}}
+            },
             'extra_validator': {'type': 'int'},
             'extra_behavior': 'allow',
         }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -108,7 +108,10 @@ def test_validation_error_multiple():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'x': {'schema': {'type': 'float'}}, 'y': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'x': {'type': 'typed-dict-field', 'schema': {'type': 'float'}},
+                    'y': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -154,11 +154,15 @@ all_schema_functions = [
         args({'type': 'int'}, {'type': 'str'}),
         {'type': 'chain', 'steps': [{'type': 'int'}, {'type': 'str'}]},
     ),
-    (core_schema.typed_dict_field, args({'type': 'int'}, required=True), {'schema': {'type': 'int'}, 'required': True}),
+    (
+        core_schema.typed_dict_field,
+        args({'type': 'int'}, required=True),
+        {'type': 'typed-dict-field', 'schema': {'type': 'int'}, 'required': True},
+    ),
     (
         core_schema.typed_dict_schema,
         args({'foo': core_schema.typed_dict_field({'type': 'int'})}),
-        {'type': 'typed-dict', 'fields': {'foo': {'schema': {'type': 'int'}}}},
+        {'type': 'typed-dict', 'fields': {'foo': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}}},
     ),
     (
         core_schema.model_schema,
@@ -235,7 +239,7 @@ def test_schema_functions(function, args_kwargs, expected_schema):
     args, kwargs = args_kwargs
     schema = function(*args, **kwargs)
     assert schema == expected_schema
-    if schema.get('type') in {None, 'definition-ref'}:
+    if schema.get('type') in {None, 'definition-ref', 'typed-dict-field'}:
         return
 
     v = SchemaValidator(schema)

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -239,7 +239,7 @@ def test_schema_functions(function, args_kwargs, expected_schema):
     args, kwargs = args_kwargs
     schema = function(*args, **kwargs)
     assert schema == expected_schema
-    if schema.get('type') in {None, 'definition-ref', 'typed-dict-field'}:
+    if schema.get('type') in {None, 'definition-ref'}:
         return
 
     v = SchemaValidator(schema)

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -222,8 +222,12 @@ all_schema_functions = [
     (core_schema.definition_reference_schema, args('foo'), {'type': 'definition-ref', 'schema_ref': 'foo'}),
     (
         core_schema.dataclass_args_schema,
-        args('Foo', [{'name': 'foo', 'schema': {'type': 'int'}}]),
-        {'type': 'dataclass-args', 'dataclass_name': 'Foo', 'fields': [{'name': 'foo', 'schema': {'type': 'int'}}]},
+        args('Foo', [{'name': 'foo', 'type': 'dataclass-field', 'schema': {'type': 'int'}}]),
+        {
+            'type': 'dataclass-args',
+            'dataclass_name': 'Foo',
+            'fields': [{'name': 'foo', 'type': 'dataclass-field', 'schema': {'type': 'int'}}],
+        },
     ),
     (
         core_schema.dataclass_schema,

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -239,7 +239,7 @@ def test_schema_functions(function, args_kwargs, expected_schema):
     args, kwargs = args_kwargs
     schema = function(*args, **kwargs)
     assert schema == expected_schema
-    if schema.get('type') in {None, 'definition-ref'}:
+    if schema.get('type') in {None, 'definition-ref', 'typed-dict-field'}:
         return
 
     v = SchemaValidator(schema)
@@ -258,6 +258,9 @@ def test_all_schema_functions_used():
         for s in core_schema.CoreSchema.__args__
     }
     types_used = {args['type'] for _, _, args in all_schema_functions if 'type' in args}
+
+    # isn't a CoreSchema type
+    types_used.remove('typed-dict-field')
 
     assert all_types == types_used
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -42,8 +42,14 @@ def test_schema_typing() -> None:
         'type': 'tagged-union',
         'discriminator': 'type',
         'choices': {
-            'apple': {'type': 'typed-dict', 'fields': {'pips': {'schema': {'type': 'int'}}}},
-            'banana': {'type': 'typed-dict', 'fields': {'curvature': {'schema': {'type': 'float'}}}},
+            'apple': {
+                'type': 'typed-dict',
+                'fields': {'pips': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+            },
+            'banana': {
+                'type': 'typed-dict',
+                'fields': {'curvature': {'type': 'typed-dict-field', 'schema': {'type': 'float'}}},
+            },
         },
     }
     SchemaValidator(schema)
@@ -78,16 +84,27 @@ def test_schema_typing() -> None:
     schema: CoreSchema = {
         'type': 'model',
         'cls': Foo,
-        'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': {'type': 'str'}}}},
+        'schema': {
+            'type': 'typed-dict',
+            'return_fields_set': True,
+            'fields': {'bar': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+        },
     }
     SchemaValidator(schema)
     schema: CoreSchema = {
         'type': 'typed-dict',
         'fields': {
-            'a': {'schema': {'type': 'str'}},
-            'b': {'schema': {'type': 'str'}, 'validation_alias': 'foobar'},
-            'c': {'schema': {'type': 'str'}, 'validation_alias': [['foobar', 0, 'bar'], ['foo']]},
-            'd': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'spam'}},
+            'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+            'b': {'type': 'typed-dict-field', 'schema': {'type': 'str'}, 'validation_alias': 'foobar'},
+            'c': {
+                'type': 'typed-dict-field',
+                'schema': {'type': 'str'},
+                'validation_alias': [['foobar', 0, 'bar'], ['foo']],
+            },
+            'd': {
+                'type': 'typed-dict-field',
+                'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'spam'},
+            },
         },
     }
     SchemaValidator(schema)
@@ -103,8 +120,9 @@ def test_schema_typing() -> None:
         'ref': 'Branch',
         'type': 'typed-dict',
         'fields': {
-            'name': {'schema': {'type': 'str'}},
+            'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
             'sub_branch': {
+                'type': 'typed-dict-field',
                 'schema': {
                     'type': 'default',
                     'schema': {
@@ -112,7 +130,7 @@ def test_schema_typing() -> None:
                         'choices': [{'type': 'none'}, {'type': 'definition-ref', 'schema_ref': 'Branch'}],
                     },
                     'default': None,
-                }
+                },
             },
         },
     }

--- a/tests/test_validation_context.py
+++ b/tests/test_validation_context.py
@@ -44,8 +44,14 @@ def test_typed_dict(py_and_json: PyAndJson):
         {
             'type': 'typed-dict',
             'fields': {
-                'f1': {'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}}},
-                'f2': {'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}}},
+                'f1': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}},
+                },
+                'f2': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}},
+                },
             },
         }
     )
@@ -112,8 +118,14 @@ def test_validate_assignment_with_context():
         {
             'type': 'typed-dict',
             'fields': {
-                'f1': {'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}}},
-                'f2': {'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}}},
+                'f1': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}},
+                },
+                'f2': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}},
+                },
             },
         }
     )

--- a/tests/validators/test_chain.py
+++ b/tests/validators/test_chain.py
@@ -141,7 +141,7 @@ def test_ask():
                     {
                         'type': 'typed-dict',
                         'return_fields_set': True,
-                        'fields': {'field_a': {'schema': {'type': 'str'}}},
+                        'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                     },
                     {'type': 'function-plain', 'function': {'type': 'general', 'function': f}},
                 ],

--- a/tests/validators/test_custom_error.py
+++ b/tests/validators/test_custom_error.py
@@ -60,7 +60,10 @@ def test_ask():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         }

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -15,13 +15,14 @@ def test_branch_nullable():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'sub_branch': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}},
                         'default': None,
-                    }
+                    },
                 },
             },
         }
@@ -51,8 +52,9 @@ def test_branch_nullable_definitions():
                     'type': 'typed-dict',
                     'ref': 'Branch',
                     'fields': {
-                        'name': {'schema': {'type': 'str'}},
+                        'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                         'sub_branch': {
+                            'type': 'typed-dict-field',
                             'schema': {
                                 'type': 'default',
                                 'schema': {
@@ -60,7 +62,7 @@ def test_branch_nullable_definitions():
                                     'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'},
                                 },
                                 'default': None,
-                            }
+                            },
                         },
                     },
                 }
@@ -84,7 +86,10 @@ def test_unused_ref():
         {
             'type': 'typed-dict',
             'ref': 'Branch',
-            'fields': {'name': {'schema': {'type': 'str'}}, 'other': {'schema': {'type': 'int'}}},
+            'fields': {
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'other': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         }
     )
     assert plain_repr(v).startswith('SchemaValidator(title="typed-dict",validator=TypedDict(TypedDictValidator')
@@ -98,8 +103,9 @@ def test_nullable_error():
             'ref': 'Branch',
             'type': 'typed-dict',
             'fields': {
-                'width': {'schema': {'type': 'int'}},
+                'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                 'sub_branch': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {
@@ -107,7 +113,7 @@ def test_nullable_error():
                             'choices': [{'type': 'none'}, {'type': 'definition-ref', 'schema_ref': 'Branch'}],
                         },
                         'default': None,
-                    }
+                    },
                 },
             },
         }
@@ -139,8 +145,9 @@ def test_list():
             'type': 'typed-dict',
             'ref': 'BranchList',
             'fields': {
-                'width': {'schema': {'type': 'int'}},
+                'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                 'branches': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {
@@ -148,7 +155,7 @@ def test_list():
                             'items_schema': {'type': 'definition-ref', 'schema_ref': 'BranchList'},
                         },
                         'default': None,
-                    }
+                    },
                 },
             },
         }
@@ -180,14 +187,16 @@ def test_multiple_intertwined():
             'ref': 'Foo',
             'type': 'typed-dict',
             'fields': {
-                'height': {'schema': {'type': 'int'}},
+                'height': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                 'bar': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'ref': 'Bar',
                         'type': 'typed-dict',
                         'fields': {
-                            'width': {'schema': {'type': 'int'}},
+                            'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                             'bars': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'default',
                                     'schema': {
@@ -195,9 +204,10 @@ def test_multiple_intertwined():
                                         'items_schema': {'type': 'definition-ref', 'schema_ref': 'Bar'},
                                     },
                                     'default': None,
-                                }
+                                },
                             },
                             'foo': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'default',
                                     'schema': {
@@ -205,10 +215,10 @@ def test_multiple_intertwined():
                                         'choices': [{'type': 'none'}, {'type': 'definition-ref', 'schema_ref': 'Foo'}],
                                     },
                                     'default': None,
-                                }
+                                },
                             },
                         },
-                    }
+                    },
                 },
             },
         }
@@ -242,8 +252,9 @@ def test_model_class():
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {
-                    'width': {'schema': {'type': 'int'}},
+                    'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                     'branch': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'schema': {
@@ -251,7 +262,7 @@ def test_model_class():
                                 'choices': [{'type': 'none'}, {'type': 'definition-ref', 'schema_ref': 'Branch'}],
                             },
                             'default': None,
-                        }
+                        },
                     },
                 },
             },
@@ -281,8 +292,9 @@ def test_invalid_schema():
                 'items_schema': {
                     'type': 'typed-dict',
                     'fields': {
-                        'width': {'schema': {'type': 'int'}},
+                        'width': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                         'branch': {
+                            'type': 'typed-dict-field',
                             'schema': {
                                 'type': 'default',
                                 'schema': {
@@ -290,7 +302,7 @@ def test_invalid_schema():
                                     'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'},
                                 },
                                 'default': None,
-                            }
+                            },
                         },
                     },
                 },
@@ -304,13 +316,14 @@ def test_outside_parent():
             'type': 'typed-dict',
             'fields': {
                 'tuple1': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'tuple-positional',
                         'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'str'}],
                         'ref': 'tuple-iis',
-                    }
+                    },
                 },
-                'tuple2': {'schema': {'type': 'definition-ref', 'schema_ref': 'tuple-iis'}},
+                'tuple2': {'type': 'typed-dict-field', 'schema': {'type': 'definition-ref', 'schema_ref': 'tuple-iis'}},
             },
         }
     )
@@ -329,13 +342,14 @@ def test_recursion_branch():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'branch': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 'Branch'}},
                         'default': None,
-                    }
+                    },
                 },
             },
         },
@@ -411,6 +425,7 @@ def multiple_tuple_schema() -> SchemaValidator:
             'type': 'typed-dict',
             'fields': {
                 'f1': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'tuple-positional',
                         'items_schema': [
@@ -418,14 +433,15 @@ def multiple_tuple_schema() -> SchemaValidator:
                             {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 't'}},
                         ],
                         'ref': 't',
-                    }
+                    },
                 },
                 'f2': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {'type': 'nullable', 'schema': {'type': 'definition-ref', 'schema_ref': 't'}},
                         'default': None,
-                    }
+                    },
                 },
             },
         }
@@ -547,12 +563,13 @@ def test_union_ref_strictness():
     v = SchemaValidator(
         {
             'fields': {
-                'a': {'schema': {'type': 'int', 'ref': 'int-type'}},
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int', 'ref': 'int-type'}},
                 'b': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'union',
                         'choices': [{'type': 'definition-ref', 'schema_ref': 'int-type'}, {'type': 'str'}],
-                    }
+                    },
                 },
             },
             'type': 'typed-dict',
@@ -574,8 +591,11 @@ def test_union_container_strictness():
     v = SchemaValidator(
         {
             'fields': {
-                'b': {'schema': {'type': 'union', 'choices': [{'type': 'int', 'ref': 'int-type'}, {'type': 'str'}]}},
-                'a': {'schema': {'type': 'definition-ref', 'schema_ref': 'int-type'}},
+                'b': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'union', 'choices': [{'type': 'int', 'ref': 'int-type'}, {'type': 'str'}]},
+                },
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'definition-ref', 'schema_ref': 'int-type'}},
             },
             'type': 'typed-dict',
         }
@@ -600,10 +620,11 @@ def test_union_cycle(strict: bool):
                 {
                     'fields': {
                         'foobar': {
+                            'type': 'typed-dict-field',
                             'schema': {
                                 'items_schema': {'schema_ref': 'root-schema', 'type': 'definition-ref'},
                                 'type': 'list',
-                            }
+                            },
                         }
                     },
                     'type': 'typed-dict',
@@ -713,12 +734,16 @@ def test_many_uses_of_ref():
             'type': 'typed-dict',
             'ref': 'Branch',
             'fields': {
-                'name': {'schema': {'type': 'str', 'max_length': 8, 'ref': 'limited-string'}},
+                'name': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'str', 'max_length': 8, 'ref': 'limited-string'},
+                },
                 'other_names': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'list',
                         'items_schema': {'type': 'definition-ref', 'schema_ref': 'limited-string'},
-                    }
+                    },
                 },
             },
         }
@@ -744,6 +769,7 @@ def test_error_inside_definition_wrapper():
                 'ref': 'Branch',
                 'fields': {
                     'sub_branch': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'schema': {
@@ -752,7 +778,7 @@ def test_error_inside_definition_wrapper():
                             },
                             'default': None,
                             'default_factory': lambda x: 'foobar',
-                        }
+                        },
                     }
                 },
             }
@@ -774,8 +800,9 @@ def test_model_td_recursive():
             'ref': '__main__.Foobar',
             'return_fields_set': True,
             'fields': {
-                'x': {'schema': {'type': 'int'}, 'required': True},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'int'}, 'required': True},
                 'y': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'default',
                         'schema': {

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -89,7 +89,10 @@ def test_function_before_error_model():
         {
             'type': 'function-before',
             'function': {'type': 'general', 'function': f},
-            'schema': {'type': 'typed-dict', 'fields': {'my_field': {'schema': {'type': 'str', 'max_length': 5}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'fields': {'my_field': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'max_length': 5}}},
+            },
         }
     )
 
@@ -226,11 +229,12 @@ def test_function_after_config():
             'type': 'typed-dict',
             'fields': {
                 'test_field': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
                         'function': {'type': 'field', 'function': f},
                         'schema': {'type': 'str'},
-                    }
+                    },
                 }
             },
         },
@@ -292,7 +296,10 @@ def test_validate_assignment():
         {
             'type': 'function-after',
             'function': {'type': 'general', 'function': f},
-            'schema': {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
         }
     )
 

--- a/tests/validators/test_json.py
+++ b/tests/validators/test_json.py
@@ -158,7 +158,10 @@ def test_ask():
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'extra_behavior': 'forbid',
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         }

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -602,7 +602,10 @@ def test_revalidate_post_init():
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'from_attributes': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
             'config': {'revalidate_models': True},
         }
@@ -737,7 +740,10 @@ def test_validate_assignment():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -811,7 +817,10 @@ def test_validate_assignment_no_fields_set():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -21,7 +21,10 @@ def test_model_class():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -72,7 +75,7 @@ def test_model_class_setattr():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}},
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
         }
     )
@@ -101,7 +104,7 @@ def test_model_class_root_validator():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}},
+                    'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                 },
             },
         }
@@ -131,7 +134,7 @@ def test_function_ask(mode, return_fields_set):
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': return_fields_set,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}},
+                    'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                 },
             },
         }
@@ -172,8 +175,16 @@ def test_union_sub_schema():
             'schema': {
                 'type': 'union',
                 'choices': [
-                    {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'foo': {'schema': {'type': 'int'}}}},
-                    {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': {'type': 'int'}}}},
+                    {
+                        'type': 'typed-dict',
+                        'return_fields_set': True,
+                        'fields': {'foo': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+                    },
+                    {
+                        'type': 'typed-dict',
+                        'return_fields_set': True,
+                        'fields': {'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+                    },
                 ],
             },
         }
@@ -203,14 +214,20 @@ def test_tagged_union_sub_schema():
                 'choices': {
                     'apple': {
                         'type': 'typed-dict',
-                        'fields': {'foo': {'schema': {'type': 'str'}}, 'bar': {'schema': {'type': 'int'}}},
+                        'fields': {
+                            'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        },
                     },
                     'banana': {
                         'type': 'typed-dict',
                         'return_fields_set': True,
                         'fields': {
-                            'foo': {'schema': {'type': 'str'}},
-                            'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                            'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            'spam': {
+                                'type': 'typed-dict-field',
+                                'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                            },
                         },
                     },
                 },
@@ -256,7 +273,7 @@ def test_model_class_function_after():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}},
+                    'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                 },
             },
         }
@@ -276,7 +293,7 @@ def test_model_class_not_type():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}},
+                    'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                 },
             }
         )
@@ -290,7 +307,10 @@ def test_not_return_fields_set():
         {
             'type': 'model',
             'cls': MyModel,
-            'schema': {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
         }
     )
     assert 'expect_fields_set:false' in plain_repr(v)
@@ -316,7 +336,7 @@ def test_model_class_instance_direct():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}},
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
         }
     )
@@ -353,7 +373,7 @@ def test_model_class_instance_subclass():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}},
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
             'config': {'from_attributes': True},
         }
@@ -381,7 +401,10 @@ def test_model_class_strict():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -412,7 +435,11 @@ def test_internal_error():
         {
             'type': 'model',
             'cls': int,
-            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': {'type': 'int'}}}},
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'f': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+            },
         }
     )
     with pytest.raises(AttributeError, match=re.escape("'int' object has no attribute '__dict__'")):
@@ -437,7 +464,10 @@ def test_revalidate():
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'from_attributes': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
             'config': {'revalidate_models': True},
         }
@@ -492,7 +522,10 @@ def test_revalidate_extra():
                 'return_fields_set': True,
                 'from_attributes': True,
                 'extra_behavior': 'allow',
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
             'config': {'revalidate_models': True},
         }
@@ -536,7 +569,10 @@ def test_call_after_init():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -562,7 +598,7 @@ def test_call_after_init_validation_error():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}},
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
         }
     )
@@ -599,7 +635,7 @@ def test_call_after_init_internal_error():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}},
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
         }
     )
@@ -625,7 +661,10 @@ def test_call_after_init_mutate():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )

--- a/tests/validators/test_model_init.py
+++ b/tests/validators/test_model_init.py
@@ -17,7 +17,10 @@ def test_model_init():
             'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
-                'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                'fields': {
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                    'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                },
             },
         }
     )
@@ -48,17 +51,21 @@ def test_model_init_nested():
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {
-                    'field_a': {'schema': {'type': 'str'}},
+                    'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                     'field_b': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'model',
                             'cls': MyModel,
                             'schema': {
                                 'type': 'typed-dict',
                                 'return_fields_set': True,
-                                'fields': {'x_a': {'schema': {'type': 'str'}}, 'x_b': {'schema': {'type': 'int'}}},
+                                'fields': {
+                                    'x_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                                    'x_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                },
                             },
-                        }
+                        },
                     },
                 },
             },
@@ -97,7 +104,10 @@ def test_function_before():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         }
@@ -131,7 +141,10 @@ def test_function_after():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         }
@@ -167,7 +180,10 @@ def test_function_wrap():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         }

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -86,13 +86,19 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'foo': {'schema': {'type': 'str'}}, 'bar': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'foo': {'schema': {'type': 'str'}},
-                        'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'spam': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                     },
                 },
             },
@@ -156,13 +162,19 @@ def test_int_choice_keys(py_and_json: PyAndJson, input_value, expected):
             'choices': {
                 123: {
                     'type': 'typed-dict',
-                    'fields': {'foo': {'schema': {'type': 'int'}}, 'bar': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'foo': {'schema': {'type': 'str'}},
-                        'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'spam': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                     },
                 },
             },
@@ -193,13 +205,19 @@ def test_enum_keys():
             'choices': {
                 1: {
                     'type': 'typed-dict',
-                    'fields': {'foo': {'schema': {'type': 'int'}}, 'bar': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'foo': {'schema': {'type': 'str'}},
-                        'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'spam': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                     },
                 },
             },
@@ -229,13 +247,16 @@ def test_discriminator_path(py_and_json: PyAndJson):
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'a': {'schema': {'type': 'str'}}, 'b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'c': {'schema': {'type': 'str'}},
-                        'd': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'd': {'type': 'typed-dict-field', 'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
                     },
                 },
             },
@@ -417,11 +438,17 @@ def test_from_attributes():
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'a': {'schema': {'type': 'str'}}, 'b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
-                    'fields': {'c': {'schema': {'type': 'str'}}, 'd': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'd': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
             },
         },
@@ -439,9 +466,16 @@ def test_use_ref():
             'type': 'tagged-union',
             'discriminator': 'foobar',
             'choices': {
-                'apple': {'type': 'typed-dict', 'ref': 'apple', 'fields': {'a': {'schema': {'type': 'str'}}}},
+                'apple': {
+                    'type': 'typed-dict',
+                    'ref': 'apple',
+                    'fields': {'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+                },
                 'apple2': {'type': 'definition-ref', 'schema_ref': 'apple'},
-                'banana': {'type': 'typed-dict', 'fields': {'b': {'schema': {'type': 'str'}}}},
+                'banana': {
+                    'type': 'typed-dict',
+                    'fields': {'b': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+                },
             },
         },
         {'from_attributes': True},
@@ -475,13 +509,19 @@ def test_custom_error():
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'foo': {'schema': {'type': 'str'}}, 'bar': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'foo': {'schema': {'type': 'str'}},
-                        'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'spam': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                     },
                 },
             },
@@ -510,13 +550,19 @@ def test_custom_error_type():
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'foo': {'schema': {'type': 'str'}}, 'bar': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'bar': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'foo': {'schema': {'type': 'str'}},
-                        'spam': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'foo': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'spam': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'list', 'items_schema': {'type': 'int'}},
+                        },
                     },
                 },
             },
@@ -587,20 +633,26 @@ def test_tag_repeated(py_and_json: PyAndJson, input_value, expected):
             'choices': {
                 'apple': {
                     'type': 'typed-dict',
-                    'fields': {'a': {'schema': {'type': 'str'}}, 'b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'banana': {
                     'type': 'typed-dict',
                     'fields': {
-                        'c': {'schema': {'type': 'str'}},
-                        'd': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
+                        'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'd': {'type': 'typed-dict-field', 'schema': {'type': 'list', 'items_schema': {'type': 'int'}}},
                     },
                 },
                 'cherry': 'banana',
                 'durian': 'apple',
                 1: {
                     'type': 'typed-dict',
-                    'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 2: 1,
             },
@@ -626,7 +678,10 @@ def test_tag_repeated_invalid():
                 'choices': {
                     'apple': {
                         'type': 'typed-dict',
-                        'fields': {'a': {'schema': {'type': 'str'}}, 'b': {'schema': {'type': 'int'}}},
+                        'fields': {
+                            'a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                        },
                     },
                     'cherry': 'wrong',
                 },

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -43,7 +43,10 @@ def test_simple():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         }
     )
 
@@ -54,7 +57,10 @@ def test_strict():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         },
         {'strict': True},
     )
@@ -75,8 +81,11 @@ def test_with_default():
             'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
-                'field_a': {'schema': {'type': 'str'}},
-                'field_b': {'schema': {'type': 'default', 'schema': {'type': 'int'}, 'default': 666}},
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'int'}, 'default': 666},
+                },
             },
         }
     )
@@ -92,7 +101,10 @@ def test_missing_error():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         }
     )
     with pytest.raises(ValidationError) as exc_info:
@@ -134,7 +146,10 @@ def test_config(config: CoreConfig, input_value, expected):
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'float'}, 'required': False}},
+            'fields': {
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'b': {'type': 'typed-dict-field', 'schema': {'type': 'float'}, 'required': False},
+            },
         },
         config,
     )
@@ -152,7 +167,10 @@ def test_ignore_extra():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
         }
     )
 
@@ -167,7 +185,7 @@ def test_forbid_extra():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str'}}},
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             'extra_behavior': 'forbid',
         }
     )
@@ -185,7 +203,7 @@ def test_allow_extra():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str'}}},
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             'extra_behavior': 'allow',
         }
     )
@@ -201,7 +219,7 @@ def test_allow_extra_validate():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str'}}},
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             'extra_validator': {'type': 'int'},
             'extra_behavior': 'allow',
         }
@@ -238,7 +256,8 @@ def test_allow_extra_wrong():
 
 def test_str_config():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}}, {'str_max_length': 5}
+        {'type': 'typed-dict', 'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}}},
+        {'str_max_length': 5},
     )
     assert v.validate_python({'field_a': 'test'}) == {'field_a': 'test'}
 
@@ -248,7 +267,11 @@ def test_str_config():
 
 def test_validate_assignment():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
+        {
+            'type': 'typed-dict',
+            'return_fields_set': True,
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+        }
     )
 
     assert v.validate_python({'field_a': 'test'}) == ({'field_a': 'test'}, {'field_a'})
@@ -261,7 +284,7 @@ def test_validate_assignment_strict_field():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'str', 'strict': True}}},
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'strict': True}}},
         }
     )
 
@@ -291,18 +314,20 @@ def test_validate_assignment_functions():
             'return_fields_set': True,
             'fields': {
                 'field_a': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
                         'function': {'type': 'general', 'function': func_a},
                         'schema': {'type': 'str'},
-                    }
+                    },
                 },
                 'field_b': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
                         'function': {'type': 'general', 'function': func_b},
                         'schema': {'type': 'int'},
-                    }
+                    },
                 },
             },
         }
@@ -325,7 +350,11 @@ def test_validate_assignment_functions():
 
 def test_validate_assignment_ignore_extra():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
+        {
+            'type': 'typed-dict',
+            'return_fields_set': True,
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+        }
     )
 
     assert v.validate_python({'field_a': 'test'}) == ({'field_a': 'test'}, {'field_a'})
@@ -340,7 +369,11 @@ def test_validate_assignment_ignore_extra():
 
 def test_validate_assignment_allow_extra():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}, 'extra_behavior': 'allow'}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            'extra_behavior': 'allow',
+        }
     )
 
     assert v.validate_python({'field_a': 'test'}) == {'field_a': 'test'}
@@ -352,7 +385,7 @@ def test_validate_assignment_allow_extra_validate():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'str'}}},
+            'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             'extra_validator': {'type': 'int'},
             'extra_behavior': 'allow',
         }
@@ -374,7 +407,13 @@ def test_validate_assignment_allow_extra_validate():
 
 def test_validate_assignment_with_strict():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
+        }
     )
 
     r = v.validate_python({'x': 'a', 'y': '123'})
@@ -392,7 +431,12 @@ def test_validate_assignment_with_strict():
 
 def test_json_error():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'list', 'items_schema': {'type': 'int'}}}
+            },
+        }
     )
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json('{"field_a": [123, "wrong"]}')
@@ -415,7 +459,13 @@ def test_missing_schema_key():
 def test_fields_required_by_default():
     """By default all fields should be required"""
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+            },
+        }
     )
 
     assert v.validate_python({'x': 'pika', 'y': 'chu'}) == {'x': 'pika', 'y': 'chu'}
@@ -433,7 +483,10 @@ def test_fields_required_by_default_with_optional():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}, 'required': False}},
+            'fields': {
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {'type': 'typed-dict-field', 'schema': {'type': 'str'}, 'required': False},
+            },
         }
     )
 
@@ -447,8 +500,11 @@ def test_fields_required_by_default_with_default():
             'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
-                'x': {'schema': {'type': 'str'}},
-                'y': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'bulbi'}},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'bulbi'},
+                },
             },
         }
     )
@@ -464,7 +520,10 @@ def test_all_optional_fields():
             'type': 'typed-dict',
             'total': False,
             'return_fields_set': True,
-            'fields': {'x': {'schema': {'type': 'str', 'strict': True}}, 'y': {'schema': {'type': 'str'}}},
+            'fields': {
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'strict': True}},
+                'y': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+            },
         }
     )
 
@@ -487,8 +546,8 @@ def test_all_optional_fields_with_required_fields():
             'total': False,
             'return_fields_set': True,
             'fields': {
-                'x': {'schema': {'type': 'str', 'strict': True}, 'required': True},
-                'y': {'schema': {'type': 'str'}},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'strict': True}, 'required': True},
+                'y': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
             },
         }
     )
@@ -511,7 +570,11 @@ def test_field_required_and_default():
             {
                 'type': 'typed-dict',
                 'fields': {
-                    'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'pika'}, 'required': True}
+                    'x': {
+                        'type': 'typed-dict-field',
+                        'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 'pika'},
+                        'required': True,
+                    }
                 },
             }
         )
@@ -519,7 +582,12 @@ def test_field_required_and_default():
 
 def test_alias(py_and_json: PyAndJson):
     v = py_and_json(
-        {'type': 'typed-dict', 'fields': {'field_a': {'validation_alias': 'FieldA', 'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'field_a': {'validation_alias': 'FieldA', 'type': 'typed-dict-field', 'schema': {'type': 'int'}}
+            },
+        }
     )
     assert v.validate_test({'FieldA': '123'}) == {'field_a': 123}
     with pytest.raises(ValidationError, match=r'field_a\n +Field required \[type=missing,'):
@@ -529,16 +597,26 @@ def test_alias(py_and_json: PyAndJson):
 
 
 def test_empty_string_field_name(py_and_json: PyAndJson):
-    v = py_and_json({'type': 'typed-dict', 'fields': {'': {'schema': {'type': 'int'}}}})
+    v = py_and_json({'type': 'typed-dict', 'fields': {'': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}}})
     assert v.validate_test({'': 123}) == {'': 123}
 
 
 def test_empty_string_aliases(py_and_json: PyAndJson):
-    v = py_and_json({'type': 'typed-dict', 'fields': {'field_a': {'validation_alias': '', 'schema': {'type': 'int'}}}})
+    v = py_and_json(
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'validation_alias': '', 'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+        }
+    )
     assert v.validate_test({'': 123}) == {'field_a': 123}
 
     v = py_and_json(
-        {'type': 'typed-dict', 'fields': {'field_a': {'validation_alias': ['', ''], 'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'field_a': {'validation_alias': ['', ''], 'type': 'typed-dict-field', 'schema': {'type': 'int'}}
+            },
+        }
     )
     assert v.validate_test({'': {'': 123}}) == {'field_a': 123}
 
@@ -549,7 +627,9 @@ def test_alias_allow_pop(py_and_json: PyAndJson):
             'type': 'typed-dict',
             'return_fields_set': True,
             'populate_by_name': True,
-            'fields': {'field_a': {'validation_alias': 'FieldA', 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'validation_alias': 'FieldA', 'type': 'typed-dict-field', 'schema': {'type': 'int'}}
+            },
         }
     )
     assert v.validate_test({'FieldA': '123'}) == ({'field_a': 123}, {'field_a'})
@@ -572,7 +652,12 @@ def test_alias_allow_pop(py_and_json: PyAndJson):
 )
 def test_alias_path(py_and_json: PyAndJson, input_value, expected):
     v = py_and_json(
-        {'type': 'typed-dict', 'fields': {'field_a': {'validation_alias': ['foo', 'bar'], 'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {
+                'field_a': {'validation_alias': ['foo', 'bar'], 'type': 'typed-dict-field', 'schema': {'type': 'int'}}
+            },
+        }
     )
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=expected.message):
@@ -606,6 +691,7 @@ def test_aliases_path_multiple(py_and_json: PyAndJson, input_value, expected):
             'fields': {
                 'field_a': {
                     'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']],
+                    'type': 'typed-dict-field',
                     'schema': {'type': 'int'},
                 }
             },
@@ -624,7 +710,13 @@ def test_aliases_debug():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3]], 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {
+                    'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3]],
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                }
+            },
         }
     )
     print(repr(v))
@@ -636,7 +728,13 @@ def get_int_key():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'validation_alias': [['foo', 3], ['spam']], 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {
+                    'validation_alias': [['foo', 3], ['spam']],
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                }
+            },
         }
     )
     assert v.validate_python({'foo': {3: 33}}) == ({'field_a': 33}, {'field_a'})
@@ -650,7 +748,10 @@ class GetItemThing:
 
 def get_custom_getitem():
     v = SchemaValidator(
-        {'type': 'typed-dict', 'fields': {'field_a': {'validation_alias': ['foo'], 'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'validation_alias': ['foo'], 'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+        }
     )
     assert v.validate_python(GetItemThing()) == ({'field_a': 321}, {'field_a'})
     assert v.validate_python({'bar': GetItemThing()}) == ({'field_a': 321}, {'field_a'})
@@ -661,7 +762,13 @@ def test_paths_allow_by_name(py_and_json: PyAndJson, input_value):
     v = py_and_json(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'validation_alias': [['foo', 'bar'], ['foo']], 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {
+                    'validation_alias': [['foo', 'bar'], ['foo']],
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                }
+            },
             'populate_by_name': True,
         }
     )
@@ -682,14 +789,25 @@ def test_paths_allow_by_name(py_and_json: PyAndJson, input_value):
 )
 def test_alias_build_error(alias_schema, error):
     with pytest.raises(SchemaError, match=error):
-        SchemaValidator({'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'int'}, **alias_schema}}})
+        SchemaValidator(
+            {
+                'type': 'typed-dict',
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}, **alias_schema}},
+            }
+        )
 
 
 def test_alias_error_loc():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'field_a': {'schema': {'type': 'int'}, 'validation_alias': [['bar'], ['foo']]}},
+            'fields': {
+                'field_a': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                    'validation_alias': [['bar'], ['foo']],
+                }
+            },
         }
     )
     assert v.validate_python({'foo': 42}) == {'field_a': 42}
@@ -731,25 +849,27 @@ def test_model_deep():
             'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
-                'field_a': {'schema': {'type': 'str'}},
+                'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                 'field_b': {
+                    'type': 'typed-dict-field',
                     'schema': {
                         'type': 'typed-dict',
                         'return_fields_set': True,
                         'fields': {
-                            'field_c': {'schema': {'type': 'str'}},
+                            'field_c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
                             'field_d': {
+                                'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'typed-dict',
                                     'return_fields_set': True,
                                     'fields': {
-                                        'field_e': {'schema': {'type': 'str'}},
-                                        'field_f': {'schema': {'type': 'int'}},
+                                        'field_e': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                                        'field_f': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                                     },
-                                }
+                                },
                             },
                         },
-                    }
+                    },
                 },
             },
         }
@@ -824,9 +944,9 @@ def test_from_attributes(input_value, expected):
             'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
-                'a': {'schema': {'type': 'int'}},
-                'b': {'schema': {'type': 'int'}},
-                'c': {'schema': {'type': 'str'}},
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
             },
             'from_attributes': True,
         }
@@ -845,9 +965,9 @@ def test_from_attributes_type_error():
         {
             'type': 'typed-dict',
             'fields': {
-                'a': {'schema': {'type': 'int'}},
-                'b': {'schema': {'type': 'int'}},
-                'c': {'schema': {'type': 'str'}},
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
             },
             'from_attributes': True,
         }
@@ -870,7 +990,7 @@ def test_from_attributes_by_name():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'a': {'schema': {'type': 'int'}, 'validation_alias': 'a_alias'}},
+            'fields': {'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}, 'validation_alias': 'a_alias'}},
             'from_attributes': True,
             'populate_by_name': True,
         }
@@ -889,9 +1009,9 @@ def test_from_attributes_missing():
         {
             'type': 'typed-dict',
             'fields': {
-                'a': {'schema': {'type': 'int'}},
-                'b': {'schema': {'type': 'int'}},
-                'c': {'schema': {'type': 'str'}},
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'c': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
             },
             'from_attributes': True,
         }
@@ -922,7 +1042,10 @@ def test_from_attributes_error():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
-            'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'int'}}},
+            'fields': {
+                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                'b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+            },
             'from_attributes': True,
         }
     )
@@ -988,7 +1111,7 @@ def test_from_attributes_extra():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'a': {'schema': {'type': 'int'}}},
+            'fields': {'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
             'from_attributes': True,
             'extra_behavior': 'allow',
         }
@@ -1017,7 +1140,13 @@ def foobar():
     ids=repr,
 )
 def test_from_attributes_function(input_value, expected):
-    v = SchemaValidator({'type': 'typed-dict', 'fields': {'a': {'schema': {'type': 'any'}}}, 'from_attributes': True})
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'fields': {'a': {'type': 'typed-dict-field', 'schema': {'type': 'any'}}},
+            'from_attributes': True,
+        }
+    )
 
     assert v.validate_python(input_value) == expected
 
@@ -1032,7 +1161,13 @@ def test_from_attributes_error_error():
         def x(self):
             raise BadError('intentional error')
 
-    v = SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'int'}}}, 'from_attributes': True})
+    v = SchemaValidator(
+        {
+            'type': 'typed-dict',
+            'fields': {'x': {'type': 'typed-dict-field', 'schema': {'type': 'int'}}},
+            'from_attributes': True,
+        }
+    )
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(Foobar())
@@ -1091,6 +1226,7 @@ def test_from_attributes_path(input_value, expected):
             'fields': {
                 'my_field': {
                     'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']],
+                    'type': 'typed-dict-field',
                     'schema': {'type': 'int'},
                 }
             },
@@ -1118,6 +1254,7 @@ def test_from_attributes_path_error():
             'fields': {
                 'my_field': {
                     'validation_alias': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']],
+                    'type': 'typed-dict-field',
                     'schema': {'type': 'int'},
                 }
             },
@@ -1143,7 +1280,13 @@ def test_alias_extra(py_and_json: PyAndJson):
         {
             'type': 'typed-dict',
             'extra_behavior': 'allow',
-            'fields': {'field_a': {'validation_alias': [['FieldA'], ['foo', 2]], 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {
+                    'validation_alias': [['FieldA'], ['foo', 2]],
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                }
+            },
         }
     )
     assert v.validate_test({'FieldA': 1}) == {'field_a': 1}
@@ -1169,7 +1312,13 @@ def test_alias_extra_from_attributes():
             'type': 'typed-dict',
             'extra_behavior': 'allow',
             'from_attributes': True,
-            'fields': {'field_a': {'validation_alias': [['FieldA'], ['foo', 2]], 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {
+                    'validation_alias': [['FieldA'], ['foo', 2]],
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'int'},
+                }
+            },
         }
     )
     assert v.validate_python({'FieldA': 1}) == {'field_a': 1}
@@ -1185,7 +1334,9 @@ def test_alias_extra_by_name(py_and_json: PyAndJson):
             'extra_behavior': 'allow',
             'from_attributes': True,
             'populate_by_name': True,
-            'fields': {'field_a': {'validation_alias': 'FieldA', 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'validation_alias': 'FieldA', 'type': 'typed-dict-field', 'schema': {'type': 'int'}}
+            },
         }
     )
     assert v.validate_test({'FieldA': 1}) == {'field_a': 1}
@@ -1199,7 +1350,9 @@ def test_alias_extra_forbid(py_and_json: PyAndJson):
         {
             'type': 'typed-dict',
             'extra_behavior': 'forbid',
-            'fields': {'field_a': {'validation_alias': 'FieldA', 'schema': {'type': 'int'}}},
+            'fields': {
+                'field_a': {'type': 'typed-dict-field', 'validation_alias': 'FieldA', 'schema': {'type': 'int'}}
+            },
         }
     )
     assert v.validate_test({'FieldA': 1}) == {'field_a': 1}
@@ -1210,7 +1363,10 @@ def test_with_default_factory():
         {
             'type': 'typed-dict',
             'fields': {
-                'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda: 'pikachu'}}
+                'x': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda: 'pikachu'},
+                }
             },
         }
     )
@@ -1227,6 +1383,7 @@ def test_field_required_and_default_factory():
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda: 'pika'},
                         'required': True,
                     }
@@ -1247,7 +1404,10 @@ def test_bad_default_factory(default_factory, error_message):
         {
             'type': 'typed-dict',
             'fields': {
-                'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': default_factory}}
+                'x': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': default_factory},
+                }
             },
         }
     )
@@ -1261,7 +1421,12 @@ class TestOnError:
             SchemaValidator(
                 {
                     'type': 'typed-dict',
-                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'rais'}}},
+                    'fields': {
+                        'x': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'rais'},
+                        }
+                    },
                 }
             )
 
@@ -1270,7 +1435,12 @@ class TestOnError:
             SchemaValidator(
                 {
                     'type': 'typed-dict',
-                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'}}},
+                    'fields': {
+                        'x': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'},
+                        }
+                    },
                 }
             )
 
@@ -1279,12 +1449,19 @@ class TestOnError:
             SchemaValidator(
                 {
                     'type': 'typed-dict',
-                    'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'default'}}},
+                    'fields': {
+                        'x': {
+                            'type': 'typed-dict-field',
+                            'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'default'},
+                        }
+                    },
                 }
             )
 
     def test_on_error_raise_by_default(self, py_and_json: PyAndJson):
-        v = py_and_json({'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}}})
+        v = py_and_json(
+            {'type': 'typed-dict', 'fields': {'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}}}
+        )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
         with pytest.raises(ValidationError) as exc_info:
             v.validate_test({'x': ['foo']})
@@ -1296,7 +1473,12 @@ class TestOnError:
         v = py_and_json(
             {
                 'type': 'typed-dict',
-                'fields': {'x': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'raise'}}},
+                'fields': {
+                    'x': {
+                        'type': 'typed-dict-field',
+                        'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'raise'},
+                    }
+                },
             }
         )
         assert v.validate_test({'x': 'foo'}) == {'x': 'foo'}
@@ -1312,6 +1494,7 @@ class TestOnError:
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'},
                         'required': False,
                     }
@@ -1328,6 +1511,7 @@ class TestOnError:
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit', 'default': 'pika'},
                         'required': False,
                     }
@@ -1344,12 +1528,13 @@ class TestOnError:
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'schema': {'type': 'str'},
                             'on_error': 'default',
                             'default': 'pika',
-                        }
+                        },
                     }
                 },
             }
@@ -1363,12 +1548,13 @@ class TestOnError:
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'schema': {'type': 'str'},
                             'on_error': 'default',
                             'default_factory': lambda: 'pika',
-                        }
+                        },
                     }
                 },
             }
@@ -1391,6 +1577,7 @@ class TestOnError:
                 'type': 'typed-dict',
                 'fields': {
                     'x': {
+                        'type': 'typed-dict-field',
                         'schema': {
                             'type': 'default',
                             'on_error': 'raise',
@@ -1399,7 +1586,7 @@ class TestOnError:
                                 'function': {'type': 'general', 'function': wrap_function},
                                 'schema': {'type': 'str'},
                             },
-                        }
+                        },
                     }
                 },
             }
@@ -1415,9 +1602,10 @@ def test_frozen_field():
         {
             'type': 'typed-dict',
             'fields': {
-                'name': {'schema': {'type': 'str'}},
-                'age': {'schema': {'type': 'int'}},
+                'name': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'age': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
                 'is_developer': {
+                    'type': 'typed-dict-field',
                     'schema': {'type': 'default', 'schema': {'type': 'bool'}, 'default': True},
                     'frozen': True,
                 },

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -64,7 +64,10 @@ class TestModelClass:
                         'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
-                            'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
+                            'fields': {
+                                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                'b': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            },
                         },
                     },
                     {
@@ -73,7 +76,10 @@ class TestModelClass:
                         'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
-                            'fields': {'c': {'schema': {'type': 'int'}}, 'd': {'schema': {'type': 'str'}}},
+                            'fields': {
+                                'c': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                'd': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            },
                         },
                     },
                 ],
@@ -128,7 +134,10 @@ class TestModelClassSimilar:
                         'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
-                            'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
+                            'fields': {
+                                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                'b': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                            },
                         },
                     },
                     {
@@ -138,9 +147,12 @@ class TestModelClassSimilar:
                             'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {
-                                'a': {'schema': {'type': 'int'}},
-                                'b': {'schema': {'type': 'str'}},
-                                'c': {'schema': {'type': 'default', 'schema': {'type': 'float'}, 'default': 1.0}},
+                                'a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                                'b': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                                'c': {
+                                    'type': 'typed-dict-field',
+                                    'schema': {'type': 'default', 'schema': {'type': 'float'}, 'default': 1.0},
+                                },
                             },
                         },
                     },

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -12,8 +12,11 @@ def test_typed_dict_default():
         {
             'type': 'typed-dict',
             'fields': {
-                'x': {'schema': {'type': 'str'}},
-                'y': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': '[default]'}},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': '[default]'},
+                },
             },
         }
     )
@@ -26,8 +29,12 @@ def test_typed_dict_omit():
         {
             'type': 'typed-dict',
             'fields': {
-                'x': {'schema': {'type': 'str'}},
-                'y': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'}, 'required': False},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'on_error': 'omit'},
+                    'required': False,
+                },
             },
         }
     )
@@ -216,8 +223,11 @@ def test_typed_dict_error():
         {
             'type': 'typed-dict',
             'fields': {
-                'x': {'schema': {'type': 'str'}},
-                'y': {'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda y: y * 2}},
+                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                'y': {
+                    'type': 'typed-dict-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default_factory': lambda y: y * 2},
+                },
             },
         }
     )
@@ -278,7 +288,10 @@ def test_model_class():
                 'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
-                    'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+                    'fields': {
+                        'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
+                        'field_b': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
+                    },
                 },
                 'default': ({'field_a': '[default-a]', 'field_b': '[default-b]'}, set()),
                 'on_error': 'default',


### PR DESCRIPTION
I think this might be the implemention for https://github.com/pydantic/pydantic-core/issues/403 but im not too sure. 

#### Changes
- add attribute `type` to `TypedDictField`
- ~~add `TypedDictField` as type to `CoreSchema` (not 100% this should be done because there is no SchemaValidator implementation for it)~~
- update tests 



 