### PR TITLE
Add `custom_init` logic

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -2737,6 +2737,7 @@ class ModelSchema(TypedDict, total=False):
     revalidate_instances: Literal['always', 'never', 'subclass-instances']  # default: 'never'
     strict: bool
     frozen: bool
+    custom_init: bool
     config: CoreConfig
     ref: str
     metadata: Any
@@ -2751,6 +2752,7 @@ def model_schema(
     revalidate_instances: Literal['always', 'never', 'subclass-instances'] | None = None,
     strict: bool | None = None,
     frozen: bool | None = None,
+    custom_init: bool | None = None,
     config: CoreConfig | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -2791,6 +2793,7 @@ def model_schema(
           should re-validate defaults to config.revalidate_instances, else 'never'
         strict: Whether the model is strict
         frozen: Whether the model is frozen
+        custom_init: Whether the model has a custom init method
         config: The config to use for the model
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -2804,6 +2807,7 @@ def model_schema(
         revalidate_instances=revalidate_instances,
         strict=strict,
         frozen=frozen,
+        custom_init=custom_init,
         config=config,
         ref=ref,
         metadata=metadata,

--- a/src/argument_markers.rs
+++ b/src/argument_markers.rs
@@ -60,3 +60,30 @@ impl ArgsKwargs {
         }
     }
 }
+
+pub(crate) const VALIDATED_DATA_KEY: &str = "validated_data";
+
+#[pyclass(module = "pydantic_core._pydantic_core", frozen, get_all, freelist = 100)]
+#[derive(Debug, Clone)]
+pub struct ValidatedData {
+    pub model_dict: PyObject,
+    pub fields_set: PyObject,
+}
+
+impl ValidatedData {
+    pub(crate) fn new(model_dict: &PyAny, fields_set: &PyAny) -> Self {
+        Self {
+            model_dict: model_dict.to_object(model_dict.py()),
+            fields_set: fields_set.to_object(model_dict.py()),
+        }
+    }
+}
+
+#[pymethods]
+impl ValidatedData {
+    fn __repr__(&self, py: Python) -> String {
+        let model_dict = safe_repr(self.model_dict.as_ref(py));
+        let fields_set = safe_repr(self.fields_set.as_ref(py));
+        format!("ValidatedData(model_dict={model_dict}, fields_set={fields_set})")
+    }
+}

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyType};
 
+use crate::argument_markers::ValidatedData;
 use crate::errors::{InputValue, LocItem, ValResult};
 use crate::{PyMultiHostUrl, PyUrl};
 
@@ -41,6 +42,11 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
 
     #[cfg_attr(has_no_coverage, no_coverage)]
     fn input_get_attr(&self, _name: &PyString) -> Option<PyResult<&PyAny>> {
+        None
+    }
+
+    #[cfg_attr(has_no_coverage, no_coverage)]
+    fn validated_data(&self) -> Option<ValidatedData> {
         None
     }
 

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -11,6 +11,7 @@ use pyo3::types::{
 use pyo3::types::{PyDictItems, PyDictKeys, PyDictValues};
 use pyo3::{ffi, intern, AsPyPointer, PyTypeInfo};
 
+use crate::argument_markers::{ValidatedData, VALIDATED_DATA_KEY};
 use crate::build_tools::safe_repr;
 use crate::errors::{ErrorType, InputValue, LocItem, ValError, ValResult};
 use crate::{ArgsKwargs, PyMultiHostUrl, PyUrl};
@@ -100,6 +101,16 @@ impl<'a> Input<'a> for PyAny {
 
     fn input_get_attr(&self, name: &PyString) -> Option<PyResult<&PyAny>> {
         Some(self.getattr(name))
+    }
+
+    #[cfg_attr(has_no_coverage, no_coverage)]
+    fn validated_data(&self) -> Option<ValidatedData> {
+        if let Ok(v) = self.get_item(intern!(self.py(), VALIDATED_DATA_KEY)) {
+            if let Ok(validated_data) = v.extract::<ValidatedData>() {
+                return Some(validated_data);
+            }
+        }
+        None
     }
 
     fn input_is_instance(&self, class: &PyAny, _json_mask: u8) -> PyResult<bool> {

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -7,6 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyTuple, PyType};
 use pyo3::{ffi, intern};
 
+use crate::argument_markers::{ValidatedData, VALIDATED_DATA_KEY};
 use crate::build_tools::{py_err, schema_or_config_same, SchemaDict};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{py_error_on_minusone, Input};
@@ -51,6 +52,7 @@ pub struct ModelValidator {
     post_init: Option<Py<PyString>>,
     name: String,
     frozen: bool,
+    custom_init: bool,
 }
 
 impl BuildValidator for ModelValidator {
@@ -87,6 +89,7 @@ impl BuildValidator for ModelValidator {
             // which is not what we want here
             name: class.getattr(intern!(py, "__name__"))?.extract()?,
             frozen: schema.get_as(intern!(py, "frozen"))?.unwrap_or(false),
+            custom_init: schema.get_as(intern!(py, "custom_init"))?.unwrap_or(false),
         }
         .into())
     }
@@ -227,6 +230,18 @@ impl ModelValidator {
             ..*extra
         };
 
+        if self.custom_init {
+            if let Some(validated_data) = input.validated_data() {
+                set_model_attrs(
+                    self_instance,
+                    validated_data.model_dict.as_ref(py),
+                    validated_data.fields_set.as_ref(py),
+                )?;
+                // we don't call post_init here, it'll be called by the original validator
+                return Ok(self_instance.into_py(py));
+            }
+        }
+
         let output = self.validator.validate(py, input, &new_extra, slots, recursion_guard)?;
         let (model_dict, fields_set): (&PyAny, &PyAny) = output.extract(py)?;
         set_model_attrs(self_instance, model_dict, fields_set)?;
@@ -250,9 +265,16 @@ impl ModelValidator {
 
     fn create_class(&self, model_dict: &PyAny, fields_set: &PyAny) -> PyResult<PyObject> {
         let py = model_dict.py();
-        let instance = create_class(self.class.as_ref(py))?;
-        set_model_attrs(instance.as_ref(py), model_dict, fields_set)?;
-        Ok(instance)
+        if self.custom_init {
+            let kwargs = PyDict::new(py);
+            let vd = ValidatedData::new(model_dict, fields_set);
+            kwargs.set_item(intern!(py, VALIDATED_DATA_KEY), vd.into_py(py))?;
+            self.class.call(py, (), Some(kwargs))
+        } else {
+            let instance = create_class(self.class.as_ref(py))?;
+            set_model_attrs(instance.as_ref(py), model_dict, fields_set)?;
+            Ok(instance)
+        }
     }
 }
 

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1161,3 +1161,102 @@ def test_validate_assignment_model_validator_function(function_schema: Any, call
     assert m.b == 2
     assert m.__pydantic_fields_set__ == {'a', 'b'}
     assert calls == [call1, call2]
+
+
+def test_custom_init():
+    calls = []
+
+    class Model:
+        __slots__ = '__dict__', '__pydantic_fields_set__'
+
+        def __init__(self, **kwargs):
+            validated_data = kwargs['validated_data']
+            self.a = validated_data.model_dict['a']
+            self.b = validated_data.model_dict['b']
+            self.__pydantic_fields_set__ = validated_data.fields_set
+            calls.append(repr(kwargs))
+
+    v = SchemaValidator(
+        core_schema.model_schema(
+            Model,
+            core_schema.typed_dict_schema(
+                {
+                    'a': core_schema.typed_dict_field(
+                        core_schema.with_default_schema(core_schema.int_schema(), default=1)
+                    ),
+                    'b': core_schema.typed_dict_field(core_schema.int_schema()),
+                },
+                return_fields_set=True,
+            ),
+            custom_init=True,
+        )
+    )
+
+    m = v.validate_python({'b': 2})
+    assert m.a == 1
+    assert m.b == 2
+    assert m.__pydantic_fields_set__ == {'b'}
+    assert calls == ["{'validated_data': ValidatedData(model_dict={'a': 1, 'b': 2}, fields_set={'b'})}"]
+
+
+def test_custom_init_nested():
+    calls = []
+
+    class ModelInner:
+        __slots__ = '__dict__', '__pydantic_fields_set__'
+        a: int
+        b: int
+
+        def __init__(self, **data):
+            calls.append(f'inner: {data!r}')
+            self.__pydantic_validator__.validate_python(data, self_instance=self)
+
+    inner_schema = core_schema.model_schema(
+        ModelInner,
+        core_schema.typed_dict_schema(
+            {
+                'a': core_schema.typed_dict_field(core_schema.with_default_schema(core_schema.int_schema(), default=1)),
+                'b': core_schema.typed_dict_field(core_schema.int_schema()),
+            },
+            return_fields_set=True,
+        ),
+        custom_init=True,
+    )
+    ModelInner.__pydantic_validator__ = SchemaValidator(inner_schema)
+
+    class ModelOuter:
+        __slots__ = '__dict__', '__pydantic_fields_set__'
+        a: int
+        b: ModelInner
+
+        def __init__(self, **data):
+            calls.append(f'outer: {data!r}')
+            self.__pydantic_validator__.validate_python(data, self_instance=self)
+
+    ModelOuter.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            ModelOuter,
+            core_schema.typed_dict_schema(
+                {
+                    'a': core_schema.typed_dict_field(
+                        core_schema.with_default_schema(core_schema.int_schema(), default=1)
+                    ),
+                    'b': core_schema.typed_dict_field(inner_schema),
+                },
+                return_fields_set=True,
+            ),
+            custom_init=True,
+        )
+    )
+
+    m = ModelOuter(a=2, b={'b': 3})
+    assert m.__pydantic_fields_set__ == {'a', 'b'}
+    assert m.a == 2
+    assert isinstance(m.b, ModelInner)
+    assert m.b.a == 1
+    assert m.b.b == 3
+    # insert_assert(calls)
+    assert calls == [
+        "outer: {'a': 2, 'b': {'b': 3}}",
+        "inner: {'validated_data': ValidatedData(model_dict={'a': 1, 'b': 3}, fields_set={'b'})}",
+    ]


### PR DESCRIPTION
This reverts commit 4c4fe8a6aa8ece15fdf93326c23961a9f881b38b - built by reverting the commit that removed `custom_init` in #565

---

Quoting from #565 

The principle is working, the only potential problem I see is that the `data` kwargs aren't the original, instead they're of the form

```py
{'validated_data': ValidatedData(model_dict={'a': 1, 'b': 3}, fields_set={'b'})}
```

where `ValidatedData` is a custom type that's internal to pydantic-core and can't be constructed outside.
