### PR TITLE
use `LiteralString` on `PydanticCustomError`

### DIFF
--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -11,9 +11,9 @@ else:
     from typing import TypedDict
 
 if sys.version_info < (3, 11):
-    from typing_extensions import Literal, NotRequired, TypeAlias
+    from typing_extensions import Literal, LiteralString, NotRequired, TypeAlias
 else:
-    from typing import Literal, NotRequired, TypeAlias
+    from typing import Literal, LiteralString, NotRequired, TypeAlias
 
 from _typeshed import SupportsAllComparisons
 
@@ -189,7 +189,9 @@ class ValidationError(ValueError):
     def json(self, indent: 'int | None' = None, include_context: bool = False) -> str: ...
 
 class PydanticCustomError(ValueError):
-    def __init__(self, error_type: str, message_template: str, context: 'dict[str, Any] | None' = None) -> None: ...
+    def __init__(
+        self, error_type: LiteralString, message_template: LiteralString, context: 'dict[str, Any] | None' = None
+    ) -> None: ...
     @property
     def type(self) -> str: ...
     @property


### PR DESCRIPTION
to avoid temptation to make `error_type` and particularly `message_template` dynamic, might require a few type-ignores, but that's fine.

Noticed while reviewing https://github.com/pydantic/pydantic/pull/5599.