### PR TITLE
Change args to list

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1278,7 +1278,7 @@ class TuplePositionalSchema(TypedDict, total=False):
 
 
 def tuple_positional_schema(
-    *items_schema: CoreSchema,
+    items_schema: list[CoreSchema],
     extra_schema: CoreSchema | None = None,
     strict: bool | None = None,
     ref: str | None = None,
@@ -1292,7 +1292,7 @@ def tuple_positional_schema(
     from pydantic_core import SchemaValidator, core_schema
 
     schema = core_schema.tuple_positional_schema(
-        core_schema.int_schema(), core_schema.str_schema()
+        [core_schema.int_schema(), core_schema.str_schema()]
     )
     v = SchemaValidator(schema)
     assert v.validate_python((1, 'hello')) == (1, 'hello')
@@ -1311,7 +1311,7 @@ def tuple_positional_schema(
     """
     return dict_not_none(
         type='tuple-positional',
-        items_schema=list(items_schema),
+        items_schema=items_schema,
         extra_schema=extra_schema,
         strict=strict,
         ref=ref,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2831,7 +2831,7 @@ def arguments_parameter(
     param = core_schema.arguments_parameter(
         name='a', schema=core_schema.str_schema(), mode='positional_only'
     )
-    schema = core_schema.arguments_schema(param)
+    schema = core_schema.arguments_schema([param])
     v = SchemaValidator(schema)
     assert v.validate_python(('hello',)) == (('hello',), {})
     ```
@@ -2857,7 +2857,7 @@ class ArgumentsSchema(TypedDict, total=False):
 
 
 def arguments_schema(
-    *arguments: ArgumentsParameter,
+    arguments: list[ArgumentsParameter],
     populate_by_name: bool | None = None,
     var_args_schema: CoreSchema | None = None,
     var_kwargs_schema: CoreSchema | None = None,
@@ -2877,7 +2877,7 @@ def arguments_schema(
     param_b = core_schema.arguments_parameter(
         name='b', schema=core_schema.bool_schema(), mode='positional_only'
     )
-    schema = core_schema.arguments_schema(param_a, param_b)
+    schema = core_schema.arguments_schema([param_a, param_b])
     v = SchemaValidator(schema)
     assert v.validate_python(('hello', True)) == (('hello', True), {})
     ```
@@ -2893,7 +2893,7 @@ def arguments_schema(
     """
     return dict_not_none(
         type='arguments',
-        arguments_schema=list(arguments),
+        arguments_schema=arguments,
         populate_by_name=populate_by_name,
         var_args_schema=var_args_schema,
         var_kwargs_schema=var_kwargs_schema,
@@ -2934,7 +2934,7 @@ def call_schema(
     param_b = core_schema.arguments_parameter(
         name='b', schema=core_schema.bool_schema(), mode='positional_only'
     )
-    args_schema = core_schema.arguments_schema(param_a, param_b)
+    args_schema = core_schema.arguments_schema([param_a, param_b])
 
     schema = core_schema.call_schema(
         arguments=args_schema,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2209,7 +2209,7 @@ def union_schema(
     ```
 
     Args:
-        *choices: The schemas to match
+        choices: The schemas to match
         auto_collapse: whether to automatically collapse unions with one element to the inner validator, default true
         custom_error_type: The custom error type to use if the validation fails
         custom_error_message: The custom error message to use if the validation fails

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -1037,7 +1037,7 @@ class LiteralSchema(TypedDict, total=False):
 
 
 def literal_schema(
-    *expected: Any, ref: str | None = None, metadata: Any = None, serialization: SerSchema | None = None
+    expected: list[Any], ref: str | None = None, metadata: Any = None, serialization: SerSchema | None = None
 ) -> LiteralSchema:
     """
     Returns a schema that matches a literal value, e.g.:
@@ -1045,7 +1045,7 @@ def literal_schema(
     ```py
     from pydantic_core import SchemaValidator, core_schema
 
-    schema = core_schema.literal_schema('hello', 'world')
+    schema = core_schema.literal_schema(['hello', 'world'])
     v = SchemaValidator(schema)
     assert v.validate_python('hello') == 'hello'
     ```
@@ -1056,9 +1056,7 @@ def literal_schema(
         metadata: See [TODO] for details
         serialization: Custom serialization schema
     """
-    return dict_not_none(
-        type='literal', expected=list(expected), ref=ref, metadata=metadata, serialization=serialization
-    )
+    return dict_not_none(type='literal', expected=expected, ref=ref, metadata=metadata, serialization=serialization)
 
 
 # must match input/parse_json.rs::JsonType::try_from

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2188,7 +2188,7 @@ class UnionSchema(TypedDict, total=False):
 
 
 def union_schema(
-    *choices: CoreSchema,
+    choices: list[CoreSchema],
     auto_collapse: bool | None = None,
     custom_error_type: str | None = None,
     custom_error_message: str | None = None,
@@ -2204,7 +2204,7 @@ def union_schema(
     ```py
     from pydantic_core import SchemaValidator, core_schema
 
-    schema = core_schema.union_schema(core_schema.str_schema(), core_schema.int_schema())
+    schema = core_schema.union_schema([core_schema.str_schema(), core_schema.int_schema()])
     v = SchemaValidator(schema)
     assert v.validate_python('hello') == 'hello'
     assert v.validate_python(1) == 1
@@ -2223,7 +2223,7 @@ def union_schema(
     """
     return dict_not_none(
         type='union',
-        choices=list(choices),
+        choices=choices,
         auto_collapse=auto_collapse,
         custom_error_type=custom_error_type,
         custom_error_message=custom_error_message,

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2343,7 +2343,7 @@ class ChainSchema(TypedDict, total=False):
 
 
 def chain_schema(
-    *steps: CoreSchema, ref: str | None = None, metadata: Any = None, serialization: SerSchema | None = None
+    steps: list[CoreSchema], ref: str | None = None, metadata: Any = None, serialization: SerSchema | None = None
 ) -> ChainSchema:
     """
     Returns a schema that chains the provided validation schemas, e.g.:
@@ -2357,7 +2357,7 @@ def chain_schema(
 
     fn_schema = core_schema.general_plain_validator_function(function=fn)
     schema = core_schema.chain_schema(
-        fn_schema, fn_schema, fn_schema, core_schema.str_schema()
+        [fn_schema, fn_schema, fn_schema, core_schema.str_schema()]
     )
     v = SchemaValidator(schema)
     assert v.validate_python('hello') == 'hello world world world'
@@ -2369,7 +2369,7 @@ def chain_schema(
         metadata: See [TODO] for details
         serialization: Custom serialization schema
     """
-    return dict_not_none(type='chain', steps=list(steps), ref=ref, metadata=metadata, serialization=serialization)
+    return dict_not_none(type='chain', steps=steps, ref=ref, metadata=metadata, serialization=serialization)
 
 
 class LaxOrStrictSchema(TypedDict, total=False):

--- a/tests/serializers/test_definitions.py
+++ b/tests/serializers/test_definitions.py
@@ -45,9 +45,11 @@ def test_repeated_ref():
     with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
         SchemaSerializer(
             core_schema.tuple_positional_schema(
-                core_schema.int_schema(ref='foobar'),
-                core_schema.definition_reference_schema('foobar'),
-                core_schema.int_schema(ref='foobar'),
+                [
+                    core_schema.int_schema(ref='foobar'),
+                    core_schema.definition_reference_schema('foobar'),
+                    core_schema.int_schema(ref='foobar'),
+                ]
             )
         )
 
@@ -56,11 +58,13 @@ def test_repeat_after():
     with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
         SchemaSerializer(
             core_schema.tuple_positional_schema(
-                core_schema.definitions_schema(
-                    core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
-                    [core_schema.int_schema(ref='foobar')],
-                ),
-                core_schema.int_schema(ref='foobar'),
+                [
+                    core_schema.definitions_schema(
+                        core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
+                        [core_schema.int_schema(ref='foobar')],
+                    ),
+                    core_schema.int_schema(ref='foobar'),
+                ]
             )
         )
 
@@ -94,15 +98,17 @@ def test_deep():
 def test_use_after():
     v = SchemaSerializer(
         core_schema.tuple_positional_schema(
-            core_schema.definitions_schema(
+            [
+                core_schema.definitions_schema(
+                    core_schema.definition_reference_schema('foobar'),
+                    [
+                        core_schema.int_schema(
+                            ref='foobar', serialization=core_schema.to_string_ser_schema(when_used='always')
+                        )
+                    ],
+                ),
                 core_schema.definition_reference_schema('foobar'),
-                [
-                    core_schema.int_schema(
-                        ref='foobar', serialization=core_schema.to_string_ser_schema(when_used='always')
-                    )
-                ],
-            ),
-            core_schema.definition_reference_schema('foobar'),
+            ]
         )
     )
     assert v.to_python((1, 2)) == ('1', '2')

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -377,7 +377,7 @@ def test_tuple_pos_dict_key():
     s = SchemaSerializer(
         core_schema.dict_schema(
             core_schema.tuple_positional_schema(
-                core_schema.int_schema(), core_schema.str_schema(), extra_schema=core_schema.int_schema()
+                [core_schema.int_schema(), core_schema.str_schema()], extra_schema=core_schema.int_schema()
             ),
             core_schema.int_schema(),
         )

--- a/tests/serializers/test_literal.py
+++ b/tests/serializers/test_literal.py
@@ -6,7 +6,7 @@ from ..conftest import plain_repr
 
 
 def test_int_literal():
-    s = SchemaSerializer(core_schema.literal_schema(1, 2, 3))
+    s = SchemaSerializer(core_schema.literal_schema([1, 2, 3]))
     r = plain_repr(s)
     assert 'expected_int:{' in r
     assert 'expected_str:{}' in r
@@ -25,7 +25,7 @@ def test_int_literal():
 
 
 def test_str_literal():
-    s = SchemaSerializer(core_schema.literal_schema('a', 'b', 'c'))
+    s = SchemaSerializer(core_schema.literal_schema(['a', 'b', 'c']))
     r = plain_repr(s)
     assert 'expected_str:{' in r
     assert 'expected_int:{}' in r
@@ -44,7 +44,7 @@ def test_str_literal():
 
 
 def test_other_literal():
-    s = SchemaSerializer(core_schema.literal_schema('a', 1))
+    s = SchemaSerializer(core_schema.literal_schema(['a', 1]))
     assert 'expected_int:{1},expected_str:{"a"},expected_py:None' in plain_repr(s)
 
     assert s.to_python('a') == 'a'
@@ -60,4 +60,4 @@ def test_other_literal():
 
 def test_empty_literal():
     with pytest.raises(SchemaError, match='`expected` should have length > 0'):
-        SchemaSerializer(core_schema.literal_schema())
+        SchemaSerializer(core_schema.literal_schema([]))

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -65,10 +65,12 @@ class DataClass:
 def test_dataclass():
     schema = core_schema.call_schema(
         core_schema.arguments_schema(
-            core_schema.arguments_parameter('foo', core_schema.int_schema()),
-            core_schema.arguments_parameter('bar', core_schema.str_schema()),
-            core_schema.arguments_parameter('spam', core_schema.bytes_schema(), mode='keyword_only'),
-            core_schema.arguments_parameter('frog', core_schema.int_schema(), mode='keyword_only'),
+            [
+                core_schema.arguments_parameter('foo', core_schema.int_schema()),
+                core_schema.arguments_parameter('bar', core_schema.str_schema()),
+                core_schema.arguments_parameter('spam', core_schema.bytes_schema(), mode='keyword_only'),
+                core_schema.arguments_parameter('frog', core_schema.int_schema(), mode='keyword_only'),
+            ]
         ),
         DataClass,
         serialization=core_schema.model_ser_schema(

--- a/tests/serializers/test_other.py
+++ b/tests/serializers/test_other.py
@@ -6,7 +6,7 @@ from ..conftest import plain_repr
 
 
 def test_chain():
-    s = SchemaSerializer(core_schema.chain_schema(core_schema.str_schema(), core_schema.int_schema()))
+    s = SchemaSerializer(core_schema.chain_schema([core_schema.str_schema(), core_schema.int_schema()]))
 
     # insert_assert(plain_repr(s))
     assert plain_repr(s) == 'SchemaSerializer(serializer=Int(IntSerializer),slots=[])'

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -158,7 +158,7 @@ def test_typed_dict_literal():
             [
                 core_schema.typed_dict_schema(
                     dict(
-                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema('cat')),
+                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema(['cat'])),
                         sound=core_schema.typed_dict_field(
                             core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
                         ),
@@ -166,7 +166,7 @@ def test_typed_dict_literal():
                 ),
                 core_schema.typed_dict_schema(
                     dict(
-                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema('dog')),
+                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema(['dog'])),
                         sound=core_schema.typed_dict_field(
                             core_schema.float_schema(serialization=core_schema.format_ser_schema('0.3f'))
                         ),

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -8,14 +8,14 @@ from pydantic_core import PydanticSerializationUnexpectedValue, SchemaSerializer
 
 @pytest.mark.parametrize('input_value,expected_value', [(True, True), (False, False), (1, 1), (123, 123), (-42, -42)])
 def test_union_bool_int(input_value, expected_value):
-    s = SchemaSerializer(core_schema.union_schema(core_schema.bool_schema(), core_schema.int_schema()))
+    s = SchemaSerializer(core_schema.union_schema([core_schema.bool_schema(), core_schema.int_schema()]))
     assert s.to_python(input_value) == expected_value
     assert s.to_python(input_value, mode='json') == expected_value
     assert s.to_json(input_value) == json.dumps(expected_value).encode()
 
 
 def test_union_error():
-    s = SchemaSerializer(core_schema.union_schema(core_schema.bool_schema(), core_schema.int_schema()))
+    s = SchemaSerializer(core_schema.union_schema([core_schema.bool_schema(), core_schema.int_schema()]))
     msg = 'Expected `Union[bool, int]` but got `str` - serialized value may not be as expected'
     with pytest.warns(UserWarning, match=re.escape(msg)):
         assert s.to_python('a string') == 'a string'
@@ -114,7 +114,10 @@ def test_keys():
     s = SchemaSerializer(
         core_schema.dict_schema(
             core_schema.union_schema(
-                core_schema.int_schema(), core_schema.float_schema(serialization=core_schema.format_ser_schema('0.0f'))
+                [
+                    core_schema.int_schema(),
+                    core_schema.float_schema(serialization=core_schema.format_ser_schema('0.0f')),
+                ]
             ),
             core_schema.int_schema(),
         )
@@ -132,10 +135,12 @@ def test_union_of_functions():
 
     s = SchemaSerializer(
         core_schema.union_schema(
-            core_schema.any_schema(
-                serialization=core_schema.general_plain_serializer_function_ser_schema(repr_function)
-            ),
-            core_schema.float_schema(serialization=core_schema.format_ser_schema('_^14')),
+            [
+                core_schema.any_schema(
+                    serialization=core_schema.general_plain_serializer_function_ser_schema(repr_function)
+                ),
+                core_schema.float_schema(serialization=core_schema.format_ser_schema('_^14')),
+            ]
         )
     )
     assert s.to_python('foobar') == "func: 'foobar'"
@@ -150,22 +155,24 @@ def test_union_of_functions():
 def test_typed_dict_literal():
     s = SchemaSerializer(
         core_schema.union_schema(
-            core_schema.typed_dict_schema(
-                dict(
-                    pet_type=core_schema.typed_dict_field(core_schema.literal_schema('cat')),
-                    sound=core_schema.typed_dict_field(
-                        core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
-                    ),
-                )
-            ),
-            core_schema.typed_dict_schema(
-                dict(
-                    pet_type=core_schema.typed_dict_field(core_schema.literal_schema('dog')),
-                    sound=core_schema.typed_dict_field(
-                        core_schema.float_schema(serialization=core_schema.format_ser_schema('0.3f'))
-                    ),
-                )
-            ),
+            [
+                core_schema.typed_dict_schema(
+                    dict(
+                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema('cat')),
+                        sound=core_schema.typed_dict_field(
+                            core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
+                        ),
+                    )
+                ),
+                core_schema.typed_dict_schema(
+                    dict(
+                        pet_type=core_schema.typed_dict_field(core_schema.literal_schema('dog')),
+                        sound=core_schema.typed_dict_field(
+                            core_schema.float_schema(serialization=core_schema.format_ser_schema('0.3f'))
+                        ),
+                    )
+                ),
+            ]
         )
     )
 
@@ -179,15 +186,17 @@ def test_typed_dict_missing():
     """
     s = SchemaSerializer(
         core_schema.union_schema(
-            core_schema.typed_dict_schema(dict(foo=core_schema.typed_dict_field(core_schema.int_schema()))),
-            core_schema.typed_dict_schema(
-                dict(
-                    foo=core_schema.typed_dict_field(
-                        core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
-                    ),
-                    bar=core_schema.typed_dict_field(core_schema.int_schema()),
-                )
-            ),
+            [
+                core_schema.typed_dict_schema(dict(foo=core_schema.typed_dict_field(core_schema.int_schema()))),
+                core_schema.typed_dict_schema(
+                    dict(
+                        foo=core_schema.typed_dict_field(
+                            core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
+                        ),
+                        bar=core_schema.typed_dict_field(core_schema.int_schema()),
+                    )
+                ),
+            ]
         )
     )
 
@@ -205,19 +214,21 @@ def test_typed_dict_extra():
     """
     s = SchemaSerializer(
         core_schema.union_schema(
-            core_schema.typed_dict_schema(
-                dict(
-                    foo=core_schema.typed_dict_field(core_schema.int_schema()),
-                    bar=core_schema.typed_dict_field(core_schema.int_schema()),
-                )
-            ),
-            core_schema.typed_dict_schema(
-                dict(
-                    foo=core_schema.typed_dict_field(
-                        core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
+            [
+                core_schema.typed_dict_schema(
+                    dict(
+                        foo=core_schema.typed_dict_field(core_schema.int_schema()),
+                        bar=core_schema.typed_dict_field(core_schema.int_schema()),
                     )
-                )
-            ),
+                ),
+                core_schema.typed_dict_schema(
+                    dict(
+                        foo=core_schema.typed_dict_field(
+                            core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
+                        )
+                    )
+                ),
+            ]
         )
     )
 
@@ -235,20 +246,22 @@ def test_typed_dict_different_fields():
     """
     s = SchemaSerializer(
         core_schema.union_schema(
-            core_schema.typed_dict_schema(
-                dict(
-                    foo=core_schema.typed_dict_field(core_schema.int_schema()),
-                    bar=core_schema.typed_dict_field(core_schema.int_schema()),
-                )
-            ),
-            core_schema.typed_dict_schema(
-                dict(
-                    spam=core_schema.typed_dict_field(core_schema.int_schema()),
-                    ham=core_schema.typed_dict_field(
-                        core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
-                    ),
-                )
-            ),
+            [
+                core_schema.typed_dict_schema(
+                    dict(
+                        foo=core_schema.typed_dict_field(core_schema.int_schema()),
+                        bar=core_schema.typed_dict_field(core_schema.int_schema()),
+                    )
+                ),
+                core_schema.typed_dict_schema(
+                    dict(
+                        spam=core_schema.typed_dict_field(core_schema.int_schema()),
+                        ham=core_schema.typed_dict_field(
+                            core_schema.int_schema(serialization=core_schema.format_ser_schema('04d'))
+                        ),
+                    )
+                ),
+            ]
         )
     )
 

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -52,7 +52,7 @@ all_schema_functions = [
     (core_schema.time_schema, args(), {'type': 'time'}),
     (core_schema.datetime_schema, args(), {'type': 'datetime'}),
     (core_schema.timedelta_schema, args(), {'type': 'timedelta'}),
-    (core_schema.literal_schema, args('a', 'b'), {'type': 'literal', 'expected': ['a', 'b']}),
+    (core_schema.literal_schema, args(['a', 'b']), {'type': 'literal', 'expected': ['a', 'b']}),
     (core_schema.is_instance_schema, args(int), {'type': 'is-instance', 'cls': int}),
     (core_schema.callable_schema, args(), {'type': 'callable'}),
     (core_schema.list_schema, args(), {'type': 'list'}),

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -151,7 +151,7 @@ all_schema_functions = [
     ),
     (
         core_schema.chain_schema,
-        args({'type': 'int'}, {'type': 'str'}),
+        args([{'type': 'int'}, {'type': 'str'}]),
         {'type': 'chain', 'steps': [{'type': 'int'}, {'type': 'str'}]},
     ),
     (

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -173,8 +173,10 @@ all_schema_functions = [
     (
         core_schema.arguments_schema,
         args(
-            core_schema.arguments_parameter('foo', {'type': 'int'}),
-            core_schema.arguments_parameter('bar', {'type': 'str'}),
+            [
+                core_schema.arguments_parameter('foo', {'type': 'int'}),
+                core_schema.arguments_parameter('bar', {'type': 'str'}),
+            ],
             serialization=core_schema.format_ser_schema('d'),
         ),
         {
@@ -188,7 +190,7 @@ all_schema_functions = [
     ),
     (
         core_schema.call_schema,
-        args(core_schema.arguments_schema(core_schema.arguments_parameter('foo', {'type': 'int'})), val_function),
+        args(core_schema.arguments_schema([core_schema.arguments_parameter('foo', {'type': 'int'})]), val_function),
         {
             'type': 'call',
             'function': val_function,

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -131,12 +131,12 @@ all_schema_functions = [
     (core_schema.nullable_schema, args({'type': 'int'}), {'type': 'nullable', 'schema': {'type': 'int'}}),
     (
         core_schema.union_schema,
-        args({'type': 'int'}, {'type': 'str'}),
+        args([{'type': 'int'}, {'type': 'str'}]),
         {'type': 'union', 'choices': [{'type': 'int'}, {'type': 'str'}]},
     ),
     (
         core_schema.union_schema,
-        args({'type': 'int'}, {'type': 'str'}, custom_error_type='foobar', custom_error_message='This is Foobar'),
+        args([{'type': 'int'}, {'type': 'str'}], custom_error_type='foobar', custom_error_message='This is Foobar'),
         {
             'type': 'union',
             'choices': [{'type': 'int'}, {'type': 'str'}],
@@ -270,14 +270,14 @@ def test_all_schema_functions_used():
 
 
 def test_invalid_custom_error():
-    s = core_schema.union_schema({'type': 'int'}, {'type': 'str'}, custom_error_type='foobar')
+    s = core_schema.union_schema([{'type': 'int'}, {'type': 'str'}], custom_error_type='foobar')
     with pytest.raises(SchemaError, match=r"KeyError: 'custom_error_message'"):
         SchemaValidator(s)
 
 
 def test_invalid_custom_error_type():
     s = core_schema.union_schema(
-        {'type': 'int'}, {'type': 'str'}, custom_error_type='finite_number', custom_error_message='x'
+        [{'type': 'int'}, {'type': 'str'}], custom_error_type='finite_number', custom_error_message='x'
     )
     msg = "custom_error.message should not be provided if 'custom_error_type' matches a known error"
     with pytest.raises(SchemaError, match=msg):

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -59,10 +59,10 @@ all_schema_functions = [
     (core_schema.list_schema, args({'type': 'int'}), {'type': 'list', 'items_schema': {'type': 'int'}}),
     (
         core_schema.tuple_positional_schema,
-        args({'type': 'int'}),
+        args([{'type': 'int'}]),
         {'type': 'tuple-positional', 'items_schema': [{'type': 'int'}]},
     ),
-    (core_schema.tuple_positional_schema, args(), {'type': 'tuple-positional', 'items_schema': []}),
+    (core_schema.tuple_positional_schema, args([]), {'type': 'tuple-positional', 'items_schema': []}),
     (
         core_schema.tuple_variable_schema,
         args({'type': 'int'}),

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -65,10 +65,12 @@ def test_repeated_ref():
     with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
         SchemaValidator(
             core_schema.tuple_positional_schema(
-                core_schema.int_schema(ref='foobar'),
-                # the definition has to be used for it to go into slots/reusable and therefore trigger the error
-                core_schema.definition_reference_schema('foobar'),
-                core_schema.int_schema(ref='foobar'),
+                [
+                    core_schema.int_schema(ref='foobar'),
+                    # the definition has to be used for it to go into slots/reusable and therefore trigger the error
+                    core_schema.definition_reference_schema('foobar'),
+                    core_schema.int_schema(ref='foobar'),
+                ]
             )
         )
 
@@ -77,11 +79,13 @@ def test_repeat_after():
     with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
         SchemaValidator(
             core_schema.tuple_positional_schema(
-                core_schema.definitions_schema(
-                    core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
-                    [core_schema.int_schema(ref='foobar')],
-                ),
-                core_schema.int_schema(ref='foobar'),
+                [
+                    core_schema.definitions_schema(
+                        core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
+                        [core_schema.int_schema(ref='foobar')],
+                    ),
+                    core_schema.int_schema(ref='foobar'),
+                ]
             )
         )
 
@@ -111,10 +115,12 @@ def test_deep():
 def test_use_after():
     v = SchemaValidator(
         core_schema.tuple_positional_schema(
-            core_schema.definitions_schema(
-                core_schema.definition_reference_schema('foobar'), [core_schema.int_schema(ref='foobar')]
-            ),
-            core_schema.definition_reference_schema('foobar'),
+            [
+                core_schema.definitions_schema(
+                    core_schema.definition_reference_schema('foobar'), [core_schema.int_schema(ref='foobar')]
+                ),
+                core_schema.definition_reference_schema('foobar'),
+            ]
         )
     )
     assert v.validate_python(['1', '2']) == (1, 2)

--- a/tests/validators/test_json.py
+++ b/tests/validators/test_json.py
@@ -122,7 +122,7 @@ def test_list_int(py_and_json: PyAndJson, input_value, expected):
 def test_dict_key(py_and_json: PyAndJson):
     v = py_and_json(
         core_schema.dict_schema(
-            core_schema.json_schema(core_schema.tuple_positional_schema(core_schema.int_schema())),
+            core_schema.json_schema(core_schema.tuple_positional_schema([core_schema.int_schema()])),
             core_schema.int_schema(),
         )
     )

--- a/tests/validators/test_literal.py
+++ b/tests/validators/test_literal.py
@@ -163,7 +163,7 @@ def test_build_error():
 
 
 def test_literal_none():
-    v = SchemaValidator(core_schema.literal_schema(None))
+    v = SchemaValidator(core_schema.literal_schema([None]))
     assert v.isinstance_python(None) is True
     assert v.isinstance_python(0) is False
     assert v.isinstance_json('null') is True
@@ -172,7 +172,7 @@ def test_literal_none():
 
 
 def test_union():
-    v = SchemaValidator(core_schema.union_schema([core_schema.literal_schema('a', 'b'), core_schema.int_schema()]))
+    v = SchemaValidator(core_schema.union_schema([core_schema.literal_schema(['a', 'b']), core_schema.int_schema()]))
     assert v.validate_python('a') == 'a'
     assert v.validate_python(4) == 4
     with pytest.raises(ValidationError) as exc_info:
@@ -199,7 +199,7 @@ def test_enum():
     class FooEnum(Enum):
         foo = 'foo_value'
 
-    v = SchemaValidator(core_schema.literal_schema(FooEnum.foo))
+    v = SchemaValidator(core_schema.literal_schema([FooEnum.foo]))
     assert v.validate_python(FooEnum.foo) == FooEnum.foo
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python('foo_value')

--- a/tests/validators/test_literal.py
+++ b/tests/validators/test_literal.py
@@ -172,7 +172,7 @@ def test_literal_none():
 
 
 def test_union():
-    v = SchemaValidator(core_schema.union_schema(core_schema.literal_schema('a', 'b'), core_schema.int_schema()))
+    v = SchemaValidator(core_schema.union_schema([core_schema.literal_schema('a', 'b'), core_schema.int_schema()]))
     assert v.validate_python('a') == 'a'
     assert v.validate_python(4) == 4
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -328,7 +328,7 @@ def test_validate_default():
 def test_validate_default_factory():
     v = SchemaValidator(
         core_schema.tuple_positional_schema(
-            core_schema.with_default_schema(core_schema.int_schema(), default_factory=lambda: '42')
+            [core_schema.with_default_schema(core_schema.int_schema(), default_factory=lambda: '42')]
         ),
         config=dict(validate_default=True),
     )
@@ -339,7 +339,7 @@ def test_validate_default_factory():
 def test_validate_default_error_tuple():
     v = SchemaValidator(
         core_schema.tuple_positional_schema(
-            core_schema.with_default_schema(core_schema.int_schema(), default='wrong', validate_default=True)
+            [core_schema.with_default_schema(core_schema.int_schema(), default='wrong', validate_default=True)]
         )
     )
     assert v.validate_python(('2',)) == (2,)


### PR DESCRIPTION
Could this be the change requested by fix #446?

- Changed all `*args` arguments from `core_schema.py` to use type `list` instead