### PR TITLE
Add ultra-strict mode for better union decisions

### DIFF
--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -136,6 +136,7 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
             self.lax_float()
         }
     }
+    fn ultra_strict_float(&self) -> ValResult<f64>;
     fn strict_float(&self) -> ValResult<f64>;
     #[cfg_attr(has_no_coverage, no_coverage)]
     fn lax_float(&self) -> ValResult<f64> {

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -129,8 +129,10 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
         self.strict_int()
     }
 
-    fn validate_float(&self, strict: bool) -> ValResult<f64> {
-        if strict {
+    fn validate_float(&self, strict: bool, ultra_strict: bool) -> ValResult<f64> {
+        if ultra_strict {
+            self.ultra_strict_float()
+        } else if strict {
             self.strict_float()
         } else {
             self.lax_float()

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -144,7 +144,6 @@ impl<'a> Input<'a> for JsonInput {
     fn strict_float(&self) -> ValResult<f64> {
         match self {
             JsonInput::Float(f) => Ok(*f),
-            JsonInput::Int(i) => Ok(*i as f64),
             _ => Err(ValError::new(ErrorType::FloatType, self)),
         }
     }

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -141,9 +141,16 @@ impl<'a> Input<'a> for JsonInput {
         }
     }
 
+    fn ultra_strict_float(&self) -> ValResult<f64> {
+        match self {
+            JsonInput::Float(f) => Ok(*f),
+            _ => Err(ValError::new(ErrorType::FloatType, self)),
+        }
+    }
     fn strict_float(&self) -> ValResult<f64> {
         match self {
             JsonInput::Float(f) => Ok(*f),
+            JsonInput::Int(i) => Ok(*i as f64),
             _ => Err(ValError::new(ErrorType::FloatType, self)),
         }
     }
@@ -367,6 +374,10 @@ impl<'a> Input<'a> for String {
         }
     }
 
+    #[cfg_attr(has_no_coverage, no_coverage)]
+    fn ultra_strict_float(&self) -> ValResult<f64> {
+        self.strict_float()
+    }
     #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_float(&self) -> ValResult<f64> {
         Err(ValError::new(ErrorType::FloatType, self))

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -4,8 +4,8 @@ use std::str::from_utf8;
 use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFrozenSet, PyIterator, PyList, PyMapping,
-    PySet, PyString, PyTime, PyTuple, PyType,
+    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFrozenSet, PyInt, PyIterator, PyList,
+    PyMapping, PySet, PyString, PyTime, PyTuple, PyType,
 };
 #[cfg(not(PyPy))]
 use pyo3::types::{PyDictItems, PyDictKeys, PyDictValues};
@@ -290,7 +290,7 @@ impl<'a> Input<'a> for PyAny {
     }
 
     fn strict_float(&self) -> ValResult<f64> {
-        if self.extract::<bool>().is_ok() {
+        if matches!(self.is_instance_of::<PyInt>(), Ok(true)) {
             Err(ValError::new(ErrorType::FloatType, self))
         } else if let Ok(float) = self.extract::<f64>() {
             Ok(float)

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -289,7 +289,7 @@ impl<'a> Input<'a> for PyAny {
         }
     }
 
-    fn strict_float(&self) -> ValResult<f64> {
+    fn ultra_strict_float(&self) -> ValResult<f64> {
         if matches!(self.is_instance_of::<PyInt>(), Ok(true)) {
             Err(ValError::new(ErrorType::FloatType, self))
         } else if let Ok(float) = self.extract::<f64>() {
@@ -298,7 +298,15 @@ impl<'a> Input<'a> for PyAny {
             Err(ValError::new(ErrorType::FloatType, self))
         }
     }
-
+    fn strict_float(&self) -> ValResult<f64> {
+        if self.extract::<bool>().is_ok() {
+            Err(ValError::new(ErrorType::FloatType, self))
+        } else if let Ok(float) = self.extract::<f64>() {
+            Ok(float)
+        } else {
+            Err(ValError::new(ErrorType::FloatType, self))
+        }
+    }
     fn lax_float(&self) -> ValResult<f64> {
         if let Ok(float) = self.extract::<f64>() {
             Ok(float)

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -36,6 +36,10 @@ impl Validator for AnyValidator {
         Ok(input.to_object(py))
     }
 
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        false
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -36,7 +36,11 @@ impl Validator for AnyValidator {
         Ok(input.to_object(py))
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         false
     }
 

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -326,6 +326,12 @@ impl Validator for ArgumentsValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.parameters
+            .iter()
+            .any(|p| p.validator.different_strict_behavior(ultra_strict))
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -326,10 +326,14 @@ impl Validator for ArgumentsValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         self.parameters
             .iter()
-            .any(|p| p.validator.different_strict_behavior(ultra_strict))
+            .any(|p| p.validator.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -42,6 +42,10 @@ impl Validator for BoolValidator {
         Ok(input.validate_bool(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -42,7 +42,11 @@ impl Validator for BoolValidator {
         Ok(input.validate_bool(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -49,7 +49,11 @@ impl Validator for BytesValidator {
         Ok(either_bytes.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -95,7 +99,11 @@ impl Validator for BytesConstrainedValidator {
         Ok(either_bytes.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -49,6 +49,10 @@ impl Validator for BytesValidator {
         Ok(either_bytes.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
@@ -89,6 +93,10 @@ impl Validator for BytesConstrainedValidator {
         }
 
         Ok(either_bytes.into_py(py))
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -81,6 +81,15 @@ impl Validator for CallValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if let Some(return_validator) = &self.return_validator {
+            if return_validator.different_strict_behavior(ultra_strict) {
+                return true;
+            }
+        }
+        self.arguments_validator.different_strict_behavior(ultra_strict)
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -81,13 +81,18 @@ impl Validator for CallValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if let Some(return_validator) = &self.return_validator {
-            if return_validator.different_strict_behavior(ultra_strict) {
+            if return_validator.different_strict_behavior(build_context, ultra_strict) {
                 return true;
             }
         }
-        self.arguments_validator.different_strict_behavior(ultra_strict)
+        self.arguments_validator
+            .different_strict_behavior(build_context, ultra_strict)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -37,6 +37,10 @@ impl Validator for CallableValidator {
         }
     }
 
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        false
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -37,7 +37,11 @@ impl Validator for CallableValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         false
     }
 

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -85,6 +85,10 @@ impl Validator for ChainValidator {
         })
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.steps.iter().any(|v| v.different_strict_behavior(ultra_strict))
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -85,8 +85,14 @@ impl Validator for ChainValidator {
         })
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.steps.iter().any(|v| v.different_strict_behavior(ultra_strict))
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.steps
+            .iter()
+            .any(|v| v.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -97,8 +97,12 @@ impl Validator for CustomErrorValidator {
             .map_err(|_| self.custom_error.as_val_error(input))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.validator.different_strict_behavior(ultra_strict)
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.validator.different_strict_behavior(build_context, ultra_strict)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -97,6 +97,10 @@ impl Validator for CustomErrorValidator {
             .map_err(|_| self.custom_error.as_val_error(input))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -380,6 +380,12 @@ impl Validator for DataclassArgsValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.fields
+            .iter()
+            .any(|f| f.validator.different_strict_behavior(ultra_strict))
+    }
+
     fn get_name(&self) -> &str {
         &self.validator_name
     }
@@ -508,6 +514,14 @@ impl Validator for DataclassValidator {
         force_setattr(py, obj, dict_py_str, dc_dict)?;
 
         Ok(obj.to_object(py))
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            self.validator.different_strict_behavior(ultra_strict)
+        } else {
+            true
+        }
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -380,10 +380,14 @@ impl Validator for DataclassArgsValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         self.fields
             .iter()
-            .any(|f| f.validator.different_strict_behavior(ultra_strict))
+            .any(|f| f.validator.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {
@@ -516,9 +520,13 @@ impl Validator for DataclassValidator {
         Ok(obj.to_object(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(ultra_strict)
+            self.validator.different_strict_behavior(build_context, ultra_strict)
         } else {
             true
         }

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -98,6 +98,10 @@ impl Validator for DateValidator {
         Ok(date.try_into_py(py)?)
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -98,7 +98,11 @@ impl Validator for DateValidator {
         Ok(date.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -102,6 +102,10 @@ impl Validator for DateTimeValidator {
         Ok(datetime.try_into_py(py)?)
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -102,7 +102,11 @@ impl Validator for DateTimeValidator {
         Ok(datetime.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -107,9 +107,18 @@ impl Validator for DefinitionRefValidator {
         }
     }
 
-    /// TODO!
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        !ultra_strict
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        if let Some(build_context) = build_context {
+            // have to unwrap here, because we can't return an error from this function, should be okay
+            let validator = build_context.find_validator(self.validator_id).unwrap();
+            validator.different_strict_behavior(None, ultra_strict)
+        } else {
+            false
+        }
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -107,6 +107,11 @@ impl Validator for DefinitionRefValidator {
         }
     }
 
+    /// TODO!
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         &self.inner_name
     }

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -80,9 +80,14 @@ impl Validator for DictValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            self.key_validator.different_strict_behavior(true) || self.value_validator.different_strict_behavior(true)
+            self.key_validator.different_strict_behavior(build_context, true)
+                || self.value_validator.different_strict_behavior(build_context, true)
         } else {
             true
         }

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -80,6 +80,14 @@ impl Validator for DictValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            self.key_validator.different_strict_behavior(true) || self.value_validator.different_strict_behavior(true)
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -68,11 +68,19 @@ impl Validator for FloatValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let float = input.validate_float(extra.strict.unwrap_or(self.strict))?;
+        let float = if extra.ultra_strict {
+            input.ultra_strict_float()?
+        } else {
+            input.validate_float(extra.strict.unwrap_or(self.strict))?
+        };
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
         Ok(float.into_py(py))
+    }
+
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        true
     }
 
     fn get_name(&self) -> &str {
@@ -104,7 +112,11 @@ impl Validator for ConstrainedFloatValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let float = input.validate_float(extra.strict.unwrap_or(self.strict))?;
+        let float = if extra.ultra_strict {
+            input.ultra_strict_float()?
+        } else {
+            input.validate_float(extra.strict.unwrap_or(self.strict))?
+        };
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
@@ -142,6 +154,11 @@ impl Validator for ConstrainedFloatValidator {
         }
         Ok(float.into_py(py))
     }
+
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        true
+    }
+
     fn get_name(&self) -> &str {
         "constrained-float"
     }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -68,11 +68,7 @@ impl Validator for FloatValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let float = if extra.ultra_strict {
-            input.ultra_strict_float()?
-        } else {
-            input.validate_float(extra.strict.unwrap_or(self.strict))?
-        };
+        let float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
@@ -116,11 +112,7 @@ impl Validator for ConstrainedFloatValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let float = if extra.ultra_strict {
-            input.ultra_strict_float()?
-        } else {
-            input.validate_float(extra.strict.unwrap_or(self.strict))?
-        };
+        let float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -79,7 +79,11 @@ impl Validator for FloatValidator {
         Ok(float.into_py(py))
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         true
     }
 
@@ -155,7 +159,11 @@ impl Validator for ConstrainedFloatValidator {
         Ok(float.into_py(py))
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         true
     }
 

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -60,6 +60,17 @@ impl Validator for FrozenSetValidator {
         Ok(f_set.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            match self.item_validator {
+                Some(ref v) => v.different_strict_behavior(true),
+                None => false,
+            }
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -60,10 +60,14 @@ impl Validator for FrozenSetValidator {
         Ok(f_set.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(true),
+                Some(ref v) => v.different_strict_behavior(build_context, true),
                 None => false,
             }
         } else {

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -94,9 +94,14 @@ macro_rules! impl_validator {
                 self._validate(validate, py, obj, extra)
             }
 
-            fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+            fn different_strict_behavior(
+                &self,
+                build_context: Option<&BuildContext<CombinedValidator>>,
+                ultra_strict: bool,
+            ) -> bool {
                 if ultra_strict {
-                    self.validator.different_strict_behavior(ultra_strict)
+                    self.validator
+                        .different_strict_behavior(build_context, ultra_strict)
                 } else {
                     true
                 }
@@ -234,7 +239,11 @@ impl Validator for FunctionPlainValidator {
         r.map_err(|e| convert_err(py, e, input))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         // best guess, should we change this?
         !ultra_strict
     }
@@ -316,9 +325,13 @@ impl Validator for FunctionWrapValidator {
         self._validate(Py::new(py, handler)?.into_ref(py), py, obj, extra)
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(ultra_strict)
+            self.validator.different_strict_behavior(build_context, ultra_strict)
         } else {
             true
         }

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -94,6 +94,14 @@ macro_rules! impl_validator {
                 self._validate(validate, py, obj, extra)
             }
 
+            fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+                if ultra_strict {
+                    self.validator.different_strict_behavior(ultra_strict)
+                } else {
+                    true
+                }
+            }
+
             fn get_name(&self) -> &str {
                 &self.name
             }
@@ -226,6 +234,11 @@ impl Validator for FunctionPlainValidator {
         r.map_err(|e| convert_err(py, e, input))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        // best guess, should we change this?
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -301,6 +314,14 @@ impl Validator for FunctionWrapValidator {
             updated_field_value: field_value.to_object(py),
         };
         self._validate(Py::new(py, handler)?.into_ref(py), py, obj, extra)
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            self.validator.different_strict_behavior(ultra_strict)
+        } else {
+            true
+        }
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -68,9 +68,13 @@ impl Validator for GeneratorValidator {
         Ok(v_iterator.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if let Some(ref v) = self.item_validator {
-            v.different_strict_behavior(ultra_strict)
+            v.different_strict_behavior(build_context, ultra_strict)
         } else {
             false
         }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -68,6 +68,14 @@ impl Validator for GeneratorValidator {
         Ok(v_iterator.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if let Some(ref v) = self.item_validator {
+            v.different_strict_behavior(ultra_strict)
+        } else {
+            false
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -238,6 +246,7 @@ impl InternalValidator {
         let extra = Extra {
             data: self.data.as_ref().map(|data| data.as_ref(py)),
             strict: self.strict,
+            ultra_strict: false,
             context: self.context.as_ref().map(|data| data.as_ref(py)),
             field_name: None,
             self_instance: self.self_instance.as_ref().map(|data| data.as_ref(py)),
@@ -269,6 +278,7 @@ impl InternalValidator {
         let extra = Extra {
             data: self.data.as_ref().map(|data| data.as_ref(py)),
             strict: self.strict,
+            ultra_strict: false,
             context: self.context.as_ref().map(|data| data.as_ref(py)),
             field_name: None,
             self_instance: self.self_instance.as_ref().map(|data| data.as_ref(py)),

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -51,6 +51,10 @@ impl Validator for IntValidator {
         Ok(input.validate_int(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
@@ -111,6 +115,10 @@ impl Validator for ConstrainedIntValidator {
             }
         }
         Ok(int.into_py(py))
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -51,7 +51,11 @@ impl Validator for IntValidator {
         Ok(input.validate_int(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -117,7 +121,11 @@ impl Validator for ConstrainedIntValidator {
         Ok(int.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -90,6 +90,10 @@ impl Validator for IsInstanceValidator {
         }
     }
 
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        false
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -90,7 +90,11 @@ impl Validator for IsInstanceValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         false
     }
 

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -61,6 +61,10 @@ impl Validator for IsSubclassValidator {
         }
     }
 
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        false
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -61,7 +61,11 @@ impl Validator for IsSubclassValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         false
     }
 

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -62,6 +62,14 @@ impl Validator for JsonValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if let Some(ref v) = self.validator {
+            v.different_strict_behavior(ultra_strict)
+        } else {
+            false
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -62,9 +62,13 @@ impl Validator for JsonValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if let Some(ref v) = self.validator {
-            v.different_strict_behavior(ultra_strict)
+            v.different_strict_behavior(build_context, ultra_strict)
         } else {
             false
         }

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -64,9 +64,13 @@ impl Validator for LaxOrStrictValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            self.strict_validator.different_strict_behavior(true)
+            self.strict_validator.different_strict_behavior(build_context, true)
         } else {
             true
         }

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -64,6 +64,14 @@ impl Validator for LaxOrStrictValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            self.strict_validator.different_strict_behavior(true)
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -128,6 +128,17 @@ impl Validator for ListValidator {
         Ok(output.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            match self.item_validator {
+                Some(ref v) => v.different_strict_behavior(true),
+                None => false,
+            }
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -128,10 +128,14 @@ impl Validator for ListValidator {
         Ok(output.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(true),
+                Some(ref v) => v.different_strict_behavior(build_context, true),
                 None => false,
             }
         } else {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -88,6 +88,10 @@ impl Validator for LiteralSingleStringValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -132,6 +136,10 @@ impl Validator for LiteralSingleIntValidator {
                 input,
             ))
         }
+    }
+
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        true
     }
 
     fn get_name(&self) -> &str {
@@ -193,6 +201,10 @@ impl Validator for LiteralMultipleStringsValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -250,6 +262,10 @@ impl Validator for LiteralMultipleIntsValidator {
                 input,
             ))
         }
+    }
+
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        true
     }
 
     fn get_name(&self) -> &str {
@@ -336,6 +352,10 @@ impl Validator for LiteralGeneralValidator {
             },
             input,
         ))
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -88,7 +88,11 @@ impl Validator for LiteralSingleStringValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -138,7 +142,11 @@ impl Validator for LiteralSingleIntValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         true
     }
 
@@ -201,7 +209,11 @@ impl Validator for LiteralMultipleStringsValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -264,7 +276,11 @@ impl Validator for LiteralMultipleIntsValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         true
     }
 
@@ -354,7 +370,11 @@ impl Validator for LiteralGeneralValidator {
         ))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -179,6 +179,7 @@ impl SchemaValidator {
         let extra = Extra {
             data: None,
             strict,
+            ultra_strict: false,
             context,
             field_name: None,
             self_instance: None,
@@ -462,6 +463,8 @@ pub struct Extra<'a> {
     pub field_name: Option<&'a str>,
     /// whether we're in strict or lax mode
     pub strict: Option<bool>,
+    /// whether we're in ultra-strict mode, only used occasionally in unions
+    pub ultra_strict: bool,
     /// context used in validator functions
     pub context: Option<&'a PyAny>,
     /// This is an instance of the model or dataclass being validated, when validation is performed from `__init__`
@@ -480,10 +483,11 @@ impl<'a> Extra<'a> {
 }
 
 impl<'a> Extra<'a> {
-    pub fn as_strict(&self) -> Self {
+    pub fn as_strict(&self, ultra_strict: bool) -> Self {
         Self {
             data: self.data,
             strict: Some(true),
+            ultra_strict,
             context: self.context,
             field_name: self.field_name,
             self_instance: self.self_instance,
@@ -627,6 +631,10 @@ pub trait Validator: Send + Sync + Clone + Debug {
         let py_err = PyTypeError::new_err(format!("validate_assignment is not supported for {}", self.get_name()));
         Err(py_err.into())
     }
+
+    /// whether the validator behaves differently in strict mode, and in ultra strict mode
+    /// implementations should return true if any of their sub-validators return true
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool;
 
     /// `get_name` generally returns `Self::EXPECTED_TYPE` or some other clear identifier of the validator
     /// this is used in the error location in unions, and in the top level message in `ValidationError`

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -634,7 +634,11 @@ pub trait Validator: Send + Sync + Clone + Debug {
 
     /// whether the validator behaves differently in strict mode, and in ultra strict mode
     /// implementations should return true if any of their sub-validators return true
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool;
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool;
 
     /// `get_name` generally returns `Self::EXPECTED_TYPE` or some other clear identifier of the validator
     /// this is used in the error location in unions, and in the top level message in `ValidationError`

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -162,6 +162,14 @@ impl Validator for ModelValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            self.validator.different_strict_behavior(ultra_strict)
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -162,9 +162,13 @@ impl Validator for ModelValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(ultra_strict)
+            self.validator.different_strict_behavior(build_context, ultra_strict)
         } else {
             true
         }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -37,6 +37,10 @@ impl Validator for NoneValidator {
         }
     }
 
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+        false
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -37,7 +37,11 @@ impl Validator for NoneValidator {
         }
     }
 
-    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
         false
     }
 

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -46,8 +46,12 @@ impl Validator for NullableValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.validator.different_strict_behavior(ultra_strict)
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.validator.different_strict_behavior(build_context, ultra_strict)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -46,6 +46,10 @@ impl Validator for NullableValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -90,6 +90,17 @@ impl Validator for SetValidator {
         Ok(set.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            match self.item_validator {
+                Some(ref v) => v.different_strict_behavior(true),
+                None => false,
+            }
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -90,10 +90,14 @@ impl Validator for SetValidator {
         Ok(set.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(true),
+                Some(ref v) => v.different_strict_behavior(build_context, true),
                 None => false,
             }
         } else {

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -48,7 +48,11 @@ impl Validator for StrValidator {
         Ok(input.validate_str(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -123,7 +127,11 @@ impl Validator for StrConstrainedValidator {
         Ok(py_string.into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -48,6 +48,10 @@ impl Validator for StrValidator {
         Ok(input.validate_str(extra.strict.unwrap_or(self.strict))?.into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
@@ -117,6 +121,10 @@ impl Validator for StrConstrainedValidator {
             either_str.as_py_string(py)
         };
         Ok(py_string.into_py(py))
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -90,6 +90,10 @@ impl Validator for TimeValidator {
         Ok(time.try_into_py(py)?)
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -90,7 +90,11 @@ impl Validator for TimeValidator {
         Ok(time.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -89,7 +89,11 @@ impl Validator for TimeDeltaValidator {
         Ok(timedelta.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -89,6 +89,10 @@ impl Validator for TimeDeltaValidator {
         Ok(timedelta.try_into_py(py)?)
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -76,10 +76,14 @@ impl Validator for TupleVariableValidator {
         Ok(PyTuple::new(py, &output).into_py(py))
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(true),
+                Some(ref v) => v.different_strict_behavior(build_context, true),
                 None => false,
             }
         } else {
@@ -234,12 +238,20 @@ impl Validator for TuplePositionalValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         if ultra_strict {
-            if self.items_validators.iter().any(|v| v.different_strict_behavior(true)) {
+            if self
+                .items_validators
+                .iter()
+                .any(|v| v.different_strict_behavior(build_context, true))
+            {
                 true
             } else if let Some(ref v) = self.extra_validator {
-                v.different_strict_behavior(true)
+                v.different_strict_behavior(build_context, true)
             } else {
                 false
             }

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -76,6 +76,17 @@ impl Validator for TupleVariableValidator {
         Ok(PyTuple::new(py, &output).into_py(py))
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            match self.item_validator {
+                Some(ref v) => v.different_strict_behavior(true),
+                None => false,
+            }
+        } else {
+            true
+        }
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -220,6 +231,20 @@ impl Validator for TuplePositionalValidator {
             Ok(PyTuple::new(py, &output).into_py(py))
         } else {
             Err(ValError::LineErrors(errors))
+        }
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        if ultra_strict {
+            if self.items_validators.iter().any(|v| v.different_strict_behavior(true)) {
+                true
+            } else if let Some(ref v) = self.extra_validator {
+                v.different_strict_behavior(true)
+            } else {
+                false
+            }
+        } else {
+            true
         }
     }
 

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -386,6 +386,12 @@ impl Validator for TypedDictValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.fields
+            .iter()
+            .any(|f| f.validator.different_strict_behavior(ultra_strict))
+    }
+
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -386,10 +386,14 @@ impl Validator for TypedDictValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         self.fields
             .iter()
-            .any(|f| f.validator.different_strict_behavior(ultra_strict))
+            .any(|f| f.validator.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -25,6 +25,8 @@ pub struct UnionValidator {
     custom_error: Option<CustomError>,
     strict: bool,
     name: String,
+    strict_required: bool,
+    ultra_strict_required: bool,
 }
 
 impl BuildValidator for UnionValidator {
@@ -54,6 +56,8 @@ impl BuildValidator for UnionValidator {
                     custom_error: CustomError::build(schema, config, build_context)?,
                     strict: is_strict(schema, config)?,
                     name: format!("{}[{descr}]", Self::EXPECTED_TYPE),
+                    strict_required: true,
+                    ultra_strict_required: false,
                 }
                 .into())
             }
@@ -84,12 +88,25 @@ impl Validator for UnionValidator {
         slots: &'data [CombinedValidator],
         recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
+        if self.ultra_strict_required {
+            // do an ultra strict check first
+            let ultra_strict_extra = extra.as_strict(true);
+            if let Some(res) = self
+                .choices
+                .iter()
+                .map(|validator| validator.validate(py, input, &ultra_strict_extra, slots, recursion_guard))
+                .find(ValResult::is_ok)
+            {
+                return res;
+            }
+        }
+
         if extra.strict.unwrap_or(self.strict) {
             let mut errors: Option<Vec<ValLineError>> = match self.custom_error {
                 None => Some(Vec::with_capacity(self.choices.len())),
                 _ => None,
             };
-            let strict_extra = extra.as_strict();
+            let strict_extra = extra.as_strict(false);
 
             for validator in &self.choices {
                 let line_errors = match validator.validate(py, input, &strict_extra, slots, recursion_guard) {
@@ -108,16 +125,18 @@ impl Validator for UnionValidator {
 
             Err(self.or_custom_error(errors, input))
         } else {
-            // 1st pass: check if the value is an exact instance of one of the Union types,
-            // e.g. use validate in strict mode
-            let strict_extra = extra.as_strict();
-            if let Some(res) = self
-                .choices
-                .iter()
-                .map(|validator| validator.validate(py, input, &strict_extra, slots, recursion_guard))
-                .find(ValResult::is_ok)
-            {
-                return res;
+            if self.strict_required {
+                // 1st pass: check if the value is an exact instance of one of the Union types,
+                // e.g. use validate in strict mode
+                let strict_extra = extra.as_strict(false);
+                if let Some(res) = self
+                    .choices
+                    .iter()
+                    .map(|validator| validator.validate(py, input, &strict_extra, slots, recursion_guard))
+                    .find(ValResult::is_ok)
+                {
+                    return res;
+                }
             }
 
             let mut errors: Option<Vec<ValLineError>> = match self.custom_error {
@@ -145,6 +164,10 @@ impl Validator for UnionValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.choices.iter().any(|v| v.different_strict_behavior(ultra_strict))
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -154,7 +177,10 @@ impl Validator for UnionValidator {
     }
 
     fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
-        self.choices.iter_mut().try_for_each(|v| v.complete(build_context))
+        self.choices.iter_mut().try_for_each(|v| v.complete(build_context))?;
+        self.strict_required = self.different_strict_behavior(false);
+        self.ultra_strict_required = self.different_strict_behavior(true);
+        Ok(())
     }
 }
 
@@ -389,6 +415,10 @@ impl Validator for TaggedUnionValidator {
                 recursion_guard,
             ),
         }
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.choices.values().any(|v| v.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -164,8 +164,14 @@ impl Validator for UnionValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.choices.iter().any(|v| v.different_strict_behavior(ultra_strict))
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.choices
+            .iter()
+            .any(|v| v.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {
@@ -178,8 +184,8 @@ impl Validator for UnionValidator {
 
     fn complete(&mut self, build_context: &BuildContext<CombinedValidator>) -> PyResult<()> {
         self.choices.iter_mut().try_for_each(|v| v.complete(build_context))?;
-        self.strict_required = self.different_strict_behavior(false);
-        self.ultra_strict_required = self.different_strict_behavior(true);
+        self.strict_required = self.different_strict_behavior(Some(build_context), false);
+        self.ultra_strict_required = self.different_strict_behavior(Some(build_context), true);
         Ok(())
     }
 }
@@ -417,8 +423,14 @@ impl Validator for TaggedUnionValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.choices.values().any(|v| v.different_strict_behavior(ultra_strict))
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.choices
+            .values()
+            .any(|v| v.different_strict_behavior(build_context, ultra_strict))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -86,6 +86,10 @@ impl Validator for UrlValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -204,6 +208,10 @@ impl Validator for MultiHostUrlValidator {
             Ok(()) => Ok(multi_url.into_py(py)),
             Err(error_type) => return Err(ValError::new(error_type, input)),
         }
+    }
+
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        !ultra_strict
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -86,7 +86,11 @@ impl Validator for UrlValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 
@@ -210,7 +214,11 @@ impl Validator for MultiHostUrlValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+    fn different_strict_behavior(
+        &self,
+        _build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
         !ultra_strict
     }
 

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -145,8 +145,12 @@ impl Validator for WithDefaultValidator {
         }
     }
 
-    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
-        self.validator.different_strict_behavior(ultra_strict)
+    fn different_strict_behavior(
+        &self,
+        build_context: Option<&BuildContext<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        self.validator.different_strict_behavior(build_context, ultra_strict)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -145,6 +145,10 @@ impl Validator for WithDefaultValidator {
         }
     }
 
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
+    }
+
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -42,11 +42,14 @@ def test_float(py_and_json: PyAndJson, input_value, expected):
 @pytest.mark.parametrize(
     'input_value,expected',
     [
-        (0, 0),
-        (1, 1),
-        (42, 42),
+        (0.0, 0.0),
+        (1.0, 1.0),
         (42.0, 42.0),
         (42.5, 42.5),
+        (True, Err('Input should be a valid number [type=float_type, input_value=True, input_type=bool]')),
+        (0, Err('Input should be a valid number [type=float_type, input_value=0, input_type=int]')),
+        (1, Err('Input should be a valid number [type=float_type, input_value=1, input_type=int]')),
+        (42, Err('Input should be a valid number [type=float_type, input_value=42, input_type=int]')),
         ('42', Err("Input should be a valid number [type=float_type, input_value='42', input_type=str]")),
         (True, Err('Input should be a valid number [type=float_type, input_value=True, input_type=bool]')),
     ],
@@ -135,8 +138,9 @@ def test_union_float(py_and_json: PyAndJson):
     v = py_and_json(
         {'type': 'union', 'choices': [{'type': 'float', 'strict': True}, {'type': 'float', 'multiple_of': 7}]}
     )
+    assert v.validate_test(14) == 14
     assert v.validate_test('14') == 14
-    assert v.validate_test(5) == 5
+    assert v.validate_test(5.0) == 5.0
     with pytest.raises(ValidationError) as exc_info:
         v.validate_test('5')
     assert exc_info.value.errors() == [

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -42,14 +42,11 @@ def test_float(py_and_json: PyAndJson, input_value, expected):
 @pytest.mark.parametrize(
     'input_value,expected',
     [
-        (0.0, 0.0),
-        (1.0, 1.0),
+        (0, 0),
+        (1, 1),
+        (42, 42),
         (42.0, 42.0),
         (42.5, 42.5),
-        (True, Err('Input should be a valid number [type=float_type, input_value=True, input_type=bool]')),
-        (0, Err('Input should be a valid number [type=float_type, input_value=0, input_type=int]')),
-        (1, Err('Input should be a valid number [type=float_type, input_value=1, input_type=int]')),
-        (42, Err('Input should be a valid number [type=float_type, input_value=42, input_type=int]')),
         ('42', Err("Input should be a valid number [type=float_type, input_value='42', input_type=str]")),
         (True, Err('Input should be a valid number [type=float_type, input_value=True, input_type=bool]')),
     ],
@@ -138,9 +135,8 @@ def test_union_float(py_and_json: PyAndJson):
     v = py_and_json(
         {'type': 'union', 'choices': [{'type': 'float', 'strict': True}, {'type': 'float', 'multiple_of': 7}]}
     )
-    assert v.validate_test(14) == 14
     assert v.validate_test('14') == 14
-    assert v.validate_test(5.0) == 5.0
+    assert v.validate_test(5) == 5
     with pytest.raises(ValidationError) as exc_info:
         v.validate_test('5')
     assert exc_info.value.errors() == [

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -395,3 +395,22 @@ def test_no_strict_check():
 
     assert v.validate_python(123) == 123
     assert v.validate_python('[1, 2, 3]') == [1, 2, 3]
+
+
+def test_strict_reference():
+    v = SchemaValidator(
+        core_schema.tuple_positional_schema(
+            [
+                core_schema.float_schema(),
+                core_schema.union_schema(
+                    [core_schema.int_schema(), core_schema.definition_reference_schema('tuple-ref')]
+                ),
+            ],
+            ref='tuple-ref',
+        )
+    )
+    assert 'strict_required:true' in plain_repr(v)
+    assert 'ultra_strict_required:true' in plain_repr(v)  # since "float" schema has ultra-strict behaviour
+
+    assert repr(v.validate_python((1, 2))) == '(1.0, 2)'
+    assert repr(v.validate_python((1.0, (2.0, 3)))) == '(1.0, (2.0, 3))'

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import plain_repr
 
@@ -326,3 +326,17 @@ def test_custom_error_type_context():
     assert exc_info.value.errors() == [
         {'type': 'less_than', 'loc': (), 'msg': 'Input should be less than 42', 'input': 123, 'ctx': {'lt': 42.0}}
     ]
+
+
+def test_int_float():
+    v = SchemaValidator(core_schema.union_schema([core_schema.int_schema(), core_schema.float_schema()]))
+    assert repr(v.validate_python(1)) == '1'
+    assert repr(v.validate_json('1')) == '1'
+    assert repr(v.validate_python(1.0)) == '1.0'
+    assert repr(v.validate_json('1.0')) == '1.0'
+
+    v = SchemaValidator(core_schema.union_schema([core_schema.float_schema(), core_schema.int_schema()]))
+    assert repr(v.validate_python(1)) == '1'
+    assert repr(v.validate_json('1')) == '1'
+    assert repr(v.validate_python(1.0)) == '1.0'
+    assert repr(v.validate_json('1.0')) == '1.0'

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -330,6 +330,9 @@ def test_custom_error_type_context():
 
 def test_int_float():
     v = SchemaValidator(core_schema.union_schema([core_schema.int_schema(), core_schema.float_schema()]))
+    assert 'strict_required:true' in plain_repr(v)
+    assert 'ultra_strict_required:true' in plain_repr(v)  # since "float" schema has ultra-strict behaviour
+
     assert repr(v.validate_python(1)) == '1'
     assert repr(v.validate_json('1')) == '1'
     assert repr(v.validate_python(1.0)) == '1.0'
@@ -340,3 +343,18 @@ def test_int_float():
     assert repr(v.validate_json('1')) == '1'
     assert repr(v.validate_python(1.0)) == '1.0'
     assert repr(v.validate_json('1.0')) == '1.0'
+
+
+def test_strict_check():
+    v = SchemaValidator(core_schema.union_schema([core_schema.int_schema(), core_schema.json_schema()]))
+    assert 'strict_required:true' in plain_repr(v)
+    assert 'ultra_strict_required:false' in plain_repr(v)
+
+
+def test_no_strict_check():
+    v = SchemaValidator(core_schema.union_schema([core_schema.is_instance_schema(int), core_schema.json_schema()]))
+    assert 'strict_required:false' in plain_repr(v)
+    assert 'ultra_strict_required:false' in plain_repr(v)
+
+    assert v.validate_python(123) == 123
+    assert v.validate_python('[1, 2, 3]') == [1, 2, 3]


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/5422.

But we need to discuss this since it means that in strict mode `1` is no longer a valid input to a `float` field, which I imagine could annoy people.

@adriangb @dmontagu @hramezani please let me know what you think.