### PR TITLE
Model subclass instances

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -31,7 +31,8 @@ class CoreConfig(TypedDict, total=False):
     typed_dict_total: bool  # default: True
     # used on typed-dicts and tagged union keys
     from_attributes: bool
-    revalidate_models: bool
+    # whether instances of models and dataclasses (including subclass instances) should re-validate, default False
+    revalidate_instances: bool
     # whether to validate default values during validation, default False
     validate_default: bool
     # used on typed-dicts and arguments
@@ -2564,6 +2565,7 @@ class ModelSchema(TypedDict, total=False):
     post_init: str
     strict: bool
     frozen: bool
+    revalidate_instances: bool
     config: CoreConfig
     ref: str
     metadata: Any
@@ -2577,6 +2579,7 @@ def model_schema(
     post_init: str | None = None,
     strict: bool | None = None,
     frozen: bool | None = None,
+    revalidate_instances: bool | None = None,
     config: CoreConfig | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -2614,6 +2617,8 @@ def model_schema(
         post_init: The call after init to use for the model
         strict: Whether the model is strict
         frozen: Whether the model is frozen
+        revalidate_instances: whether instances of models and dataclasses (including subclass instances)
+          should re-validate defaults to config.revalidate_instances, else False
         config: The config to use for the model
         ref: See [TODO] for details
         metadata: See [TODO] for details
@@ -2626,6 +2631,7 @@ def model_schema(
         post_init=post_init,
         strict=strict,
         frozen=frozen,
+        revalidate_instances=revalidate_instances,
         config=config,
         ref=ref,
         metadata=metadata,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2563,9 +2563,9 @@ class ModelSchema(TypedDict, total=False):
     cls: Required[Type[Any]]
     schema: Required[CoreSchema]
     post_init: str
+    revalidate_instances: bool
     strict: bool
     frozen: bool
-    revalidate_instances: bool
     config: CoreConfig
     ref: str
     metadata: Any
@@ -2577,9 +2577,9 @@ def model_schema(
     schema: CoreSchema,
     *,
     post_init: str | None = None,
+    revalidate_instances: bool | None = None,
     strict: bool | None = None,
     frozen: bool | None = None,
-    revalidate_instances: bool | None = None,
     config: CoreConfig | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -2615,10 +2615,10 @@ def model_schema(
         cls: The class to use for the model
         schema: The schema to use for the model
         post_init: The call after init to use for the model
-        strict: Whether the model is strict
-        frozen: Whether the model is frozen
         revalidate_instances: whether instances of models and dataclasses (including subclass instances)
           should re-validate defaults to config.revalidate_instances, else False
+        strict: Whether the model is strict
+        frozen: Whether the model is frozen
         config: The config to use for the model
         ref: See [TODO] for details
         metadata: See [TODO] for details
@@ -2629,9 +2629,9 @@ def model_schema(
         cls=cls,
         schema=schema,
         post_init=post_init,
+        revalidate_instances=revalidate_instances,
         strict=strict,
         frozen=frozen,
-        revalidate_instances=revalidate_instances,
         config=config,
         ref=ref,
         metadata=metadata,
@@ -2762,6 +2762,7 @@ class DataclassSchema(TypedDict, total=False):
     cls: Required[Type[Any]]
     schema: Required[CoreSchema]
     post_init: bool  # default: False
+    revalidate_instances: bool  # default: False
     strict: bool  # default: False
     ref: str
     metadata: Any
@@ -2773,6 +2774,7 @@ def dataclass_schema(
     schema: CoreSchema,
     *,
     post_init: bool | None = None,
+    revalidate_instances: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -2786,6 +2788,8 @@ def dataclass_schema(
         cls: The dataclass type, used to to perform subclass checks
         schema: The schema to use for the dataclass fields
         post_init: Whether to call `__post_init__` after validation
+        revalidate_instances: whether instances of models and dataclasses (including subclass instances)
+          should re-validate defaults to config.revalidate_instances, else False
         strict: Whether to require an exact instance of `cls`
         ref: See [TODO] for details
         metadata: See [TODO] for details
@@ -2796,6 +2800,7 @@ def dataclass_schema(
         cls=cls,
         schema=schema,
         post_init=post_init,
+        revalidate_instances=revalidate_instances,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -40,7 +40,7 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
     fn is_none(&self) -> bool;
 
     #[cfg_attr(has_no_coverage, no_coverage)]
-    fn get_attr(&self, _name: &PyString) -> Option<&PyAny> {
+    fn input_get_attr(&self, _name: &PyString) -> Option<PyResult<&PyAny>> {
         None
     }
 
@@ -57,11 +57,6 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
 
     fn input_is_subclass(&self, _class: &PyType) -> PyResult<bool> {
         Ok(false)
-    }
-
-    // if the input is a subclass of `_class`, return `input.__dict__`, used on dataclasses
-    fn maybe_subclass_dict(&self, _class: &PyType) -> PyResult<&Self> {
-        Ok(self)
     }
 
     fn input_as_url(&self) -> Option<PyUrl> {

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -51,6 +51,10 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
         false
     }
 
+    fn is_python(&self) -> bool {
+        false
+    }
+
     fn input_is_subclass(&self, _class: &PyType) -> PyResult<bool> {
         Ok(false)
     }

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -47,8 +47,8 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
     // input_ prefix to differentiate from the function on PyAny
     fn input_is_instance(&self, class: &PyAny, json_mask: u8) -> PyResult<bool>;
 
-    fn is_exact_instance(&self, _class: &PyType) -> PyResult<bool> {
-        Ok(false)
+    fn is_exact_instance(&self, _class: &PyType) -> bool {
+        false
     }
 
     fn input_is_subclass(&self, _class: &PyType) -> PyResult<bool> {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -114,6 +114,10 @@ impl<'a> Input<'a> for PyAny {
         self.get_type().is(class)
     }
 
+    fn is_python(&self) -> bool {
+        true
+    }
+
     fn input_is_subclass(&self, class: &PyType) -> PyResult<bool> {
         match self.downcast::<PyType>() {
             Ok(py_type) => py_type.is_subclass(class),

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -110,8 +110,8 @@ impl<'a> Input<'a> for PyAny {
         Ok(result == 1)
     }
 
-    fn is_exact_instance(&self, class: &PyType) -> PyResult<bool> {
-        self.get_type().eq(class)
+    fn is_exact_instance(&self, class: &PyType) -> bool {
+        self.get_type().is(class)
     }
 
     fn input_is_subclass(&self, class: &PyType) -> PyResult<bool> {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -98,8 +98,8 @@ impl<'a> Input<'a> for PyAny {
         self.is_none()
     }
 
-    fn get_attr(&self, name: &PyString) -> Option<&PyAny> {
-        self.getattr(name).ok()
+    fn input_get_attr(&self, name: &PyString) -> Option<PyResult<&PyAny>> {
+        Some(self.getattr(name))
     }
 
     fn input_is_instance(&self, class: &PyAny, _json_mask: u8) -> PyResult<bool> {
@@ -122,14 +122,6 @@ impl<'a> Input<'a> for PyAny {
         match self.downcast::<PyType>() {
             Ok(py_type) => py_type.is_subclass(class),
             Err(_) => Ok(false),
-        }
-    }
-
-    fn maybe_subclass_dict(&self, class: &PyType) -> PyResult<&Self> {
-        if matches!(self.is_instance(class), Ok(true)) {
-            self.getattr(intern!(self.py(), "__dict__"))
-        } else {
-            Ok(self)
         }
     }
 

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -47,7 +47,7 @@ impl BuildSerializer for ModelSerializer {
 impl ModelSerializer {
     fn allow_value(&self, value: &PyAny, extra: &Extra) -> PyResult<bool> {
         match extra.check {
-            SerCheck::Strict => value.get_type().eq(self.class.as_ref(value.py())),
+            SerCheck::Strict => Ok(value.get_type().is(self.class.as_ref(value.py()))),
             SerCheck::Lax => value.is_instance(self.class.as_ref(value.py())),
             SerCheck::None => value.hasattr(intern!(value.py(), "__dict__")),
         }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -436,12 +436,12 @@ impl Validator for DataclassValidator {
                 ))
             }
         } else if extra.strict.unwrap_or(self.strict) && input.is_python() {
-            return Err(ValError::new(
+            Err(ValError::new(
                 ErrorType::ModelClassType {
                     class_name: self.get_name().to_string(),
                 },
                 input,
-            ));
+            ))
         } else {
             let val_output = self.validator.validate(py, input, extra, slots, recursion_guard)?;
             let dc = create_class(self.class.as_ref(py))?;

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -418,7 +418,7 @@ impl Validator for DataclassValidator {
         // created with invalid types
         // in theory we could have a flag to skip validation for an exact type in some scenarios, but I'm not sure
         // that's a good idea
-        if extra.strict.unwrap_or(self.strict) && !input.is_exact_instance(class)? {
+        if extra.strict.unwrap_or(self.strict) && !input.is_exact_instance(class) {
             Err(ValError::new(
                 ErrorType::ModelClassType {
                     class_name: self.get_name().to_string(),

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -2,12 +2,12 @@ use std::cmp::Ordering;
 use std::ptr::null_mut;
 
 use pyo3::conversion::AsPyPointer;
-use pyo3::exceptions::{PyAttributeError, PyTypeError};
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyTuple, PyType};
 use pyo3::{ffi, intern};
 
-use crate::build_tools::{py_err, safe_repr, schema_or_config_same, SchemaDict};
+use crate::build_tools::{py_err, schema_or_config_same, SchemaDict};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{py_error_on_minusone, Input};
 use crate::questions::Question;
@@ -97,16 +97,12 @@ impl Validator for ModelValidator {
             // which means raise ane error in the case of an instance of a subclass in strict mode
             if input.is_exact_instance(class) || !extra.strict.unwrap_or(self.strict) {
                 if self.revalidate {
-                    let fields_set = input.get_attr(intern!(py, "__fields_set__"));
-                    // get dict here so from_attributes logic doesn't apply
-                    let dict = match input.get_attr(intern!(py, "__dict__")) {
-                        Some(d) => d,
-                        None => {
-                            return Err(
-                                PyAttributeError::new_err("Input unexpectedly had no `__dict__` attribute").into(),
-                            )
-                        }
+                    let fields_set = match input.input_get_attr(intern!(py, "__fields_set__")) {
+                        Some(fields_set) => fields_set.ok(),
+                        None => None,
                     };
+                    // get dict here so from_attributes logic doesn't apply
+                    let dict = input.input_get_attr(intern!(py, "__dict__")).unwrap()?;
                     let output = self.validator.validate(py, dict, extra, slots, recursion_guard)?;
                     let instance = if self.expect_fields_set {
                         let (model_dict, validation_fields_set): (&PyAny, &PyAny) = output.extract(py)?;
@@ -167,10 +163,8 @@ impl Validator for ModelValidator {
         if self.frozen {
             return Err(ValError::new(ErrorType::FrozenInstance, field_value));
         }
-        let dict: &PyDict = match model.get_attr(intern!(py, "__dict__")) {
-            Some(v) => v.downcast()?,
-            None => return Err(PyTypeError::new_err(format!("{} is not a model instance", safe_repr(model))).into()),
-        };
+        let dict_py_str = intern!(py, "__dict__");
+        let dict: &PyDict = model.getattr(dict_py_str)?.downcast()?;
 
         let new_dict = dict.copy()?;
         new_dict.set_item(field_name, field_value)?;
@@ -180,7 +174,7 @@ impl Validator for ModelValidator {
                 .validate_assignment(py, new_dict, field_name, field_value, extra, slots, recursion_guard)?;
         let output = if self.expect_fields_set {
             let (output, updated_fields_set): (&PyDict, &PySet) = output.extract(py)?;
-            if let Some(fields_set) = model.get_attr(intern!(py, "__fields_set__")) {
+            if let Ok(fields_set) = model.input_get_attr(intern!(py, "__fields_set__")).unwrap() {
                 let fields_set: &PySet = fields_set.downcast()?;
                 for field_name in updated_fields_set {
                     fields_set.add(field_name)?;
@@ -190,7 +184,7 @@ impl Validator for ModelValidator {
         } else {
             output
         };
-        force_setattr(py, model, intern!(py, "__dict__"), output)?;
+        force_setattr(py, model, dict_py_str, output)?;
         Ok(model.into_py(py))
     }
 }

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -267,16 +267,23 @@ class DuplicateDifferent:
 
 
 @pytest.mark.parametrize(
-    'input_value,expected',
+    'revalidate_instances,input_value,expected',
     [
-        ({'a': 'hello', 'b': True}, {'a': 'hello', 'b': True}),
-        (FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
-        (FooDataclassSame(a='hello', b=True), {'a': 'hello', 'b': True}),
-        (FooDataclassMore(a='hello', b=True, c='more'), Err(r'c\s+Unexpected keyword argument')),
-        (DuplicateDifferent(a='hello', b=True), Err('Input should be a dictionary or an instance of FooDataclass')),
+        (True, {'a': 'hello', 'b': True}, {'a': 'hello', 'b': True}),
+        (True, FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (True, FooDataclassSame(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (True, FooDataclassMore(a='hello', b=True, c='more'), Err(r'c\s+Unexpected keyword argument')),
+        (True, DuplicateDifferent(a='hello', b=True), Err('should be a dictionary or an instance of FooDataclass')),
+        # revalidate_instances=False
+        (False, {'a': 'hello', 'b': True}, {'a': 'hello', 'b': True}),
+        (False, FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (False, FooDataclassSame(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (False, FooDataclassMore(a='hello', b=True, c='more'), {'a': 'hello', 'b': True, 'c': 'more'}),
+        (False, FooDataclassMore(a='hello', b='wrong', c='more'), {'a': 'hello', 'b': 'wrong', 'c': 'more'}),
+        (False, DuplicateDifferent(a='hello', b=True), Err('should be a dictionary or an instance of FooDataclass')),
     ],
 )
-def test_dataclass_subclass(input_value, expected):
+def test_dataclass_subclass(revalidate_instances, input_value, expected):
     schema = core_schema.dataclass_schema(
         FooDataclass,
         core_schema.dataclass_args_schema(
@@ -286,12 +293,13 @@ def test_dataclass_subclass(input_value, expected):
                 core_schema.dataclass_field(name='b', schema=core_schema.bool_schema()),
             ],
         ),
+        revalidate_instances=revalidate_instances,
     )
     v = SchemaValidator(schema)
 
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=expected.message) as exc_info:
-            v.validate_python(input_value)
+            print(v.validate_python(input_value))
 
         # debug(exc_info.value.errors())
         if expected.errors is not None:
@@ -398,14 +406,17 @@ def test_dataclass_post_init_args_multiple():
 
 
 @pytest.mark.parametrize(
-    'input_value,expected',
+    'revalidate_instances,input_value,expected',
     [
-        ({'a': b'hello', 'b': 'true'}, {'a': 'hello', 'b': True}),
-        (FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
-        (FooDataclass(a=b'hello', b='true'), {'a': 'hello', 'b': True}),
+        (True, {'a': b'hello', 'b': 'true'}, {'a': 'hello', 'b': True}),
+        (True, FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (True, FooDataclass(a=b'hello', b='true'), {'a': 'hello', 'b': True}),
+        (False, {'a': b'hello', 'b': 'true'}, {'a': 'hello', 'b': True}),
+        (False, FooDataclass(a='hello', b=True), {'a': 'hello', 'b': True}),
+        (False, FooDataclass(a=b'hello', b='true'), {'a': b'hello', 'b': 'true'}),
     ],
 )
-def test_dataclass_exact_validation(input_value, expected):
+def test_dataclass_exact_validation(revalidate_instances, input_value, expected):
     schema = core_schema.dataclass_schema(
         FooDataclass,
         core_schema.dataclass_args_schema(
@@ -415,6 +426,7 @@ def test_dataclass_exact_validation(input_value, expected):
                 core_schema.dataclass_field(name='b', schema=core_schema.bool_schema()),
             ],
         ),
+        revalidate_instances=revalidate_instances,
     )
 
     v = SchemaValidator(schema)

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -726,7 +726,7 @@ def test_dataclass_validate_assignment():
     ]
 
     # wrong arguments
-    with pytest.raises(TypeError, match="'field_a' is not a model instance"):
+    with pytest.raises(AttributeError, match="'str' object has no attribute '__dict__'"):
         v.validate_assignment('field_a', 'c', 123)
 
 

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1048,7 +1048,7 @@ def test_validate_assignment_no_fields_set():
     assert not hasattr(m, '__fields_set__')
 
     # wrong arguments
-    with pytest.raises(TypeError, match="'field_a' is not a model instance"):
+    with pytest.raises(AttributeError, match="'str' object has no attribute '__dict__'"):
         v.validate_assignment('field_a', 'field_a', b'different')
 
 

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -520,7 +520,7 @@ def test_model_class_instance_subclass_revalidate():
                 'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
             'post_init': 'model_post_init',
-            'config': {'from_attributes': True, 'revalidate_instances': True},
+            'revalidate_instances': True,
         }
     )
 

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Set, Tuple
 
 import pytest
+from dirty_equals import HasRepr, IsStr
 
 from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
 
@@ -442,12 +443,17 @@ def test_model_class_instance_direct():
 
 
 def test_model_class_instance_subclass():
+    post_init_calls = []
+
     class MyModel:
         __slots__ = '__dict__', '__fields_set__'
         field_a: str
 
         def __init__(self):
             self.field_a = 'init_a'
+
+        def model_post_init(self, context):
+            post_init_calls.append(context)
 
     class MySubModel(MyModel):
         field_b: str
@@ -465,16 +471,75 @@ def test_model_class_instance_subclass():
                 'return_fields_set': True,
                 'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
             },
-            'config': {'from_attributes': True},
+            'post_init': 'model_post_init',
         }
     )
 
     m2 = MySubModel()
     assert m2.field_a
-    m3 = v.validate_python(m2)
-    assert m2 != m3
+    m3 = v.validate_python(m2, context='call1')
+    assert m2 is m3
+    assert m3.field_a == 'init_a'
+    assert m3.field_b == 'init_b'
+    assert post_init_calls == []
+
+    m4 = v.validate_python({'field_a': b'hello'}, context='call2')
+    assert isinstance(m4, MyModel)
+    assert m4.field_a == 'hello'
+    assert m4.__fields_set__ == {'field_a'}
+    assert post_init_calls == ['call2']
+
+
+def test_model_class_instance_subclass_revalidate():
+    post_init_calls = []
+
+    class MyModel:
+        __slots__ = '__dict__', '__fields_set__'
+        field_a: str
+
+        def __init__(self):
+            self.field_a = 'init_a'
+
+        def model_post_init(self, context):
+            post_init_calls.append(context)
+
+    class MySubModel(MyModel):
+        field_b: str
+
+        def __init__(self):
+            super().__init__()
+            self.field_b = 'init_b'
+
+    v = SchemaValidator(
+        {
+            'type': 'model',
+            'cls': MyModel,
+            'schema': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
+            },
+            'post_init': 'model_post_init',
+            'config': {'from_attributes': True, 'revalidate_models': True},
+        }
+    )
+
+    m2 = MySubModel()
+    assert m2.field_a
+    m3 = v.validate_python(m2, context='call1')
+    assert m2 is not m3
     assert m3.field_a == 'init_a'
     assert not hasattr(m3, 'field_b')
+    assert post_init_calls == ['call1']
+
+    m4 = MySubModel()
+    m4.__fields_set__ = {'fruit_loop'}
+    m5 = v.validate_python(m4, context='call2')
+    assert m4 is not m5
+    assert m5.__fields_set__ == {'fruit_loop'}
+    assert m5.field_a == 'init_a'
+    assert not hasattr(m5, 'field_b')
+    assert post_init_calls == ['call1', 'call2']
 
 
 def test_model_class_strict():
@@ -506,7 +571,7 @@ def test_model_class_strict():
     assert m.field_a == 'init_a'
     # note that since dict validation was not run here, there has been no check this is an int
     assert m.field_b == 'init_b'
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(ValidationError, match='^1 validation error for MyModel\n') as exc_info:
         v.validate_python({'field_a': 'test', 'field_b': 12})
     assert exc_info.value.errors() == [
         {
@@ -518,6 +583,28 @@ def test_model_class_strict():
         }
     ]
     assert str(exc_info.value).startswith('1 validation error for MyModel\n')
+
+    class MySubModel(MyModel):
+        field_c: str
+
+        def __init__(self):
+            super().__init__()
+            self.field_c = 'init_c'
+
+    # instances of subclasses are not supported in strict mode
+    m3 = MySubModel()
+    with pytest.raises(ValidationError, match='^1 validation error for MyModel\n') as exc_info:
+        v.validate_python(m3)
+    # insert_assert(exc_info.value.errors())
+    assert exc_info.value.errors() == [
+        {
+            'type': 'model_class_type',
+            'loc': (),
+            'msg': 'Input should be an instance of MyModel',
+            'input': HasRepr(IsStr(regex='.+MySubModel object at.+')),
+            'ctx': {'class_name': 'MyModel'},
+        }
+    ]
 
 
 def test_internal_error():


### PR DESCRIPTION
TODO:
* [x] make sure `revalidate` works without `from_attributes`
* [x] do we need to remove warnings from model serialization on extra fields? - turns out I already thought about this!
* [x] implement the same logic on dataclasses
* [x] I think this now means we're calling `__instancecheck__` in python on every validation, that's going to be super slow, we might need our own fast `isinstance` check, this in turn will need to work with the nascent `PydanticGenericAlias` - this only seems to add ~10%, I think fine

This allows both instances of the model, and instances of subclasses of the model to be validated.

In strict mode, only instances of the exact model type are allowed - this is up for discussion.

In both strict and lax mode, regardless of whether we have an exact instance or subclass instance, the `validate_instances` config flag (can also be set on the validator directly) forces fields to be revalidated.

When re-validating, `__fields_set__` from the original instance is reused.

## Leaking private data and "the FastAPI problem"

A big problem FastAPI had is was that allowing subclasses meant private information on subclasses was being leaked during serialisation.

E.g.:

```py
from pydantic import BaseModel


class DataModel(BaseModel):
    name: str
    age: int


class ResponseModel(BaseModel):
    data: DataModel


class PrivateDataModel(DataModel):
    massive_secret: str


def my_view():
    data = PrivateDataModel(
        name='John',
        age=30,
        massive_secret=(
            'generative AI is good at inferring meaning and bad a '
            'calculating an answer LLMs are over-hyped'
        ),
    )
    response = ResponseModel(data=data)
    return response.json(indent=2)


print(my_view())
# output includes "massive_secret" in V1, but not in V2
```

However this is not a problem with Pydantic V2 since the serializer build for `ResponseModel` uses `DataModel` to build the serialization logic for `.data`, and only fields of `DataModel` are included.

You can run the above on pydantic main now and it works correctly (you'll need to install `pydantic-core` from this branch, and change `.json` to `.model_dump_json`, but otherwise it'll work.

@tiangolo please confirm you're happy with this approach.