### PR TITLE
Flatten validators

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -181,24 +181,26 @@ def simple_ser_schema(type: ExpectedSerializationTypes) -> SimpleSerSchema:
     return SimpleSerSchema(type=type)
 
 
-class GeneralPlainSerializerFunction(Protocol):  # pragma: no cover
-    def __call__(self, __input_value: Any, __info: SerializationInfo) -> Any:
-        ...
+# (__input_value: Any) -> Any
+GeneralPlainNoInfoSerializerFunction = Callable[[Any], Any]
+# (__input_value: Any, __info: FieldSerializationInfo) -> Any
+GeneralPlainInfoSerializerFunction = Callable[[Any, SerializationInfo], Any]
+# (__model: Any, __input_value: Any) -> Any
+FieldPlainNoInfoSerializerFunction = Callable[[Any, Any], Any]
+# (__model: Any, __input_value: Any, __info: FieldSerializationInfo) -> Any
+FieldPlainInfoSerializerFunction = Callable[[Any, Any, FieldSerializationInfo], Any]
+SerializerFunction = Union[
+    GeneralPlainNoInfoSerializerFunction,
+    GeneralPlainInfoSerializerFunction,
+    FieldPlainNoInfoSerializerFunction,
+    FieldPlainInfoSerializerFunction,
+]
 
 
-class FieldPlainSerializerFunction(Protocol):  # pragma: no cover
-    def __call__(self, __model: Any, __input_value: Any, __info: FieldSerializationInfo) -> Any:
-        ...
-
-
-class GeneralPlainSerializerFunctionSchema(TypedDict):
-    type: Literal['general']
-    function: GeneralPlainSerializerFunction
-
-
-class FieldPlainSerializerFunctionSchema(TypedDict):
-    type: Literal['field']
-    function: FieldPlainSerializerFunction
+class SerializerFunctionSchema(TypedDict):
+    type: Literal['general', 'field']
+    info_arg: bool
+    function: SerializerFunction
 
 
 # must match `src/serializers/ob_type.rs::ObType`
@@ -244,22 +246,26 @@ Values have the following meanings:
 
 class PlainSerializerFunctionSerSchema(TypedDict, total=False):
     type: Required[Literal['function-plain']]
-    function: Required[Union[GeneralPlainSerializerFunctionSchema, FieldPlainSerializerFunctionSchema]]
+    function: Required[SerializerFunctionSchema]
     json_return_type: JsonReturnTypes
     when_used: WhenUsed  # default: 'always'
 
 
-def general_plain_serializer_function_ser_schema(
-    function: GeneralPlainSerializerFunction,
+def plain_serializer_function_ser_schema(
+    function: SerializerFunction,
+    function_type: Literal['general', 'field'],
+    info_arg: bool,
     *,
     json_return_type: JsonReturnTypes | None = None,
     when_used: WhenUsed = 'always',
 ) -> PlainSerializerFunctionSerSchema:
     """
-    Returns a schema for serialization with a function.
+    Returns a schema for serialization with a function, can be either a "general" or "field" function.
 
     Args:
         function: The function to use for serialization
+        function_type: The type of function, either 'general' or 'field'
+        info_arg: Whether the function takes an `__info` argument
         json_return_type: The type that the function returns if `mode='json'`
         when_used: When the function should be called
     """
@@ -268,32 +274,7 @@ def general_plain_serializer_function_ser_schema(
         when_used = None  # type: ignore
     return dict_not_none(
         type='function-plain',
-        function={'type': 'general', 'function': function},
-        json_return_type=json_return_type,
-        when_used=when_used,
-    )
-
-
-def field_plain_serializer_function_ser_schema(
-    function: FieldPlainSerializerFunction,
-    *,
-    json_return_type: JsonReturnTypes | None = None,
-    when_used: WhenUsed = 'always',
-) -> PlainSerializerFunctionSerSchema:
-    """
-    Returns a schema to serialize a field from a model, TypedDict or dataclass.
-
-    Args:
-        function: The function to use for serialization
-        json_return_type: The type that the function returns if `mode='json'`
-        when_used: When the function should be called
-    """
-    if when_used == 'always':
-        # just to avoid extra elements in schema, and to use the actual default defined in rust
-        when_used = None  # type: ignore
-    return dict_not_none(
-        type='function-plain',
-        function={'type': 'field', 'function': function},
+        function={'type': function_type, 'info_arg': info_arg, 'function': function},
         json_return_type=json_return_type,
         when_used=when_used,
     )
@@ -304,54 +285,52 @@ class SerializerFunctionWrapHandler(Protocol):  # pragma: no cover
         ...
 
 
-class GeneralWrapSerializerFunction(Protocol):  # pragma: no cover
-    def __call__(
-        self, __input_value: Any, __serializer: SerializerFunctionWrapHandler, __info: SerializationInfo
-    ) -> Any:
-        ...
+# (__input_value: Any, __serializer: SerializerFunctionWrapHandler) -> Any
+GeneralWrapNoInfoSerializerFunction = Callable[[Any, SerializerFunctionWrapHandler], Any]
+# (__input_value: Any, __serializer: SerializerFunctionWrapHandler, __info: SerializationInfo) -> Any
+GeneralWrapInfoSerializerFunction = Callable[[Any, SerializerFunctionWrapHandler, SerializationInfo], Any]
+# (__model: Any, __input_value: Any, __serializer: SerializerFunctionWrapHandler) -> Any
+FieldWrapNoInfoSerializerFunction = Callable[[Any, Any, SerializerFunctionWrapHandler], Any]
+# (__model: Any, __input_value: Any, __serializer: SerializerFunctionWrapHandler, __info: FieldSerializationInfo) -> Any
+FieldWrapInfoSerializerFunction = Callable[[Any, Any, SerializerFunctionWrapHandler, FieldSerializationInfo], Any]
+WrapSerializerFunction = Union[
+    GeneralWrapNoInfoSerializerFunction,
+    GeneralWrapInfoSerializerFunction,
+    FieldWrapNoInfoSerializerFunction,
+    FieldWrapInfoSerializerFunction,
+]
 
 
-class FieldWrapSerializerFunction(Protocol):  # pragma: no cover
-    def __call__(
-        self,
-        __model: Any,
-        __input_value: Any,
-        __serializer: SerializerFunctionWrapHandler,
-        __info: FieldSerializationInfo,
-    ) -> Any:
-        ...
-
-
-class GeneralWrapSerializerFunctionSchema(TypedDict):
-    type: Literal['general']
-    function: GeneralWrapSerializerFunction
-
-
-class FieldWrapSerializerFunctionSchema(TypedDict):
-    type: Literal['field']
-    function: FieldWrapSerializerFunction
+class WrapSerializerFunctionSchema(TypedDict):
+    type: Literal['general', 'field']
+    info_arg: bool
+    function: WrapSerializerFunction
 
 
 class WrapSerializerFunctionSerSchema(TypedDict, total=False):
     type: Required[Literal['function-wrap']]
-    function: Required[Union[GeneralWrapSerializerFunctionSchema, FieldWrapSerializerFunctionSchema]]
-    schema: CoreSchema  # if ommited, the schema on which this serializer is defined is used
+    function: Required[WrapSerializerFunctionSchema]
+    schema: CoreSchema  # if omitted, the schema on which this serializer is defined is used
     json_return_type: JsonReturnTypes
     when_used: WhenUsed  # default: 'always'
 
 
-def general_wrap_serializer_function_ser_schema(
-    function: GeneralWrapSerializerFunction,
+def wrap_serializer_function_ser_schema(
+    function: WrapSerializerFunction,
+    function_type: Literal['general', 'field'],
+    info_arg: bool,
     *,
     schema: CoreSchema | None = None,
     json_return_type: JsonReturnTypes | None = None,
     when_used: WhenUsed = 'always',
 ) -> WrapSerializerFunctionSerSchema:
     """
-    Returns a schema for serialization with a general wrap function.
+    Returns a schema for serialization with a wrap function, can be either a "general" or "field" function.
 
     Args:
         function: The function to use for serialization
+        function_type: The type of function, either 'general' or 'field'
+        info_arg: Whether the function takes an `__info` argument
         schema: The schema to use for the inner serialization
         json_return_type: The type that the function returns if `mode='json'`
         when_used: When the function should be called
@@ -362,35 +341,7 @@ def general_wrap_serializer_function_ser_schema(
     return dict_not_none(
         type='function-wrap',
         schema=schema,
-        function={'type': 'general', 'function': function},
-        json_return_type=json_return_type,
-        when_used=when_used,
-    )
-
-
-def field_wrap_serializer_function_ser_schema(
-    function: FieldWrapSerializerFunction,
-    *,
-    schema: CoreSchema | None = None,
-    json_return_type: JsonReturnTypes | None = None,
-    when_used: WhenUsed = 'always',
-) -> WrapSerializerFunctionSerSchema:
-    """
-    Returns a schema to serialize a field from a model, TypedDict or dataclass using a wrap function.
-
-    Args:
-        function: The function to use for serialization
-        schema: The schema to use for the inner serialization
-        json_return_type: The type that the function returns if `mode='json'`
-        when_used: When the function should be called
-    """
-    if when_used == 'always':
-        # just to avoid extra elements in schema, and to use the actual default defined in rust
-        when_used = None  # type: ignore
-    return dict_not_none(
-        type='function-wrap',
-        schema=schema,
-        function={'type': 'field', 'function': function},
+        function={'type': function_type, 'info_arg': info_arg, 'function': function},
         json_return_type=json_return_type,
         when_used=when_used,
     )
@@ -482,8 +433,8 @@ def any_schema(*, ref: str | None = None, metadata: Any = None, serialization: S
     ```
 
     Args:
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='any', ref=ref, metadata=metadata, serialization=serialization)
@@ -509,8 +460,8 @@ def none_schema(*, ref: str | None = None, metadata: Any = None, serialization: 
     ```
 
     Args:
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='none', ref=ref, metadata=metadata, serialization=serialization)
@@ -540,8 +491,8 @@ def bool_schema(
 
     Args:
         strict: Whether the value should be a bool or a value that can be converted to a bool
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='bool', strict=strict, ref=ref, metadata=metadata, serialization=serialization)
@@ -590,8 +541,8 @@ def int_schema(
         lt: The value must be strictly less than this number
         gt: The value must be strictly greater than this number
         strict: Whether the value should be a int or a value that can be converted to a int
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -654,8 +605,8 @@ def float_schema(
         lt: The value must be strictly less than this number
         gt: The value must be strictly greater than this number
         strict: Whether the value should be a float or a value that can be converted to a float
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -719,8 +670,8 @@ def str_schema(
         to_lower: Whether to convert the value to lowercase
         to_upper: Whether to convert the value to uppercase
         strict: Whether the value should be a string or a value that can be converted to a string
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -772,8 +723,8 @@ def bytes_schema(
         max_length: The value must be at most this length
         min_length: The value must be at least this length
         strict: Whether the value should be a bytes or a value that can be converted to a bytes
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -836,8 +787,8 @@ def date_schema(
         gt: The value must be strictly greater than this date
         now_op: The value must be in the past or future relative to the current date
         now_utc_offset: The value must be in the past or future relative to the current date with this utc offset
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -896,8 +847,8 @@ def time_schema(
         ge: The value must be greater than or equal to this time
         lt: The value must be strictly less than this time
         gt: The value must be strictly greater than this time
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -958,8 +909,8 @@ def datetime_schema(
         now_op: The value must be in the past or future relative to the current datetime
         tz_constraint: The value must be timezone aware or naive
         now_utc_offset: The value must be in the past or future relative to the current datetime with this utc offset
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1019,8 +970,8 @@ def timedelta_schema(
         ge: The value must be greater than or equal to this timedelta
         lt: The value must be strictly less than this timedelta
         gt: The value must be strictly greater than this timedelta
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1060,8 +1011,8 @@ def literal_schema(
 
     Args:
         expected: The value must be one of these values
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='literal', expected=expected, ref=ref, metadata=metadata, serialization=serialization)
@@ -1112,8 +1063,8 @@ def is_instance_schema(
         json_function: When parsing JSON directly, If provided, the JSON value is passed to this
             function and the return value used as the output value
         cls_repr: If provided this string is used in the validator name instead of `repr(cls)`
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1165,8 +1116,8 @@ def is_subclass_schema(
     Args:
         cls: The value must be a subclass of this class
         cls_repr: If provided this string is used in the validator name instead of `repr(cls)`
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1196,8 +1147,8 @@ def callable_schema(
     ```
 
     Args:
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='callable', ref=ref, metadata=metadata, serialization=serialization)
@@ -1256,8 +1207,8 @@ def list_schema(
         max_length: The value must be a list with at most this many items
         strict: The value must be a list with exactly this many items
         allow_any_iter: Whether the value can be any iterable
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1312,8 +1263,8 @@ def tuple_positional_schema(
             In python's `typing.Tuple`, you can't specify a type for "extra" items -- they must all be the same type
             if the length is variable. So this field won't be set from a `typing.Tuple` annotation on a pydantic model.
         strict: The value must be a tuple with exactly this many items
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1366,8 +1317,8 @@ def tuple_variable_schema(
         min_length: The value must be a tuple with at least this many items
         max_length: The value must be a tuple with at most this many items
         strict: The value must be a tuple with exactly this many items
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1426,8 +1377,8 @@ def set_schema(
             This is important because generators can be infinite, and even with a `max_length` on the set,
             an infinite generator could run forever without producing more than `max_length` distinct items.
         strict: The value must be a set with exactly this many items
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1485,8 +1436,8 @@ def frozenset_schema(
         max_length: The value must be a frozenset with at most this many items
         generator_max_length: The value must generate a frozenset with at most this many items
         strict: The value must be a frozenset with exactly this many items
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1544,8 +1495,8 @@ def generator_schema(
         items_schema: The value must be a generator with items that match this schema
         min_length: The value must be a generator that yields at least this many items
         max_length: The value must be a generator that yields at most this many items
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1617,8 +1568,8 @@ def dict_schema(
         min_length: The value must be a dict with at least this many items
         max_length: The value must be a dict with at most this many items
         strict: Whether the keys and values should be validated with strict mode
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1698,8 +1649,8 @@ def field_before_validator_function(
     Args:
         function: The validator function to call
         schema: The schema to validate the output of the validator function
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1742,8 +1693,8 @@ def general_before_validator_function(
     Args:
         function: The validator function to call
         schema: The schema to validate the output of the validator function
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1792,8 +1743,8 @@ def field_after_validator_function(
     Args:
         schema: The schema to validate before the validator function
         function: The validator function to call after the schema is validated
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1834,8 +1785,8 @@ def general_after_validator_function(
     Args:
         schema: The schema to validate before the validator function
         function: The validator function to call after the schema is validated
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1919,8 +1870,8 @@ def general_wrap_validator_function(
     Args:
         function: The validator function to call
         schema: The schema to validate the output of the validator function
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -1971,8 +1922,8 @@ def field_wrap_validator_function(
     Args:
         function: The validator function to call
         schema: The schema to validate the output of the validator function
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2017,8 +1968,8 @@ def general_plain_validator_function(
 
     Args:
         function: The validator function to call
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2058,8 +2009,8 @@ def field_plain_validator_function(
 
     Args:
         function: The validator function to call
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2120,8 +2071,8 @@ def with_default_schema(
         on_error: What to do if the schema validation fails. One of 'raise', 'omit', 'default'
         validate_default: Whether the default value should be validated
         strict: Whether the underlying schema should be validated with strict mode
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     s = dict_not_none(
@@ -2171,8 +2122,8 @@ def nullable_schema(
     Args:
         schema: The schema to wrap
         strict: Whether the underlying schema should be validated with strict mode
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2225,8 +2176,8 @@ def union_schema(
         custom_error_message: The custom error message to use if the validation fails
         custom_error_context: The custom error context to use if the validation fails
         strict: Whether the underlying schemas should be validated with strict mode
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2323,8 +2274,8 @@ def tagged_union_schema(
         custom_error_context: The custom error context to use if the validation fails
         strict: Whether the underlying schemas should be validated with strict mode
         from_attributes: Whether to use the attributes of the object to retrieve the discriminator value
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2373,8 +2324,8 @@ def chain_schema(
 
     Args:
         steps: The schemas to chain
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='chain', steps=steps, ref=ref, metadata=metadata, serialization=serialization)
@@ -2429,8 +2380,8 @@ def lax_or_strict_schema(
         lax_schema: The lax schema to use
         strict_schema: The strict schema to use
         strict: Whether the strict schema should be used
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2481,7 +2432,7 @@ def typed_dict_field(
         serialization_alias: The alias to use as a key when serializing
         serialization_exclude: Whether to exclude the field when serializing
         frozen: Whether the field is frozen
-        metadata: See [TODO] for details
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
     """
     return dict_not_none(
         type='typed-dict-field',
@@ -2543,12 +2494,13 @@ def typed_dict_schema(
         strict: Whether the typed dict is strict
         extra_validator: The extra validator to use for the typed dict
         return_fields_set: Whether the typed dict should return a fields set
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         extra_behavior: The extra behavior to use for the typed dict
         total: Whether the typed dict is total
         populate_by_name: Whether the typed dict should populate by name
         from_attributes: Whether the typed dict should be populated from attributes
+        serialization: Custom serialization schema
     """
     return dict_not_none(
         type='typed-dict',
@@ -2628,8 +2580,8 @@ def model_schema(
         strict: Whether the model is strict
         frozen: Whether the model is frozen
         config: The config to use for the model
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2694,7 +2646,8 @@ def dataclass_field(
         validation_alias: The alias(es) to use to find the field in the validation data
         serialization_alias: The alias to use as a key when serializing
         serialization_exclude: Whether to exclude the field when serializing
-        metadata: See [TODO] for details
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
+        frozen: Whether the field is frozen
     """
     return dict_not_none(
         type='dataclass-field',
@@ -2755,9 +2708,10 @@ def dataclass_args_schema(
         fields: The fields to use for the dataclass
         populate_by_name: Whether to populate by name
         collect_init_only: Whether to collect init only fields into a dict to pass to `__post_init__`
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
+        extra_behavior: How to handle extra fields
     """
     return dict_not_none(
         type='dataclass-args',
@@ -2808,9 +2762,10 @@ def dataclass_schema(
         revalidate_instances: whether instances of models and dataclasses (including subclass instances)
           should re-validate defaults to config.revalidate_instances, else 'never'
         strict: Whether to require an exact instance of `cls`
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
+        frozen: Whether the dataclass is frozen
     """
     return dict_not_none(
         type='dataclass',
@@ -2906,8 +2861,8 @@ def arguments_schema(
         populate_by_name: Whether to populate by name
         var_args_schema: The variable args schema to use for the arguments schema
         var_kwargs_schema: The variable kwargs schema to use for the arguments schema
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -2968,8 +2923,8 @@ def call_schema(
         arguments: The arguments to use for the arguments schema
         function: The function to use for the call schema
         return_schema: The return schema to use for the call schema
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -3024,8 +2979,8 @@ def custom_error_schema(
         custom_error_type: The custom error type to use for the custom error schema
         custom_error_message: The custom error message to use for the custom error schema
         custom_error_context: The custom error context to use for the custom error schema
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -3082,8 +3037,8 @@ def json_schema(
 
     Args:
         schema: The schema to use for the JSON schema
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='json', schema=schema, ref=ref, metadata=metadata, serialization=serialization)
@@ -3124,8 +3079,7 @@ def url_schema(
 
     schema = core_schema.url_schema()
     v = SchemaValidator(schema)
-    # TODO: Assert this is equal to a constructed URL object
-    v.validate_python('https://example.com')
+    print(v.validate_python('https://example.com'))
     ```
 
     Args:
@@ -3136,8 +3090,8 @@ def url_schema(
         default_port: The default port to use if the URL does not have a port
         default_path: The default path to use if the URL does not have a path
         strict: Whether to use strict URL parsing
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -3190,8 +3144,7 @@ def multi_host_url_schema(
 
     schema = core_schema.multi_host_url_schema()
     v = SchemaValidator(schema)
-    # TODO: Assert this is equal to a constructed URL object
-    v.validate_python('redis://localhost,0.0.0.0,127.0.0.1')
+    print(v.validate_python('redis://localhost,0.0.0.0,127.0.0.1'))
     ```
 
     Args:
@@ -3202,8 +3155,8 @@ def multi_host_url_schema(
         default_port: The default port to use if the URL does not have a port
         default_path: The default path to use if the URL does not have a path
         strict: Whether to use strict URL parsing
-        ref: See [TODO] for details
-        metadata: See [TODO] for details
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(
@@ -3277,7 +3230,7 @@ def definition_reference_schema(
 
     Args:
         schema_ref: The schema ref to use for the definition reference schema
-        metadata: See [TODO] for details
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return dict_not_none(type='definition-ref', schema_ref=schema_ref, metadata=metadata, serialization=serialization)

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -99,19 +99,6 @@ pub fn is_strict(schema: &PyDict, config: Option<&PyDict>) -> PyResult<bool> {
     Ok(schema_or_config_same(schema, config, intern!(py, "strict"))?.unwrap_or(false))
 }
 
-pub fn destructure_function_schema(schema: &PyDict) -> PyResult<(bool, bool, &PyAny)> {
-    let func_dict: &PyDict = schema.get_as_req(intern!(schema.py(), "function"))?;
-    let function: &PyAny = func_dict.get_as_req(intern!(schema.py(), "function"))?;
-    let func_type: &str = func_dict.get_as_req(intern!(schema.py(), "type"))?;
-    let is_field_serializer = match func_type {
-        "field" => true,
-        "general" => false,
-        _ => unreachable!(),
-    };
-    let info_arg: bool = func_dict.get_as(intern!(schema.py(), "info_arg"))?.unwrap_or(true);
-    Ok((is_field_serializer, info_arg, function))
-}
-
 enum SchemaErrorEnum {
     Message(String),
     ValidationError(ValidationError),

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -99,7 +99,7 @@ pub fn is_strict(schema: &PyDict, config: Option<&PyDict>) -> PyResult<bool> {
     Ok(schema_or_config_same(schema, config, intern!(py, "strict"))?.unwrap_or(false))
 }
 
-pub fn destructure_function_schema(schema: &PyDict) -> PyResult<(bool, &PyAny)> {
+pub fn destructure_function_schema(schema: &PyDict) -> PyResult<(bool, bool, &PyAny)> {
     let func_dict: &PyDict = schema.get_as_req(intern!(schema.py(), "function"))?;
     let function: &PyAny = func_dict.get_as_req(intern!(schema.py(), "function"))?;
     let func_type: &str = func_dict.get_as_req(intern!(schema.py(), "type"))?;
@@ -108,7 +108,8 @@ pub fn destructure_function_schema(schema: &PyDict) -> PyResult<(bool, &PyAny)> 
         "general" => false,
         _ => unreachable!(),
     };
-    Ok((is_field_serializer, function))
+    let info_arg: bool = func_dict.get_as(intern!(schema.py(), "info_arg"))?.unwrap_or(true);
+    Ok((is_field_serializer, info_arg, function))
 }
 
 enum SchemaErrorEnum {

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -3,7 +3,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyString};
 
-use crate::build_tools::{destructure_function_schema, function_name, py_err, SchemaDict};
+use crate::build_tools::{function_name, py_err, SchemaDict};
 use crate::errors::{
     ErrorType, LocItem, PydanticCustomError, PydanticKnownError, PydanticOmit, ValError, ValResult, ValidationError,
 };
@@ -13,6 +13,19 @@ use crate::recursion_guard::RecursionGuard;
 
 use super::generator::InternalValidator;
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
+
+fn destructure_function_schema(schema: &PyDict) -> PyResult<(bool, bool, &PyAny)> {
+    let func_dict: &PyDict = schema.get_as_req(intern!(schema.py(), "function"))?;
+    let function: &PyAny = func_dict.get_as_req(intern!(schema.py(), "function"))?;
+    let func_type: &str = func_dict.get_as_req(intern!(schema.py(), "type"))?;
+    let (is_field_serializer, info_arg) = match func_type {
+        "field" => (true, true),
+        "general" => (false, true),
+        "no-info" => (false, false),
+        _ => unreachable!(),
+    };
+    Ok((is_field_serializer, info_arg, function))
+}
 
 macro_rules! impl_build {
     ($impl_name:ident, $name:literal) => {
@@ -25,7 +38,7 @@ macro_rules! impl_build {
             ) -> PyResult<CombinedValidator> {
                 let py = schema.py();
                 let validator = build_validator(schema.get_as_req(intern!(py, "schema"))?, config, build_context)?;
-                let (is_field_validator, _info_arg, function) = destructure_function_schema(schema)?;
+                let (is_field_validator, info_arg, function) = destructure_function_schema(schema)?;
                 let name = format!(
                     "{}[{}(), {}]",
                     $name,
@@ -41,6 +54,7 @@ macro_rules! impl_build {
                     },
                     name,
                     is_field_validator,
+                    info_arg,
                 }
                 .into())
             }
@@ -102,6 +116,7 @@ pub struct FunctionBeforeValidator {
     config: PyObject,
     name: String,
     is_field_validator: bool,
+    info_arg: bool,
 }
 
 impl_build!(FunctionBeforeValidator, "function-before");
@@ -114,11 +129,13 @@ impl FunctionBeforeValidator {
         input: &'data PyAny,
         extra: &Extra,
     ) -> ValResult<'data, PyObject> {
-        let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
-        let value = self
-            .func
-            .call1(py, (input.to_object(py), info))
-            .map_err(|e| convert_err(py, e, input))?;
+        let r = if self.info_arg {
+            let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
+            self.func.call1(py, (input.to_object(py), info))
+        } else {
+            self.func.call1(py, (input.to_object(py),))
+        };
+        let value = r.map_err(|e| convert_err(py, e, input))?;
         call(value.into_ref(py), extra)
     }
 }
@@ -132,6 +149,7 @@ pub struct FunctionAfterValidator {
     config: PyObject,
     name: String,
     is_field_validator: bool,
+    info_arg: bool,
 }
 
 impl_build!(FunctionAfterValidator, "function-after");
@@ -144,11 +162,14 @@ impl FunctionAfterValidator {
         input: &'data PyAny,
         extra: &Extra,
     ) -> ValResult<'data, PyObject> {
-        let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
         let v = call(input, extra)?;
-        self.func
-            .call1(py, (v.to_object(py), info))
-            .map_err(|e| convert_err(py, e, input))
+        let r = if self.info_arg {
+            let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
+            self.func.call1(py, (v.to_object(py), info))
+        } else {
+            self.func.call1(py, (v.to_object(py),))
+        };
+        r.map_err(|e| convert_err(py, e, input))
     }
 }
 
@@ -160,6 +181,7 @@ pub struct FunctionPlainValidator {
     config: PyObject,
     name: String,
     is_field_validator: bool,
+    info_arg: bool,
 }
 
 impl BuildValidator for FunctionPlainValidator {
@@ -171,7 +193,7 @@ impl BuildValidator for FunctionPlainValidator {
         _build_context: &mut BuildContext<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        let (is_field_validator, _info_arg, function) = destructure_function_schema(schema)?;
+        let (is_field_validator, info_arg, function) = destructure_function_schema(schema)?;
         Ok(Self {
             func: function.into_py(py),
             config: match config {
@@ -180,6 +202,7 @@ impl BuildValidator for FunctionPlainValidator {
             },
             name: format!("function-plain[{}()]", function_name(function)?),
             is_field_validator,
+            info_arg,
         }
         .into())
     }
@@ -194,10 +217,13 @@ impl Validator for FunctionPlainValidator {
         _slots: &'data [CombinedValidator],
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
-        self.func
-            .call1(py, (input.to_object(py), info))
-            .map_err(|e| convert_err(py, e, input))
+        let r = if self.info_arg {
+            let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
+            self.func.call1(py, (input.to_object(py), info))
+        } else {
+            self.func.call1(py, (input.to_object(py),))
+        };
+        r.map_err(|e| convert_err(py, e, input))
     }
 
     fn get_name(&self) -> &str {
@@ -216,6 +242,7 @@ pub struct FunctionWrapValidator {
     config: PyObject,
     name: String,
     is_field_validator: bool,
+    info_arg: bool,
 }
 
 impl_build!(FunctionWrapValidator, "function-wrap");
@@ -228,10 +255,13 @@ impl FunctionWrapValidator {
         input: &'data PyAny,
         extra: &Extra,
     ) -> ValResult<'data, PyObject> {
-        let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
-        self.func
-            .call1(py, (input.to_object(py), handler, info))
-            .map_err(|e| convert_err(py, e, input))
+        let r = if self.info_arg {
+            let info = ValidationInfo::new(py, extra, &self.config, self.is_field_validator)?;
+            self.func.call1(py, (input.to_object(py), handler, info))
+        } else {
+            self.func.call1(py, (input.to_object(py), handler))
+        };
+        r.map_err(|e| convert_err(py, e, input))
     }
 }
 

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -25,7 +25,7 @@ macro_rules! impl_build {
             ) -> PyResult<CombinedValidator> {
                 let py = schema.py();
                 let validator = build_validator(schema.get_as_req(intern!(py, "schema"))?, config, build_context)?;
-                let (is_field_validator, function) = destructure_function_schema(schema)?;
+                let (is_field_validator, _info_arg, function) = destructure_function_schema(schema)?;
                 let name = format!(
                     "{}[{}(), {}]",
                     $name,
@@ -171,7 +171,7 @@ impl BuildValidator for FunctionPlainValidator {
         _build_context: &mut BuildContext<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        let (is_field_validator, function) = destructure_function_schema(schema)?;
+        let (is_field_validator, _info_arg, function) = destructure_function_schema(schema)?;
         Ok(Self {
             func: function.into_py(py),
             config: match config {

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -166,7 +166,8 @@ def schema(*, strict: bool = False) -> dict:
                                 'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-before',
-                                    'function': {'type': 'general', 'function': append_func},
+                                    'function': append_func,
+                                    'signature': 'general',
                                     'schema': {'type': 'str'},
                                 },
                             },
@@ -174,7 +175,8 @@ def schema(*, strict: bool = False) -> dict:
                                 'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-after',
-                                    'function': {'type': 'general', 'function': append_func},
+                                    'function': append_func,
+                                    'signature': 'general',
                                     'schema': {'type': 'str'},
                                 },
                             },
@@ -182,16 +184,14 @@ def schema(*, strict: bool = False) -> dict:
                                 'type': 'typed-dict-field',
                                 'schema': {
                                     'type': 'function-wrap',
-                                    'function': {'type': 'general', 'function': wrap_function},
+                                    'function': wrap_function,
+                                    'signature': 'general',
                                     'schema': {'type': 'str'},
                                 },
                             },
                             'field_plain': {
                                 'type': 'typed-dict-field',
-                                'schema': {
-                                    'type': 'function-plain',
-                                    'function': {'type': 'general', 'function': append_func},
-                                },
+                                'schema': {'type': 'function-plain', 'function': append_func, 'signature': 'general'},
                             },
                         },
                     },

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -932,7 +932,7 @@ def test_dont_raise_error(benchmark):
     def f(input_value, info):
         return input_value
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     @benchmark
     def t():
@@ -944,7 +944,7 @@ def test_dont_raise_error_no_info(benchmark):
     def f(input_value):
         return input_value
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'no-info', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'no-info'})
 
     @benchmark
     def t():
@@ -956,7 +956,7 @@ def test_raise_error_value_error(benchmark):
     def f(input_value, info):
         raise ValueError('this is a custom error')
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     @benchmark
     def t():
@@ -973,7 +973,7 @@ def test_raise_error_custom(benchmark):
     def f(input_value, info):
         raise PydanticCustomError('my_error', 'this is a custom error {foo}', {'foo': 'FOOBAR'})
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     @benchmark
     def t():
@@ -1070,7 +1070,7 @@ def test_chain_list(benchmark):
             'type': 'chain',
             'steps': [
                 {'type': 'str'},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: Decimal(v)}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: Decimal(v)},
             ],
         }
     )
@@ -1085,7 +1085,8 @@ def test_chain_function(benchmark):
         {
             'type': 'function-after',
             'schema': {'type': 'str'},
-            'function': {'type': 'general', 'function': lambda v, info: Decimal(v)},
+            'signature': 'general',
+            'function': lambda v, info: Decimal(v),
         }
     )
     assert validator.validate_python('42.42') == Decimal('42.42')
@@ -1100,8 +1101,8 @@ def test_chain_two_functions(benchmark):
             'type': 'chain',
             'steps': [
                 {'type': 'str'},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: Decimal(v)}},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: v * 2}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: Decimal(v)},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: v * 2},
             ],
         }
     )
@@ -1118,9 +1119,11 @@ def test_chain_nested_functions(benchmark):
             'schema': {
                 'type': 'function-after',
                 'schema': {'type': 'str'},
-                'function': {'type': 'general', 'function': lambda v, info: Decimal(v)},
+                'signature': 'general',
+                'function': lambda v, info: Decimal(v),
             },
-            'function': {'type': 'general', 'function': lambda v, info: v * 2},
+            'signature': 'general',
+            'function': lambda v, info: v * 2,
         }
     )
     assert validator.validate_python('42.42') == Decimal('84.84')
@@ -1143,7 +1146,7 @@ def generator_gen_python(v, validator, info):
 
 @pytest.mark.benchmark(group='generator')
 def test_generator_python(benchmark):
-    schema = core_schema.general_wrap_validator_function(generator_gen_python, {'type': 'int'})
+    schema = core_schema.wrap_validator_function(generator_gen_python, {'type': 'int'}, signature='general')
     v = SchemaValidator(schema)
     input_value = tuple(range(100))
 

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -940,6 +940,18 @@ def test_dont_raise_error(benchmark):
 
 
 @pytest.mark.benchmark(group='raise-error')
+def test_dont_raise_error_no_info(benchmark):
+    def f(input_value):
+        return input_value
+
+    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'no-info', 'function': f}})
+
+    @benchmark
+    def t():
+        v.validate_python(42)
+
+
+@pytest.mark.benchmark(group='raise-error')
 def test_raise_error_value_error(benchmark):
     def f(input_value, info):
         raise ValueError('this is a custom error')

--- a/tests/benchmarks/test_serialization_micro.py
+++ b/tests/benchmarks/test_serialization_micro.py
@@ -203,6 +203,24 @@ def test_date_format_function(benchmark):
     benchmark(serializer.to_python, d)
 
 
+@pytest.mark.benchmark(group='date-format')
+def test_date_format_function_no_info(benchmark):
+    def fmt(value):
+        return value.strftime('%Y-%m-%d')
+
+    serializer = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                fmt, 'general', False, json_return_type='str'
+            )
+        )
+    )
+    d = date(2022, 11, 20)
+    assert serializer.to_python(d) == '2022-11-20'
+
+    benchmark(serializer.to_python, d)
+
+
 @pytest.fixture(scope='module', name='v1_model')
 def v1_model_fixture():
     class PydanticModel(BaseModel):

--- a/tests/benchmarks/test_serialization_micro.py
+++ b/tests/benchmarks/test_serialization_micro.py
@@ -194,7 +194,7 @@ def test_date_format_function(benchmark):
 
     serializer = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(fmt, json_return_type='str')
+            serialization=core_schema.plain_serializer_function_ser_schema(fmt, 'general', True, json_return_type='str')
         )
     )
     d = date(2022, 11, 20)

--- a/tests/serializers/test_definitions_recursive.py
+++ b/tests/serializers/test_definitions_recursive.py
@@ -88,7 +88,7 @@ def test_recursive_function():
             'ref': 'my_ref',
             'serialization': {
                 'type': 'function-wrap',
-                'function': {'type': 'general', 'function': lambda x, _1, _2: x},
+                'function': {'type': 'general', 'info_arg': True, 'function': lambda x, _1, _2: x},
             },
         }
     )
@@ -116,7 +116,7 @@ def test_recursive_function_deeper_ref():
             },
             'serialization': {
                 'type': 'function-wrap',
-                'function': {'type': 'general', 'function': lambda x, _1, _2: x},
+                'function': {'type': 'general', 'info_arg': True, 'function': lambda x, _1, _2: x},
             },
         }
     )

--- a/tests/serializers/test_functions.py
+++ b/tests/serializers/test_functions.py
@@ -18,7 +18,9 @@ def repr_function(value, _info):
 )
 def test_function(value, expected_python, expected_json):
     s = SchemaSerializer(
-        core_schema.any_schema(serialization=core_schema.general_plain_serializer_function_ser_schema(repr_function))
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(repr_function, 'general', True)
+        )
     )
     assert s.to_python(value) == expected_python
     assert s.to_json(value) == expected_json
@@ -34,7 +36,7 @@ def test_function_args():
         return value * 2
 
     s = SchemaSerializer(
-        core_schema.any_schema(serialization=core_schema.general_plain_serializer_function_ser_schema(double))
+        core_schema.any_schema(serialization=core_schema.plain_serializer_function_ser_schema(double, 'general', True))
     )
     assert s.to_python(4) == 8
     # insert_assert(f_info)
@@ -100,7 +102,9 @@ def test_function_error():
         raise TypeError('foo')
 
     s = SchemaSerializer(
-        core_schema.any_schema(serialization=core_schema.general_plain_serializer_function_ser_schema(raise_error))
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(raise_error, 'general', True)
+        )
     )
 
     msg = 'Error calling function `raise_error`: TypeError: foo$'
@@ -122,7 +126,9 @@ def test_function_error_keys():
 
     s = SchemaSerializer(
         core_schema.dict_schema(
-            core_schema.any_schema(serialization=core_schema.general_plain_serializer_function_ser_schema(raise_error)),
+            core_schema.any_schema(
+                serialization=core_schema.plain_serializer_function_ser_schema(raise_error, 'general', True)
+            ),
             core_schema.int_schema(),
         )
     )
@@ -148,7 +154,9 @@ def test_function_known_type():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(append_42, json_return_type='list')
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                append_42, 'general', True, json_return_type='list'
+            )
         )
     )
     assert s.to_python([1, 2, 3]) == [1, 2, 3, 42]
@@ -171,7 +179,9 @@ def test_function_args_str():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(append_args, json_return_type='str')
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                append_args, 'general', True, json_return_type='str'
+            )
         )
     )
     assert s.to_python(123) == (
@@ -200,8 +210,8 @@ def test_invalid_return_type():
     with pytest.raises(SchemaError, match=r'function-plain\.json_return_type\n  Input should be'):
         SchemaSerializer(
             core_schema.any_schema(
-                serialization=core_schema.general_plain_serializer_function_ser_schema(
-                    lambda _: 1, json_return_type='different'
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda _: 1, 'general', True, json_return_type='different'
                 )
             )
         )
@@ -213,7 +223,7 @@ def test_dict_keys():
 
     s = SchemaSerializer(
         core_schema.dict_schema(
-            core_schema.int_schema(serialization=core_schema.general_plain_serializer_function_ser_schema(fmt))
+            core_schema.int_schema(serialization=core_schema.plain_serializer_function_ser_schema(fmt, 'general', True))
         )
     )
     assert s.to_python({1: True}) == {'<1>': True}
@@ -223,7 +233,7 @@ def test_function_as_key():
     s = SchemaSerializer(
         core_schema.dict_schema(
             core_schema.any_schema(
-                serialization=core_schema.general_plain_serializer_function_ser_schema(repr_function)
+                serialization=core_schema.plain_serializer_function_ser_schema(repr_function, 'general', True)
             ),
             core_schema.any_schema(),
         )
@@ -239,7 +249,7 @@ def test_function_only_json():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(double, when_used='json')
+            serialization=core_schema.plain_serializer_function_ser_schema(double, 'general', True, when_used='json')
         )
     )
     assert s.to_python(4) == 4
@@ -252,8 +262,8 @@ def test_function_only_json():
 def test_function_unless_none():
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(
-                repr_function, when_used='unless-none'
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                repr_function, 'general', True, when_used='unless-none'
             )
         )
     )
@@ -269,8 +279,8 @@ def test_function_unless_none():
 def test_wrong_return_type():
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(
-                repr_function, json_return_type='int'
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                repr_function, 'general', True, json_return_type='int'
             )
         )
     )
@@ -291,7 +301,9 @@ def test_wrong_return_type_str():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(f, json_return_type='str_subclass')
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                f, 'general', True, json_return_type='str_subclass'
+            )
         )
     )
     assert s.to_python(123) == '123'
@@ -313,7 +325,7 @@ def test_function_wrap():
         return f'result={serializer(len(value))} repr={serializer!r}'
 
     s = SchemaSerializer(
-        core_schema.int_schema(serialization=core_schema.general_wrap_serializer_function_ser_schema(f))
+        core_schema.int_schema(serialization=core_schema.wrap_serializer_function_ser_schema(f, 'general', True))
     )
     assert s.to_python('foo') == 'result=3 repr=SerializationCallable(serializer=int)'
     assert s.to_python('foo', mode='json') == 'result=3 repr=SerializationCallable(serializer=int)'
@@ -326,7 +338,9 @@ def test_function_wrap_custom_schema():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(f, schema=core_schema.int_schema())
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                f, 'general', True, schema=core_schema.int_schema()
+            )
         )
     )
     assert s.to_python('foo') == 'result=3 repr=SerializationCallable(serializer=int)'
@@ -348,7 +362,9 @@ def test_function_wrap_fallback():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(f, schema=core_schema.any_schema())
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                f, 'general', True, schema=core_schema.any_schema()
+            )
         )
     )
     assert s.to_python('foo') == 'result=foo'
@@ -383,8 +399,8 @@ def test_deque():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(
-                serialize_deque, schema=core_schema.any_schema()
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                serialize_deque, 'general', True, schema=core_schema.any_schema()
             )
         )
     )
@@ -411,8 +427,8 @@ def test_custom_mapping():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(
-                serialize_custom_mapping, schema=core_schema.int_schema()
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                serialize_custom_mapping, 'general', True, schema=core_schema.int_schema()
             )
         )
     )
@@ -446,7 +462,7 @@ def test_function_wrap_model():
                     'c': core_schema.typed_dict_field(core_schema.any_schema(), serialization_exclude=True),
                 }
             ),
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(wrap_function),
+            serialization=core_schema.wrap_serializer_function_ser_schema(wrap_function, 'general', True),
         )
     )
     m = MyModel(a=1, b=b'foobar', c='excluded')
@@ -488,7 +504,7 @@ def test_function_plain_model():
                     'c': core_schema.typed_dict_field(core_schema.any_schema(), serialization_exclude=True),
                 }
             ),
-            serialization=core_schema.general_plain_serializer_function_ser_schema(wrap_function),
+            serialization=core_schema.plain_serializer_function_ser_schema(wrap_function, 'general', True),
         )
     )
     m = MyModel(a=1, b=b'foobar', c='not excluded')
@@ -515,7 +531,9 @@ def test_wrap_return_type():
 
     s = SchemaSerializer(
         core_schema.str_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(to_path, json_return_type='path')
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                to_path, 'general', True, json_return_type='path'
+            )
         )
     )
     assert s.to_python('foobar') == Path('foobar.new')

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -333,14 +333,14 @@ def test_function_positional_tuple():
             'type': 'tuple-positional',
             'items_schema': [
                 core_schema.any_schema(
-                    serialization=core_schema.general_plain_serializer_function_ser_schema(partial(f, 'a'))
+                    serialization=core_schema.plain_serializer_function_ser_schema(partial(f, 'a'), 'general', True)
                 ),
                 core_schema.any_schema(
-                    serialization=core_schema.general_plain_serializer_function_ser_schema(partial(f, 'b'))
+                    serialization=core_schema.plain_serializer_function_ser_schema(partial(f, 'b'), 'general', True)
                 ),
             ],
             'extra_schema': core_schema.any_schema(
-                serialization=core_schema.general_plain_serializer_function_ser_schema(partial(f, 'extra'))
+                serialization=core_schema.plain_serializer_function_ser_schema(partial(f, 'extra'), 'general', True)
             ),
         }
     )

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -415,7 +415,7 @@ def test_function_plain_field_serializer_to_python():
                 {
                     'x': core_schema.typed_dict_field(
                         core_schema.int_schema(
-                            serialization=core_schema.field_plain_serializer_function_ser_schema(Model.ser_x)
+                            serialization=core_schema.plain_serializer_function_ser_schema(Model.ser_x, 'field', True)
                         )
                     )
                 }
@@ -442,8 +442,8 @@ def test_function_wrap_field_serializer_to_python():
                 {
                     'x': core_schema.typed_dict_field(
                         core_schema.int_schema(
-                            serialization=core_schema.field_wrap_serializer_function_ser_schema(
-                                Model.ser_x, schema=core_schema.any_schema()
+                            serialization=core_schema.wrap_serializer_function_ser_schema(
+                                Model.ser_x, 'field', True, schema=core_schema.any_schema()
                             )
                         )
                     )
@@ -470,7 +470,7 @@ def test_function_plain_field_serializer_to_json():
                 {
                     'x': core_schema.typed_dict_field(
                         core_schema.int_schema(
-                            serialization=core_schema.field_plain_serializer_function_ser_schema(Model.ser_x)
+                            serialization=core_schema.plain_serializer_function_ser_schema(Model.ser_x, 'field', True)
                         )
                     )
                 }
@@ -497,8 +497,8 @@ def test_function_wrap_field_serializer_to_json():
                 {
                     'x': core_schema.typed_dict_field(
                         core_schema.int_schema(
-                            serialization=core_schema.field_wrap_serializer_function_ser_schema(
-                                Model.ser_x, schema=core_schema.any_schema()
+                            serialization=core_schema.wrap_serializer_function_ser_schema(
+                                Model.ser_x, 'field', True, schema=core_schema.any_schema()
                             )
                         )
                     )

--- a/tests/serializers/test_other.py
+++ b/tests/serializers/test_other.py
@@ -16,20 +16,24 @@ def test_chain():
 
 
 def test_function_plain():
-    s = SchemaSerializer(core_schema.general_plain_validator_function(lambda v, info: v + 1))
+    s = SchemaSerializer(core_schema.plain_validator_function(lambda v, info: v + 1, signature='general'))
     # can't infer the type from plain function validators
     # insert_assert(plain_repr(s))
     assert plain_repr(s) == 'SchemaSerializer(serializer=Any(AnySerializer),slots=[])'
 
 
 def test_function_before():
-    s = SchemaSerializer(core_schema.general_before_validator_function(lambda v, info: v + 1, core_schema.int_schema()))
+    s = SchemaSerializer(
+        core_schema.before_validator_function(lambda v, info: v + 1, core_schema.int_schema(), signature='general')
+    )
     # insert_assert(plain_repr(s))
     assert plain_repr(s) == 'SchemaSerializer(serializer=Int(IntSerializer),slots=[])'
 
 
 def test_function_after():
-    s = SchemaSerializer(core_schema.general_after_validator_function(lambda v, info: v + 1, core_schema.int_schema()))
+    s = SchemaSerializer(
+        core_schema.after_validator_function(lambda v, info: v + 1, core_schema.int_schema(), signature='general')
+    )
     # insert_assert(plain_repr(s))
     assert plain_repr(s) == 'SchemaSerializer(serializer=Int(IntSerializer),slots=[])'
 

--- a/tests/serializers/test_typed_dict.py
+++ b/tests/serializers/test_typed_dict.py
@@ -182,7 +182,9 @@ def test_function_plain_field_serializer_to_python():
         core_schema.typed_dict_schema(
             {
                 'x': core_schema.typed_dict_field(
-                    core_schema.int_schema(serialization=core_schema.field_plain_serializer_function_ser_schema(ser_x))
+                    core_schema.int_schema(
+                        serialization=core_schema.plain_serializer_function_ser_schema(ser_x, 'field', True)
+                    )
                 )
             }
         )
@@ -204,8 +206,8 @@ def test_function_wrap_field_serializer_to_python():
             {
                 'x': core_schema.typed_dict_field(
                     core_schema.int_schema(
-                        serialization=core_schema.field_wrap_serializer_function_ser_schema(
-                            ser_x, schema=core_schema.any_schema()
+                        serialization=core_schema.wrap_serializer_function_ser_schema(
+                            ser_x, 'field', True, schema=core_schema.any_schema()
                         )
                     )
                 )
@@ -227,7 +229,9 @@ def test_function_plain_field_serializer_to_json():
         core_schema.typed_dict_schema(
             {
                 'x': core_schema.typed_dict_field(
-                    core_schema.int_schema(serialization=core_schema.field_plain_serializer_function_ser_schema(ser_x))
+                    core_schema.int_schema(
+                        serialization=core_schema.plain_serializer_function_ser_schema(ser_x, 'field', True)
+                    )
                 )
             }
         )
@@ -249,8 +253,8 @@ def test_function_wrap_field_serializer_to_json():
             {
                 'x': core_schema.typed_dict_field(
                     core_schema.int_schema(
-                        serialization=core_schema.field_wrap_serializer_function_ser_schema(
-                            ser_x, schema=core_schema.any_schema()
+                        serialization=core_schema.wrap_serializer_function_ser_schema(
+                            ser_x, 'field', True, schema=core_schema.any_schema()
                         )
                     )
                 )

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -137,7 +137,7 @@ def test_union_of_functions():
         core_schema.union_schema(
             [
                 core_schema.any_schema(
-                    serialization=core_schema.general_plain_serializer_function_ser_schema(repr_function)
+                    serialization=core_schema.plain_serializer_function_ser_schema(repr_function, 'general', True)
                 ),
                 core_schema.float_schema(serialization=core_schema.format_ser_schema('_^14')),
             ]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -46,7 +46,7 @@ def test_pydantic_value_error_usage():
     def f(input_value, info):
         raise PydanticCustomError('my_error', 'this is a custom error {foo} {bar}', {'foo': 'FOOBAR', 'bar': 42})
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(42)
@@ -66,7 +66,7 @@ def test_pydantic_value_error_invalid_dict():
     def my_function(input_value, info):
         raise PydanticCustomError('my_error', 'this is a custom error {foo}', {(): 'foobar'})
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': my_function}})
+    v = SchemaValidator({'type': 'function-plain', 'function': my_function, 'signature': 'general'})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(42)
@@ -84,7 +84,7 @@ def test_pydantic_value_error_invalid_type():
     def f(input_value, info):
         raise PydanticCustomError('my_error', 'this is a custom error {foo}', [('foo', 123)])
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     with pytest.raises(TypeError, match="argument 'context': 'list' object cannot be converted to 'PyDict'"):
         v.validate_python(42)
@@ -101,7 +101,7 @@ def test_validator_instance_plain():
 
     c = CustomValidator()
     v = SchemaValidator(
-        {'type': 'function-plain', 'metadata': {'instance': c}, 'function': {'type': 'general', 'function': c.validate}}
+        {'type': 'function-plain', 'metadata': {'instance': c}, 'signature': 'general', 'function': c.validate}
     )
     c.foo += 1
 
@@ -124,7 +124,8 @@ def test_validator_instance_after():
         {
             'type': 'function-after',
             'metadata': {'instance': c},
-            'function': {'type': 'general', 'function': c.validate},
+            'signature': 'general',
+            'function': c.validate,
             'schema': {'type': 'str'},
         }
     )
@@ -147,9 +148,7 @@ def test_pydantic_error_type_raise_no_ctx():
     def f(input_value, info):
         raise PydanticKnownError('finite_number')
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'int'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'int'}})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(4)
@@ -163,9 +162,7 @@ def test_pydantic_error_type_raise_ctx():
     def f(input_value, info):
         raise PydanticKnownError('greater_than', {'gt': 42})
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'int'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'int'}})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(4)
@@ -315,7 +312,7 @@ def test_pydantic_value_error_plain(py_and_json: PyAndJson):
     def f(input_value, info):
         raise PydanticCustomError
 
-    v = py_and_json({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = py_and_json({'type': 'function-plain', 'function': f, 'signature': 'general'})
     with pytest.raises(TypeError, match='missing 2 required positional arguments'):
         v.validate_test('4')
 
@@ -333,7 +330,8 @@ def test_list_omit_exception(py_and_json: PyAndJson, exception):
             'items_schema': {
                 'type': 'function-after',
                 'schema': {'type': 'int'},
-                'function': {'type': 'general', 'function': f},
+                'function': f,
+                'signature': 'general',
             },
         }
     )

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -82,7 +82,7 @@ def test_omit(py_and_json: PyAndJson):
         else:
             return v
 
-    v = py_and_json(core_schema.general_plain_validator_function(omit))
+    v = py_and_json(core_schema.plain_validator_function(omit, signature='general'))
     assert v.validate_test('foo') == 'foo'
     assert v.isinstance_test('foo') is True
 

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date
+from functools import partial
 from typing import Any
 
 import pytest
@@ -20,7 +21,9 @@ class MyModel:
 
 
 def ids_function(val):
-    if callable(val):
+    if isinstance(val, partial):
+        return ids_function(val.func)
+    elif callable(val):
         return val.__name__
     elif isinstance(val, tuple) and len(val) == 2:
         return '({})'.format(', '.join([repr(a) for a in val[0]] + [f'{k}={v!r}' for k, v in val[1].items()]))
@@ -86,32 +89,24 @@ all_schema_functions = [
         {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'int'}},
     ),
     (
-        core_schema.general_before_validator_function,
+        partial(core_schema.before_validator_function, signature='general'),
         args(val_function, {'type': 'int'}),
-        {
-            'type': 'function-before',
-            'function': {'type': 'general', 'function': val_function},
-            'schema': {'type': 'int'},
-        },
+        {'type': 'function-before', 'function': val_function, 'signature': 'general', 'schema': {'type': 'int'}},
     ),
     (
-        core_schema.general_after_validator_function,
+        partial(core_schema.after_validator_function, signature='general'),
         args(val_function, {'type': 'int'}),
-        {
-            'type': 'function-after',
-            'function': {'type': 'general', 'function': val_function},
-            'schema': {'type': 'int'},
-        },
+        {'type': 'function-after', 'function': val_function, 'signature': 'general', 'schema': {'type': 'int'}},
     ),
     (
-        core_schema.general_wrap_validator_function,
+        partial(core_schema.wrap_validator_function, signature='general'),
         args(val_function, {'type': 'int'}),
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': val_function}, 'schema': {'type': 'int'}},
+        {'type': 'function-wrap', 'function': val_function, 'signature': 'general', 'schema': {'type': 'int'}},
     ),
     (
-        core_schema.general_plain_validator_function,
+        partial(core_schema.plain_validator_function, signature='general'),
         args(val_function),
-        {'type': 'function-plain', 'function': {'type': 'general', 'function': val_function}},
+        {'type': 'function-plain', 'function': val_function, 'signature': 'general'},
     ),
     (
         core_schema.with_default_schema,

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -294,8 +294,8 @@ def repr_function(value, _info):
 def test_expected_serialization_types(json_return_type):
     SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(
-                repr_function, json_return_type=json_return_type
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                repr_function, 'general', True, json_return_type=json_return_type
             )
         )
     )

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -219,7 +219,7 @@ def test_ser_function_plain():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_plain_serializer_function_ser_schema(f, json_return_type='str')
+            serialization=core_schema.plain_serializer_function_ser_schema(f, 'general', True, json_return_type='str')
         )
     )
     assert s.to_python(123) == (
@@ -236,8 +236,8 @@ def test_ser_function_wrap():
 
     s = SchemaSerializer(
         core_schema.any_schema(
-            serialization=core_schema.general_wrap_serializer_function_ser_schema(
-                f, schema=core_schema.str_schema(), when_used='json'
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                f, 'general', True, schema=core_schema.str_schema(), when_used='json'
             )
         )
     )

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -110,11 +110,12 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: CoreSchema = {
         'type': 'function-wrap',
-        'function': {'type': 'general', 'function': wrap_validator},
+        'function': wrap_validator,
+        'signature': 'general',
         'schema': {'type': 'str'},
     }
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'function-plain', 'function': {'type': 'general', 'function': validator}}
+    schema: CoreSchema = {'type': 'function-plain', 'function': validator, 'signature': 'general'}
     SchemaValidator(schema)
     schema: CoreSchema = {
         'ref': 'Branch',
@@ -182,7 +183,7 @@ def test_correct_function_signature() -> None:
     def my_validator(value: Any, info: Any) -> str:
         return str(value)
 
-    v = SchemaValidator(core_schema.general_plain_validator_function(my_validator))
+    v = SchemaValidator(core_schema.plain_validator_function(my_validator, signature='general'))
     assert v.validate_python(1) == '1'
 
 
@@ -190,7 +191,7 @@ def test_wrong_function_signature() -> None:
     def wrong_validator(value: Any) -> Any:
         return value
 
-    v = SchemaValidator(core_schema.general_plain_validator_function(wrong_validator))  # type: ignore
+    v = SchemaValidator(core_schema.plain_validator_function(wrong_validator, signature='general'))
 
     # use this instead of pytest.raises since pyright complains about input when pytest isn't installed
     try:

--- a/tests/test_validation_context.py
+++ b/tests/test_validation_context.py
@@ -9,9 +9,7 @@ def test_after(py_and_json: PyAndJson):
     def f(input_value, info):
         return input_value + f'| context: {info.context}'
 
-    v = py_and_json(
-        {'type': 'function-after', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = py_and_json({'type': 'function-after', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_test('foobar') == 'foobar| context: None'
     assert v.validate_test('foobar', None, {1: 10}) == 'foobar| context: {1: 10}'
@@ -23,9 +21,7 @@ def test_mutable_context(py_and_json: PyAndJson):
         info.context['foo'] = input_value
         return input_value
 
-    v = py_and_json(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = py_and_json({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
     mutable_context = {}
     assert v.validate_test('foobar', None, mutable_context) == 'foobar'
     assert mutable_context == {'foo': 'foobar'}
@@ -46,11 +42,11 @@ def test_typed_dict(py_and_json: PyAndJson):
             'fields': {
                 'f1': {
                     'type': 'typed-dict-field',
-                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}},
+                    'schema': {'type': 'function-plain', 'function': f1, 'signature': 'general'},
                 },
                 'f2': {
                     'type': 'typed-dict-field',
-                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}},
+                    'schema': {'type': 'function-plain', 'function': f2, 'signature': 'general'},
                 },
             },
         }
@@ -66,9 +62,7 @@ def test_wrap(py_and_json: PyAndJson):
     def f(input_value, validator, info):
         return validator(input_value) + f'| context: {info.context}'
 
-    v = py_and_json(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = py_and_json({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_test('foobar') == 'foobar| context: None'
     assert v.validate_test('foobar', None, {1: 10}) == 'foobar| context: {1: 10}'
@@ -81,9 +75,7 @@ def test_isinstance(py_and_json: PyAndJson):
             raise ValueError('wrong')
         return validator(input_value)
 
-    v = py_and_json(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = py_and_json({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('foobar', None, {}) == 'foobar'
 
@@ -120,11 +112,11 @@ def test_validate_assignment_with_context():
             'fields': {
                 'f1': {
                     'type': 'typed-dict-field',
-                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f1}},
+                    'schema': {'type': 'function-plain', 'function': f1, 'signature': 'general'},
                 },
                 'f2': {
                     'type': 'typed-dict-field',
-                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f2}},
+                    'schema': {'type': 'function-plain', 'function': f2, 'signature': 'general'},
                 },
             },
         }

--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -621,7 +621,7 @@ def test_internal_error(py_and_json: PyAndJson):
                 {
                     'name': 'b',
                     'mode': 'positional_only',
-                    'schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': double_or_bust}},
+                    'schema': {'type': 'function-plain', 'function': double_or_bust, 'signature': 'general'},
                 },
             ],
         }

--- a/tests/validators/test_chain.py
+++ b/tests/validators/test_chain.py
@@ -14,7 +14,7 @@ def test_chain():
             'type': 'chain',
             'steps': [
                 {'type': 'str'},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: Decimal(v)}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: Decimal(v)},
             ],
         }
     )
@@ -28,10 +28,10 @@ def test_chain_many():
         {
             'type': 'chain',
             'steps': [
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-1'}},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-2'}},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-3'}},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-4'}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-1'},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-2'},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-3'},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-4'},
             ],
         }
     )
@@ -67,7 +67,7 @@ def test_json(py_and_json: PyAndJson, input_value, expected):
             'type': 'chain',
             'steps': [
                 {'type': 'union', 'choices': [{'type': 'str'}, {'type': 'float'}]},
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: Decimal(v)}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: Decimal(v)},
             ],
         }
     )
@@ -81,18 +81,12 @@ def test_flatten():
         {
             'type': 'chain',
             'steps': [
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-1'}},
+                {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-1'},
                 {
                     'type': 'chain',
                     'steps': [
-                        {
-                            'type': 'function-plain',
-                            'function': {'type': 'general', 'function': lambda v, info: f'{v}-2'},
-                        },
-                        {
-                            'type': 'function-plain',
-                            'function': {'type': 'general', 'function': lambda v, info: f'{v}-3'},
-                        },
+                        {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-2'},
+                        {'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-3'},
                     ],
                 },
             ],
@@ -112,9 +106,7 @@ def test_chain_one():
     validator = SchemaValidator(
         {
             'type': 'chain',
-            'steps': [
-                {'type': 'function-plain', 'function': {'type': 'general', 'function': lambda v, info: f'{v}-1'}}
-            ],
+            'steps': [{'type': 'function-plain', 'signature': 'general', 'function': lambda v, info: f'{v}-1'}],
         }
     )
     assert validator.validate_python('input') == 'input-1'
@@ -143,7 +135,7 @@ def test_ask():
                         'return_fields_set': True,
                         'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
                     },
-                    {'type': 'function-plain', 'function': {'type': 'general', 'function': f}},
+                    {'type': 'function-plain', 'function': f, 'signature': 'general'},
                 ],
             },
         }

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -491,7 +491,9 @@ def test_dataclass_field_after_validator():
                 core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
                 core_schema.dataclass_field(
                     name='b',
-                    schema=core_schema.field_after_validator_function(Foo.validate_b, core_schema.str_schema()),
+                    schema=core_schema.after_validator_function(
+                        Foo.validate_b, core_schema.str_schema(), signature='field'
+                    ),
                 ),
             ],
         ),
@@ -522,7 +524,7 @@ def test_dataclass_field_plain_validator():
             [
                 core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
                 core_schema.dataclass_field(
-                    name='b', schema=core_schema.field_plain_validator_function(Foo.validate_b)
+                    name='b', schema=core_schema.plain_validator_function(Foo.validate_b, signature='field')
                 ),
             ],
         ),
@@ -554,7 +556,9 @@ def test_dataclass_field_before_validator():
                 core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
                 core_schema.dataclass_field(
                     name='b',
-                    schema=core_schema.field_before_validator_function(Foo.validate_b, core_schema.str_schema()),
+                    schema=core_schema.before_validator_function(
+                        Foo.validate_b, core_schema.str_schema(), signature='field'
+                    ),
                 ),
             ],
         ),
@@ -589,7 +593,10 @@ def test_dataclass_field_wrap_validator1():
             [
                 core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
                 core_schema.dataclass_field(
-                    name='b', schema=core_schema.field_wrap_validator_function(Foo.validate_b, core_schema.str_schema())
+                    name='b',
+                    schema=core_schema.wrap_validator_function(
+                        Foo.validate_b, core_schema.str_schema(), signature='field'
+                    ),
                 ),
             ],
         ),
@@ -622,7 +629,10 @@ def test_dataclass_field_wrap_validator2():
             [
                 core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
                 core_schema.dataclass_field(
-                    name='b', schema=core_schema.field_wrap_validator_function(Foo.validate_b, core_schema.str_schema())
+                    name='b',
+                    schema=core_schema.wrap_validator_function(
+                        Foo.validate_b, core_schema.str_schema(), signature='field'
+                    ),
                 ),
             ],
         ),
@@ -841,7 +851,8 @@ def test_validate_assignment_function():
                 [
                     core_schema.dataclass_field('field_a', core_schema.str_schema()),
                     core_schema.dataclass_field(
-                        'field_b', core_schema.field_after_validator_function(func, core_schema.int_schema())
+                        'field_b',
+                        core_schema.after_validator_function(func, core_schema.int_schema(), signature='field'),
                     ),
                     core_schema.dataclass_field('field_c', core_schema.int_schema()),
                 ],

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -530,7 +530,8 @@ def test_definition_wrap():
         {
             'type': 'function-wrap',
             'ref': 'wrapper',
-            'function': {'type': 'general', 'function': wrap_func},
+            'function': wrap_func,
+            'signature': 'general',
             'schema': {
                 'type': 'tuple-positional',
                 'items_schema': [
@@ -658,7 +659,8 @@ def test_function_name():
             'choices': [
                 {
                     'type': 'function-after',
-                    'function': {'type': 'general', 'function': f},
+                    'function': f,
+                    'signature': 'general',
                     'schema': {'schema_ref': 'root-schema', 'type': 'definition-ref'},
                 },
                 {'type': 'int'},
@@ -700,7 +702,8 @@ def test_function_change_id(strict: bool):
             'choices': [
                 {
                     'type': 'function-before',
-                    'function': {'type': 'general', 'function': f},
+                    'function': f,
+                    'signature': 'general',
                     'schema': {'schema_ref': 'root-schema', 'type': 'definition-ref'},
                 }
             ],

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -23,9 +23,7 @@ def test_function_before():
     def f(input_value, _info):
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -34,9 +32,7 @@ def test_function_before_no_info():
     def f(input_value):
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'no-info', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -45,9 +41,7 @@ def test_function_before_raise():
     def f(input_value, info):
         raise ValueError('foobar')
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python('input value') == 'input value Changed'
@@ -70,7 +64,8 @@ def test_function_before_error():
     v = SchemaValidator(
         {
             'type': 'function-before',
-            'function': {'type': 'general', 'function': my_function},
+            'function': my_function,
+            'signature': 'general',
             'schema': {'type': 'str', 'max_length': 5},
         }
     )
@@ -99,7 +94,8 @@ def test_function_before_error_model():
     v = SchemaValidator(
         {
             'type': 'function-before',
-            'function': {'type': 'general', 'function': f},
+            'function': f,
+            'signature': 'general',
             'schema': {
                 'type': 'typed-dict',
                 'fields': {'my_field': {'type': 'typed-dict-field', 'schema': {'type': 'str', 'max_length': 5}}},
@@ -137,7 +133,7 @@ def test_val_info_repr(config, kwargs, expected_repr):
         return input_value
 
     v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}, config
+        {'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}}, config
     )
 
     assert v.validate_python('input value', **kwargs) == 'input value'
@@ -147,9 +143,7 @@ def test_function_wrap():
     def f(input_value, validator, info):
         return validator(input_value=input_value) + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -158,9 +152,7 @@ def test_function_wrap_no_info():
     def f(input_value, validator):
         return validator(input_value=input_value) + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'no-info', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -170,9 +162,7 @@ def test_function_wrap_repr():
         assert repr(validator) == str(validator)
         return plain_repr(validator)
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'ValidatorCallable(Str(StrValidator{strict:false}))'
 
@@ -181,18 +171,14 @@ def test_function_wrap_str():
     def f(input_value, validator, info):
         return plain_repr(validator)
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'ValidatorCallable(Str(StrValidator{strict:false}))'
 
 
 def test_function_wrap_not_callable():
-    with pytest.raises(SchemaError, match='function-wrap.function.typed-dict.function\n  Input should be callable'):
-        SchemaValidator(
-            {'type': 'function-wrap', 'function': {'type': 'general', 'function': []}, 'schema': {'type': 'str'}}
-        )
+    with pytest.raises(SchemaError, match='Input should be callable'):
+        SchemaValidator({'type': 'function-wrap', 'function': [], 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(SchemaError, match='function-wrap.function\n  Field required'):
         SchemaValidator({'type': 'function-wrap', 'schema': {'type': 'str'}})
@@ -207,9 +193,7 @@ def test_wrap_error():
             assert str(e).startswith('1 validation error for ValidatorCallable\n')
             raise e
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'int'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'int'}})
 
     assert v.validate_python('42') == 84
     with pytest.raises(ValidationError) as exc_info:
@@ -228,9 +212,7 @@ def test_function_wrap_location():
     def f(input_value, validator, info):
         return validator(input_value, outer_location='foo') + 2
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'int'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'int'}})
 
     assert v.validate_python(4) == 6
     with pytest.raises(ValidationError) as exc_info:
@@ -250,9 +232,7 @@ def test_function_wrap_invalid_location():
     def f(input_value, validator, info):
         return validator(input_value, ('4',)) + 2
 
-    v = SchemaValidator(
-        {'type': 'function-wrap', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'int'}}
-    )
+    v = SchemaValidator({'type': 'function-wrap', 'function': f, 'signature': 'general', 'schema': {'type': 'int'}})
 
     with pytest.raises(TypeError, match='^outer_location must be a str or int$'):
         v.validate_python(4)
@@ -262,9 +242,7 @@ def test_function_after():
     def f(input_value, _info):
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-after', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-after', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -273,9 +251,7 @@ def test_function_no_info():
     def f(input_value):
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-after', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-after', 'function': f, 'signature': 'no-info', 'schema': {'type': 'str'}})
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -284,9 +260,7 @@ def test_function_after_raise():
     def f(input_value, info):
         raise ValueError('foobar')
 
-    v = SchemaValidator(
-        {'type': 'function-after', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-after', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python('input value') == 'input value Changed'
@@ -318,7 +292,8 @@ def test_function_after_config():
                     'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
-                        'function': {'type': 'field', 'function': f},
+                        'function': f,
+                        'signature': 'field',
                         'schema': {'type': 'str'},
                     },
                 }
@@ -344,9 +319,7 @@ def test_config_no_model():
         f_kwargs = deepcopy_info(info)
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-after', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-after', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     assert v.validate_python(b'abc') == 'abc Changed'
     assert f_kwargs == {'data': None, 'config': None, 'context': None, 'field_name': None}
@@ -356,7 +329,7 @@ def test_function_plain():
     def f(input_value, _info):
         return input_value * 2
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'general'})
 
     assert v.validate_python(1) == 2
     assert v.validate_python('x') == 'xx'
@@ -366,7 +339,7 @@ def test_function_plain_no_info():
     def f(input_value):
         return input_value * 2
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'no-info', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'no-info'})
 
     assert v.validate_python(1) == 2
     assert v.validate_python('x') == 'xx'
@@ -375,11 +348,7 @@ def test_function_plain_no_info():
 def test_plain_with_schema():
     with pytest.raises(SchemaError, match='function-plain.schema\n  Extra inputs are not permitted'):
         SchemaValidator(
-            {
-                'type': 'function-plain',
-                'function': {'type': 'general', 'function': lambda x: x},
-                'schema': {'type': 'str'},
-            }
+            {'type': 'function-plain', 'signature': 'general', 'function': lambda x: x, 'schema': {'type': 'str'}}
         )
 
 
@@ -391,7 +360,8 @@ def test_validate_assignment():
     v = SchemaValidator(
         {
             'type': 'function-after',
-            'function': {'type': 'general', 'function': f},
+            'function': f,
+            'signature': 'general',
             'schema': {
                 'type': 'typed-dict',
                 'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}}},
@@ -408,9 +378,7 @@ def test_function_wrong_sig():
     def f(input_value):
         return input_value + ' Changed'
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     # exception messages differ between python and pypy
     if platform.python_implementation() == 'PyPy':
@@ -434,11 +402,7 @@ def test_class_with_validator():
             return Foobar(input_value * 2)
 
     v = SchemaValidator(
-        {
-            'type': 'function-after',
-            'function': {'type': 'general', 'function': Foobar.__validate__},
-            'schema': {'type': 'str'},
-        }
+        {'type': 'function-after', 'function': Foobar.__validate__, 'signature': 'general', 'schema': {'type': 'str'}}
     )
 
     f = v.validate_python('foo')
@@ -461,9 +425,7 @@ def test_raise_assertion_error():
     def f(input_value, info):
         raise AssertionError('foobar')
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python('input value')
@@ -483,9 +445,7 @@ def test_raise_assertion_error_plain():
     def f(input_value, info):
         raise AssertionError
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python('input value')
@@ -510,9 +470,7 @@ def test_error_with_error(base_error: Type[Exception]):
     def f(input_value, info):
         raise MyError()
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(RuntimeError, match='internal error'):
         v.validate_python('input value')
@@ -522,9 +480,7 @@ def test_raise_type_error():
     def f(input_value, info):
         raise TypeError('foobar')
 
-    v = SchemaValidator(
-        {'type': 'function-before', 'function': {'type': 'general', 'function': f}, 'schema': {'type': 'str'}}
-    )
+    v = SchemaValidator({'type': 'function-before', 'function': f, 'signature': 'general', 'schema': {'type': 'str'}})
 
     with pytest.raises(TypeError, match='^foobar$'):
         v.validate_python('input value')
@@ -551,7 +507,7 @@ def test_model_field_before_validator() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.field_before_validator_function(f, core_schema.str_schema())
+                        core_schema.before_validator_function(f, core_schema.str_schema(), signature='field')
                     )
                 }
             ),
@@ -580,7 +536,7 @@ def test_model_field_after_validator() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.field_after_validator_function(f, core_schema.str_schema())
+                        core_schema.after_validator_function(f, core_schema.str_schema(), signature='field')
                     )
                 }
             ),
@@ -607,7 +563,7 @@ def test_model_field_plain_validator() -> None:
         core_schema.model_schema(
             Model,
             core_schema.typed_dict_schema(
-                {'x': core_schema.typed_dict_field(core_schema.field_plain_validator_function(f))}
+                {'x': core_schema.typed_dict_field(core_schema.plain_validator_function(f, signature='field'))}
             ),
         )
     )
@@ -636,7 +592,7 @@ def test_model_field_wrap_validator() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.field_wrap_validator_function(f, core_schema.str_schema())
+                        core_schema.wrap_validator_function(f, core_schema.str_schema(), signature='field')
                     )
                 }
             ),
@@ -673,7 +629,7 @@ def test_non_model_field_before_validator_tries_to_access_field_info() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.general_before_validator_function(f, core_schema.str_schema())
+                        core_schema.before_validator_function(f, core_schema.str_schema(), signature='general')
                     )
                 }
             ),
@@ -700,7 +656,7 @@ def test_non_model_field_after_validator_tries_to_access_field_info() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.general_after_validator_function(f, core_schema.str_schema())
+                        core_schema.after_validator_function(f, core_schema.str_schema(), signature='general')
                     )
                 }
             ),
@@ -726,7 +682,7 @@ def test_non_model_field_plain_validator_tries_to_access_field_info() -> None:
         core_schema.model_schema(
             Model,
             core_schema.typed_dict_schema(
-                {'x': core_schema.typed_dict_field(core_schema.general_plain_validator_function(f))}
+                {'x': core_schema.typed_dict_field(core_schema.plain_validator_function(f, signature='general'))}
             ),
         )
     )
@@ -751,7 +707,7 @@ def test_non_model_field_wrap_validator_tries_to_access_field_info() -> None:
             core_schema.typed_dict_schema(
                 {
                     'x': core_schema.typed_dict_field(
-                        core_schema.general_wrap_validator_function(f, core_schema.str_schema())
+                        core_schema.wrap_validator_function(f, core_schema.str_schema(), signature='general')
                     )
                 }
             ),
@@ -765,7 +721,7 @@ def test_method_function_no_model():
     def f(*args: Any, **kwargs: Any) -> Any:  # pragma: no cover
         raise AssertionError('Should not be called')
 
-    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'field', 'function': f}})
+    v = SchemaValidator({'type': 'function-plain', 'function': f, 'signature': 'field'})
 
     with pytest.raises(
         RuntimeError,
@@ -789,7 +745,7 @@ def test_typed_dict_data() -> None:
                 'a': core_schema.typed_dict_field(core_schema.int_schema()),
                 'b': core_schema.typed_dict_field(core_schema.int_schema()),
                 'c': core_schema.typed_dict_field(
-                    core_schema.field_after_validator_function(f, core_schema.str_schema())
+                    core_schema.after_validator_function(f, core_schema.str_schema(), signature='field')
                 ),
             }
         )
@@ -839,7 +795,8 @@ def test_model_root_function_assignment(mode: str, calls1: Any, calls2: Any):
             Model,
             {
                 'type': f'function-{mode}',
-                'function': {'type': 'general', 'function': f},
+                'function': f,
+                'signature': 'general',
                 'schema': core_schema.typed_dict_schema(
                     {
                         'x': core_schema.typed_dict_field(core_schema.str_schema()),

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -30,6 +30,17 @@ def test_function_before():
     assert v.validate_python('input value') == 'input value Changed'
 
 
+def test_function_before_no_info():
+    def f(input_value):
+        return input_value + ' Changed'
+
+    v = SchemaValidator(
+        {'type': 'function-before', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
+    )
+
+    assert v.validate_python('input value') == 'input value Changed'
+
+
 def test_function_before_raise():
     def f(input_value, info):
         raise ValueError('foobar')
@@ -143,6 +154,17 @@ def test_function_wrap():
     assert v.validate_python('input value') == 'input value Changed'
 
 
+def test_function_wrap_no_info():
+    def f(input_value, validator):
+        return validator(input_value=input_value) + ' Changed'
+
+    v = SchemaValidator(
+        {'type': 'function-wrap', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
+    )
+
+    assert v.validate_python('input value') == 'input value Changed'
+
+
 def test_function_wrap_repr():
     def f(input_value, validator, info):
         assert repr(validator) == str(validator)
@@ -247,6 +269,17 @@ def test_function_after():
     assert v.validate_python('input value') == 'input value Changed'
 
 
+def test_function_no_info():
+    def f(input_value):
+        return input_value + ' Changed'
+
+    v = SchemaValidator(
+        {'type': 'function-after', 'function': {'type': 'no-info', 'function': f}, 'schema': {'type': 'str'}}
+    )
+
+    assert v.validate_python('input value') == 'input value Changed'
+
+
 def test_function_after_raise():
     def f(input_value, info):
         raise ValueError('foobar')
@@ -320,10 +353,20 @@ def test_config_no_model():
 
 
 def test_function_plain():
-    def f(input_value, info):
+    def f(input_value, _info):
         return input_value * 2
 
     v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'general', 'function': f}})
+
+    assert v.validate_python(1) == 2
+    assert v.validate_python('x') == 'xx'
+
+
+def test_function_plain_no_info():
+    def f(input_value):
+        return input_value * 2
+
+    v = SchemaValidator({'type': 'function-plain', 'function': {'type': 'no-info', 'function': f}})
 
     assert v.validate_python(1) == 2
     assert v.validate_python('x') == 'xx'

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -220,7 +220,7 @@ def test_list_function():
         return input_value * 2
 
     v = SchemaValidator(
-        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f}}}
+        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': f, 'signature': 'general'}}
     )
 
     assert v.validate_python([1, 2, 3]) == [2, 4, 6]
@@ -231,7 +231,7 @@ def test_list_function_val_error():
         raise ValueError(f'error {input_value}')
 
     v = SchemaValidator(
-        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f}}}
+        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': f, 'signature': 'general'}}
     )
 
     with pytest.raises(ValidationError) as exc_info:
@@ -247,7 +247,7 @@ def test_list_function_internal_error():
         raise RuntimeError(f'error {input_value}')
 
     v = SchemaValidator(
-        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': {'type': 'general', 'function': f}}}
+        {'type': 'list', 'items_schema': {'type': 'function-plain', 'function': f, 'signature': 'general'}}
     )
 
     with pytest.raises(RuntimeError, match='^error 1$') as exc_info:

--- a/tests/validators/test_model_init.py
+++ b/tests/validators/test_model_init.py
@@ -96,7 +96,8 @@ def test_function_before():
     v = SchemaValidator(
         {
             'type': 'function-before',
-            'function': {'type': 'general', 'function': f},
+            'function': f,
+            'signature': 'general',
             'schema': {
                 'type': 'model',
                 'cls': MyModel,
@@ -133,7 +134,8 @@ def test_function_after():
     v = SchemaValidator(
         {
             'type': 'function-after',
-            'function': {'type': 'general', 'function': f},
+            'function': f,
+            'signature': 'general',
             'schema': {
                 'type': 'model',
                 'cls': MyModel,
@@ -172,7 +174,8 @@ def test_function_wrap():
     v = SchemaValidator(
         {
             'type': 'function-wrap',
-            'function': {'type': 'general', 'function': f},
+            'function': f,
+            'signature': 'general',
             'schema': {
                 'type': 'model',
                 'cls': MyModel,

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -271,7 +271,8 @@ def test_validate_assignment_functions():
                     'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
-                        'function': {'type': 'general', 'function': func_a},
+                        'function': func_a,
+                        'signature': 'general',
                         'schema': {'type': 'str'},
                     },
                 },
@@ -279,7 +280,8 @@ def test_validate_assignment_functions():
                     'type': 'typed-dict-field',
                     'schema': {
                         'type': 'function-after',
-                        'function': {'type': 'general', 'function': func_b},
+                        'function': func_b,
+                        'signature': 'general',
                         'schema': {'type': 'int'},
                     },
                 },
@@ -1660,7 +1662,8 @@ class TestOnError:
                             'on_error': 'raise',
                             'schema': {
                                 'type': 'function-wrap',
-                                'function': {'type': 'general', 'function': wrap_function},
+                                'signature': 'general',
+                                'function': wrap_function,
                                 'schema': {'type': 'str'},
                             },
                         },


### PR DESCRIPTION
We could then do something similar for serializers. It will save a lot of LOC, and if we want to enforce the types in the future we can do that via overloads on the functions that produce them.