### PR TITLE
maturin build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,11 @@ jobs:
       - run: 'pip install "maturin>=0.14.16,<0.15" typing_extensions'
 
       # purposefully building here using maturin, not `pip install` so we do a debug build
-      - run: maturin develop
+      - run: maturin build
         env:
           RUST_BACKTRACE: 1
+
+      - run: pip install `find target/wheels/*.whl`
 
       - run: pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
 
       - run: pip install -r tests/requirements.txt
 
-      - run: pip install -e .
+      # purposefully building here using maturin, not `pip install` so we do a debug build
+      - run: maturin develop
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - run: pip install `find target/wheels/*.whl`
+      - run: rm tests/__init__.py
 
       - run: pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,10 @@ jobs:
 
       - run: 'pip install "maturin>=0.14.16,<0.15" typing_extensions'
 
-      # purposefully building here using maturin, not `pip install` so we do a debug build
-      - run: maturin build
+      # purposefully building here using `make build-dev`, not `pip install` so we do a debug build
+      - run: make build-dev
         env:
           RUST_BACKTRACE: 1
-
-      - run: pip install `find target/wheels/*.whl`
-      - run: rm tests/__init__.py
 
       - run: pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
 
       - run: pip install -r tests/requirements.txt
 
+      - run: 'pip install maturin>=0.14.16,<0.15 typing_extensions'
+
       # purposefully building here using maturin, not `pip install` so we do a debug build
       - run: maturin develop
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - run: pip install -r tests/requirements.txt
 
-      - run: 'pip install maturin>=0.14.16,<0.15 typing_extensions'
+      - run: 'pip install "maturin>=0.14.16,<0.15" typing_extensions'
 
       # purposefully building here using maturin, not `pip install` so we do a debug build
       - run: maturin develop


### PR DESCRIPTION
Doing it this way since running tests with a debug build catches some errors that an optimised release build doesn't.

@messense is there any way to do build in unoptimised mode with `pip install -e .`? That would be a cleaner alternative.