### PR TITLE
`LazyIndexMap` for JSON objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,6 @@ dependencies = [
  "base64",
  "enum_dispatch",
  "idna",
- "indexmap",
  "mimalloc",
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ strum_macros = "0.24.3"
 serde_json = {version = "1.0.87", features = ["preserve_order"]}
 enum_dispatch = "0.3.8"
 serde = "1.0.147"
-indexmap = "1.9.1"
 mimalloc = { version = "0.1.30", default-features = false, optional = true }
 speedate = "0.7.0"
 ahash = "0.8.0"

--- a/src/input/parse_json.rs
+++ b/src/input/parse_json.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
-use indexmap::IndexMap;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PySet};
 use serde::de::{Deserialize, DeserializeSeed, Error as SerdeError, MapAccess, SeqAccess, Visitor};
+
+use crate::lazy_index_map::LazyIndexMap;
 
 use crate::build_tools::py_err;
 
@@ -58,7 +59,7 @@ pub enum JsonInput {
     Object(JsonObject),
 }
 pub type JsonArray = Vec<JsonInput>;
-pub type JsonObject = IndexMap<String, JsonInput>;
+pub type JsonObject = LazyIndexMap<String, JsonInput>;
 
 impl ToPyObject for JsonInput {
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -159,7 +160,7 @@ impl<'de> Deserialize<'de> for JsonInput {
             {
                 match visitor.next_key_seed(KeyDeserializer)? {
                     Some(first_key) => {
-                        let mut values = IndexMap::new();
+                        let mut values = LazyIndexMap::new();
 
                         values.insert(first_key, visitor.next_value()?);
                         while let Some((key, value)) = visitor.next_entry()? {
@@ -167,7 +168,7 @@ impl<'de> Deserialize<'de> for JsonInput {
                         }
                         Ok(JsonInput::Object(values))
                     }
-                    None => Ok(JsonInput::Object(IndexMap::new())),
+                    None => Ok(JsonInput::Object(LazyIndexMap::new())),
                 }
             }
         }

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::slice::Iter as SliceIter;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -9,8 +10,6 @@ use pyo3::types::{PyBytes, PyDict, PyFrozenSet, PyIterator, PyList, PyMapping, P
 use pyo3::types::PyFunction;
 #[cfg(not(PyPy))]
 use pyo3::PyTypeInfo;
-
-use indexmap::map::Iter;
 
 use crate::errors::{py_err_string, ErrorType, InputValue, ValError, ValLineError, ValResult};
 use crate::recursion_guard::RecursionGuard;
@@ -403,7 +402,7 @@ impl<'py> Iterator for AttributesGenericIterator<'py> {
 }
 
 pub struct JsonObjectGenericIterator<'py> {
-    object_iter: Iter<'py, String, JsonInput>,
+    object_iter: SliceIter<'py, (String, JsonInput)>,
 }
 
 impl<'py> JsonObjectGenericIterator<'py> {
@@ -418,7 +417,7 @@ impl<'py> Iterator for JsonObjectGenericIterator<'py> {
     type Item = ValResult<'py, (&'py String, &'py JsonInput)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.object_iter.next().map(Ok)
+        self.object_iter.next().map(|(key, value)| Ok((key, value)))
     }
     // size_hint is omitted as it isn't needed
 }

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -45,7 +45,8 @@ where
         } else {
             let mut new_map = AHashMap::with_capacity(self.vec.len());
             let mut value = None;
-            for (index, (k, v)) in self.vec.iter().enumerate() {
+            // reverse here so the last value is the one that's returned
+            for (index, (k, v)) in self.vec.iter().enumerate().rev() {
                 if value.is_none() && k == key {
                     value = Some(v);
                 }

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -1,0 +1,66 @@
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::cmp::{Eq, PartialEq};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::slice::Iter as SliceIter;
+
+use ahash::AHashMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct LazyIndexMap<K, V> {
+    vec: Vec<(K, V)>,
+    map: RefCell<Option<AHashMap<K, usize>>>,
+}
+
+/// Like [IndexMap](https://docs.rs/indexmap/latest/indexmap/) but only builds the lookup map when it's needed.
+impl<K, V> LazyIndexMap<K, V>
+where
+    K: Clone + Debug + Eq + Hash,
+    V: Clone + Debug,
+{
+    pub fn new() -> Self {
+        Self {
+            vec: Vec::new(),
+            map: RefCell::new(None),
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.vec.push((key, value))
+    }
+
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q> + PartialEq<Q>,
+        Q: Hash + Eq,
+    {
+        let mut map = self.map.borrow_mut();
+        if let Some(map) = map.as_ref() {
+            if let Some(index) = map.get(key) {
+                return Some(&self.vec[*index].1);
+            }
+        }
+        if let Some((index, (k, v))) = self.vec.iter().enumerate().find(|(_, (k, _))| k == key) {
+            if map.is_none() {
+                *map = Some(AHashMap::with_capacity(self.vec.len()));
+            }
+            map.as_mut().unwrap().insert(k.clone(), index);
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.vec.iter().map(|(k, _)| k)
+    }
+
+    pub fn iter(&self) -> SliceIter<'_, (K, V)> {
+        self.vec.iter()
+    }
+}

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -41,18 +41,18 @@ where
     {
         let mut map = self.map.borrow_mut();
         if let Some(map) = map.as_ref() {
-            if let Some(index) = map.get(key) {
-                return Some(&self.vec[*index].1);
-            }
-        }
-        if let Some((index, (k, v))) = self.vec.iter().enumerate().find(|(_, (k, _))| k == key) {
-            if map.is_none() {
-                *map = Some(AHashMap::with_capacity(self.vec.len()));
-            }
-            map.as_mut().unwrap().insert(k.clone(), index);
-            Some(v)
+            map.get(key).map(|&i| &self.vec[i].1)
         } else {
-            None
+            let mut new_map = AHashMap::with_capacity(self.vec.len());
+            let mut value = None;
+            for (index, (k, v)) in self.vec.iter().enumerate() {
+                if value.is_none() && k == key {
+                    value = Some(v);
+                }
+                new_map.insert(k.clone(), index);
+            }
+            *map = Some(new_map);
+            value
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod build_context;
 mod build_tools;
 mod errors;
 mod input;
+mod lazy_index_map;
 mod lookup_key;
 mod questions;
 mod recursion_guard;

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -92,7 +93,7 @@ def test_float(input_value, expected):
         assert v.validate_json(input_value) == expected
 
 
-def test_model():
+def test_typed_dict():
     v = SchemaValidator(
         {
             'type': 'typed-dict',
@@ -106,6 +107,10 @@ def test_model():
     # language=json
     input_str = '{"field_a": "abc", "field_b": 1}'
     assert v.validate_json(input_str) == {'field_a': 'abc', 'field_b': 1}
+    # language=json
+    input_str = '{"field_a": "a", "field_a": "b", "field_b": 1}'
+    assert v.validate_json(input_str) == {'field_a': 'b', 'field_b': 1}
+    assert v.validate_json(input_str) == {'field_a': 'b', 'field_b': 1}
 
 
 def test_float_no_remainder():
@@ -144,7 +149,8 @@ def test_dict():
     v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_json('{"1": 2, "3": 4}') == {1: 2, 3: 4}
 
-    # duplicate keys are not allowed
+    # duplicate keys, the last value wins, like with python
+    assert json.loads('{"1": 1, "1": 2}') == {'1': 2}
     assert v.validate_json('{"1": 1, "1": 2}') == {1: 2}
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -144,6 +144,9 @@ def test_dict():
     v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_json('{"1": 2, "3": 4}') == {1: 2, 3: 4}
 
+    # duplicate keys are not allowed
+    assert v.validate_json('{"1": 1, "1": 2}') == {1: 2}
+
 
 def test_dict_any_value():
     v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'str'}})


### PR DESCRIPTION
Until now we used [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/) to represent a JSON object which has behavior like a python dict - hashing with order preserved. It does this by using a `Vec<(KeyType, ValueType)>` and a `HashMap<(KeyType, usize)>`.

The point is that in some scenarios we don't need the `HashMap` e.g. when validating a `dict[x, y]`, so this type defers creating the hashmap until it's needed.

Other advantages:
* when we do build the hashmap, we know how big it needs to be
* we use `AHashMap` which is significantly faster

Like before (and like with `import json; json.loads()`), when there are repeated keys in JSON objects, the last value "wins".