### PR TITLE
Fix Validator::complete not being implemented properly for all validator types

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -166,7 +166,7 @@ def type_dict_schema(typed_dict) -> dict[str, Any]:  # noqa: C901
     return {'type': 'typed-dict', 'fields': fields, 'extra_behavior': 'forbid'}
 
 
-def union_schema(union_type: UnionType) -> core_schema.UnionSchema | core_schema.RecursiveReferenceSchema:
+def union_schema(union_type: UnionType) -> core_schema.UnionSchema | core_schema.DefinitionReferenceSchema:
     return {'type': 'union', 'choices': [get_schema(arg) for arg in union_type.__args__]}
 
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -132,7 +132,7 @@ impl<T: Clone + std::fmt::Debug> BuildContext<T> {
     }
 
     /// find a validator/serializer by `slot_id` - this used in `Validator.complete`,
-    /// specifically `RecursiveRefValidator` to set its name
+    /// specifically `DefinitionRefValidator` to set its name
     pub fn find_validator(&self, slot_id: usize) -> PyResult<&T> {
         match self.slots.get(slot_id) {
             Some(slot) => match slot.op_val_ser {

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -323,4 +323,17 @@ impl Validator for ArgumentsValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        self.parameters
+            .iter_mut()
+            .try_for_each(|parameter| parameter.validator.complete(build_context))?;
+        if let Some(v) = &mut self.var_args_validator {
+            v.complete(build_context)?;
+        }
+        if let Some(v) = &mut self.var_kwargs_validator {
+            v.complete(build_context)?;
+        };
+        Ok(())
+    }
 }

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -85,4 +85,12 @@ impl Validator for CallValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        self.arguments_validator.complete(build_context)?;
+        match &mut self.return_validator {
+            Some(v) => v.complete(build_context),
+            None => Ok(()),
+        }
+    }
 }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -295,6 +295,12 @@ impl Validator for DataclassArgsValidator {
         &self.validator_name
     }
 
+    fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        self.fields
+            .iter_mut()
+            .try_for_each(|field| field.validator.complete(build_context))
+    }
+
     fn validate_assignment<'s, 'data: 's>(
         &'s self,
         py: Python<'data>,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -641,7 +641,7 @@ pub trait Validator: Send + Sync + Clone + Debug {
     }
 
     /// this method must be implemented for any validator which holds references to other validators,
-    /// it is used by `RecursiveRefValidator` to set its name
+    /// it is used by `DefinitionRefValidator` to set its name
     fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
         Ok(())
     }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -128,6 +128,10 @@ impl Validator for ModelValidator {
         &self.name
     }
 
+    fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        self.validator.complete(build_context)
+    }
+
     fn validate_assignment<'s, 'data: 's>(
         &'s self,
         py: Python<'data>,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -230,6 +230,10 @@ impl Validator for TuplePositionalValidator {
     fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
         self.items_validators
             .iter_mut()
-            .try_for_each(|v| v.complete(build_context))
+            .try_for_each(|v| v.complete(build_context))?;
+        match &mut self.extra_validator {
+            Some(v) => v.complete(build_context),
+            None => Ok(()),
+        }
     }
 }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -326,7 +326,11 @@ impl Validator for TypedDictValidator {
     fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
         self.fields
             .iter_mut()
-            .try_for_each(|f| f.validator.complete(build_context))
+            .try_for_each(|f| f.validator.complete(build_context))?;
+        match &mut self.extra_validator {
+            Some(v) => v.complete(build_context),
+            None => Ok(()),
+        }
     }
 
     fn validate_assignment<'s, 'data: 's>(


### PR DESCRIPTION
This resolves the issue of some definitions refs not getting updated properly.

The issue in pydantic only required the fix for ModelValidator, but the comments where this stuff is used seemed to indicate that _every_ contained validator should have `complete` called. So I went through all the files and made sure this was done (many were missing this).

I think it might be preferable if you had to explicitly define the `fn complete` for each Validator type and didn't get a default for free, but I don't know how hard that would be to refactor. (Yes there would be a bunch of trivial implementations but I feel that's less likely to cause errors than forgetting to "complete" a new validator type.)

Alternatively I guess it could make sense to refactor so this "completion" wasn't necessary, if that's even possible, but I also don't know how hard that would be.