### PR TITLE
Remove duplicate test case from test_arguments

### DIFF
--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -17,7 +17,6 @@ from ..conftest import Err, PyAndJson, plain_repr
         [(1, 'a', True), ((1, 'a', True), {})],
         [[1, 'a', True], ((1, 'a', True), {})],
         [{'__args__': (1, 'a', True), '__kwargs__': {}}, ((1, 'a', True), {})],
-        [[1, 'a', True], ((1, 'a', True), {})],
         [(1, 'a', 'true'), ((1, 'a', True), {})],
         ['x', Err('type=arguments_type,')],
         [


### PR DESCRIPTION
Just realized this duplicate test case. seems a duplicate of [line 18](https://github.com/pydantic/pydantic-core/blob/cb05dcfae4aef90666a4e74bc8fa7ad20fd399c6/tests/validators/test_arguments.py#L18)