### PR TITLE
Make Validator::complete required

### DIFF
--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -39,4 +39,8 @@ impl Validator for AnyValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -45,4 +45,8 @@ impl Validator for BoolValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -52,6 +52,10 @@ impl Validator for BytesValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -89,6 +93,10 @@ impl Validator for BytesConstrainedValidator {
 
     fn get_name(&self) -> &str {
         "constrained-bytes"
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -40,4 +40,8 @@ impl Validator for CallableValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -513,6 +513,10 @@ impl Validator for DataclassValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        self.validator.complete(_build_context)
+    }
 }
 
 impl DataclassValidator {

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -101,6 +101,10 @@ impl Validator for DateValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 /// In lax mode, if the input is not a date, we try parsing the input as a datetime, then check it is an

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -105,6 +105,10 @@ impl Validator for DateTimeValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -78,6 +78,10 @@ impl Validator for FloatValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -140,6 +144,10 @@ impl Validator for ConstrainedFloatValidator {
     }
     fn get_name(&self) -> &str {
         "constrained-float"
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -203,6 +203,10 @@ impl Validator for FunctionPlainValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -54,6 +54,10 @@ impl Validator for IntValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +115,10 @@ impl Validator for ConstrainedIntValidator {
 
     fn get_name(&self) -> &str {
         "constrained-int"
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -93,4 +93,8 @@ impl Validator for IsInstanceValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -64,4 +64,8 @@ impl Validator for IsSubclassValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -91,6 +91,10 @@ impl Validator for LiteralSingleStringValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -132,6 +136,10 @@ impl Validator for LiteralSingleIntValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 
@@ -188,6 +196,10 @@ impl Validator for LiteralMultipleStringsValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -242,6 +254,10 @@ impl Validator for LiteralMultipleIntsValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 
@@ -324,6 +340,10 @@ impl Validator for LiteralGeneralValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -642,7 +642,5 @@ pub trait Validator: Send + Sync + Clone + Debug {
 
     /// this method must be implemented for any validator which holds references to other validators,
     /// it is used by `DefinitionRefValidator` to set its name
-    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
-        Ok(())
-    }
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()>;
 }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -40,4 +40,8 @@ impl Validator for NoneValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -51,6 +51,10 @@ impl Validator for StrValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 /// Any new properties set here must be reflected in `has_constraints_set`
@@ -117,6 +121,10 @@ impl Validator for StrConstrainedValidator {
 
     fn get_name(&self) -> &str {
         "constrained-str"
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -93,6 +93,10 @@ impl Validator for TimeValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 fn convert_pytime(schema: &PyDict, field: &PyString) -> PyResult<Option<Time>> {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -92,6 +92,10 @@ impl Validator for TimeDeltaValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 fn py_timedelta_as_timedelta(schema: &PyDict, field: &PyString) -> PyResult<Option<Duration>> {

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -89,6 +89,10 @@ impl Validator for UrlValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
 }
 
 impl UrlValidator {
@@ -204,6 +208,10 @@ impl Validator for MultiHostUrlValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn complete(&mut self, _build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic-core/issues/496

I think only `DataclassValidator` was referencing other validators.