### PR TITLE
Add metadata to dataclass-field

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2410,6 +2410,7 @@ def typed_dict_field(
         serialization_alias: The alias to use as a key when serializing
         serialization_exclude: Whether to exclude the field when serializing
         frozen: Whether the field is frozen
+        metadata: See [TODO] for details
     """
     return dict_not_none(
         schema=schema,
@@ -2572,6 +2573,7 @@ class DataclassField(TypedDict, total=False):
     validation_alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
     serialization_alias: str
     serialization_exclude: bool  # default: False
+    metadata: Any
 
 
 def dataclass_field(
@@ -2583,6 +2585,7 @@ def dataclass_field(
     validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
     serialization_alias: str | None = None,
     serialization_exclude: bool | None = None,
+    metadata: Any = None,
 ) -> DataclassField:
     """
     Returns a schema for a dataclass field, e.g.:
@@ -2603,6 +2606,7 @@ def dataclass_field(
         validation_alias: The alias(es) to use to find the field in the validation data
         serialization_alias: The alias to use as a key when serializing
         serialization_exclude: Whether to exclude the field when serializing
+        metadata: See [TODO] for details
     """
     return dict_not_none(
         name=name,
@@ -2612,6 +2616,7 @@ def dataclass_field(
         validation_alias=validation_alias,
         serialization_alias=serialization_alias,
         serialization_exclude=serialization_exclude,
+        metadata=metadata,
     )
 
 


### PR DESCRIPTION
Needed to use existing code for handling metadata (specifically for JSON schema) in pydantic in the same way between typed_dict_field and dataclass_field