### PR TITLE
Uprev to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "ahash",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"


### PR DESCRIPTION
Doing another release so quickly so we can get it working to inherit from `ValidationError` for work on making FastAPI compatible with pydantic v2.