### PR TITLE
Make ValidationError behave more like an ExceptionGroup

### DIFF
--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -15,7 +15,7 @@ else:
 if sys.version_info < (3, 11):
     from typing_extensions import Literal, LiteralString, NotRequired, Self, TypeAlias
 else:
-    from typing import Literal, LiteralString, NotRequired, TypeAlias
+    from typing import Literal, LiteralString, NotRequired, Self, TypeAlias
 
 from _typeshed import SupportsAllComparisons
 
@@ -185,13 +185,15 @@ Location = tuple[str | int, ...]
 class ValidationError(ValueError):
     def __init__(
         self,
-        title: str,
+        message: str,
         errors: 'list[InitErrorDetails | ValidationError]',
         error_mode: Literal['python', 'json'] = 'python',
         loc_prefix: Location | None = None,
     ) -> None: ...
     @property
-    def title(self) -> str: ...
+    def message(self) -> str: ...
+    @property
+    def error_mode(self) -> Literal['python', 'json']: ...
     def error_count(self) -> int: ...
     def errors(self, *, include_url: bool = True, include_context: bool = True) -> 'list[ErrorDetails]': ...
     def json(self, *, indent: 'int | None' = None, include_url: bool = True, include_context: bool = False) -> str: ...

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import decimal
 import sys
 from typing import Any, Callable

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -11,7 +11,7 @@ else:
     from typing import TypedDict
 
 if sys.version_info < (3, 11):
-    from typing_extensions import Literal, LiteralString, NotRequired, TypeAlias
+    from typing_extensions import Literal, LiteralString, NotRequired, Self, TypeAlias
 else:
     from typing import Literal, LiteralString, NotRequired, TypeAlias
 
@@ -178,15 +178,22 @@ class SchemaError(Exception):
     def error_count(self) -> int: ...
     def errors(self) -> 'list[ErrorDetails]': ...
 
+Location = tuple[str | int, ...]
+
 class ValidationError(ValueError):
     def __init__(
-        self, title: str, errors: 'list[InitErrorDetails]', error_mode: Literal['python', 'json'] = 'python'
+        self,
+        title: str,
+        errors: 'list[InitErrorDetails | ValidationError]',
+        error_mode: Literal['python', 'json'] = 'python',
+        loc_prefix: Location | None = None,
     ) -> None: ...
     @property
     def title(self) -> str: ...
     def error_count(self) -> int: ...
     def errors(self, *, include_url: bool = True, include_context: bool = True) -> 'list[ErrorDetails]': ...
     def json(self, *, indent: 'int | None' = None, include_url: bool = True, include_context: bool = False) -> str: ...
+    def derive(self: Self, __exceptions: 'list[InitErrorDetails | ValidationError]') -> Self: ...
 
 class PydanticCustomError(ValueError):
     def __init__(

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -114,8 +114,7 @@ impl Serialize for LocItem {
 /// Note: location in List is stored in **REVERSE** so adding an "outer" item to location involves
 /// pushing to the vec which is faster than inserting and shifting everything along.
 /// Then when "using" location in `Display` and `ToPyObject` order has to be reversed
-#[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Debug)]
 pub enum Location {
     // no location, avoid creating an unnecessary vec
     Empty,

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -114,7 +114,8 @@ impl Serialize for LocItem {
 /// Note: location in List is stored in **REVERSE** so adding an "outer" item to location involves
 /// pushing to the vec which is faster than inserting and shifting everything along.
 /// Then when "using" location in `Display` and `ToPyObject` order has to be reversed
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub enum Location {
     // no location, avoid creating an unnecessary vec
     Empty,

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -190,13 +190,18 @@ impl Location {
     }
 
     pub fn with_prefix(&self, prefix: &Location) -> Location {
+        // Reminder: locations are reversed!
         match (prefix, self) {
             (Location::Empty, Location::Empty) => Location::Empty,
             (Location::Empty, Location::List(_)) => self.clone(),
-            (Location::List(_), Location::Empty) => prefix.clone(),
-            (Location::List(prefix_list), Location::List(self_list)) => {
-                Location::List(prefix_list.iter().chain(self_list.iter()).cloned().collect())
-            }
+            (Location::List(v), Location::Empty) => Location::List(v.iter().rev().cloned().collect()),
+            (Location::List(prefix_list), Location::List(self_list)) => Location::List(
+                self_list
+                    .iter()
+                    .cloned()
+                    .chain(prefix_list.iter().rev().cloned())
+                    .collect(),
+            ),
         }
     }
 }

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -143,6 +143,12 @@ impl ToPyObject for Location {
     }
 }
 
+impl IntoPy<PyObject> for Location {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        self.to_object(py)
+    }
+}
+
 impl From<&LookupPath> for Location {
     fn from(lookup_path: &LookupPath) -> Self {
         let v = lookup_path
@@ -181,6 +187,17 @@ impl Location {
                 *self = Self::new_some(loc_item);
             }
         };
+    }
+
+    pub fn with_prefix(&self, prefix: &Location) -> Location {
+        match (prefix, self) {
+            (Location::Empty, Location::Empty) => Location::Empty,
+            (Location::Empty, Location::List(_)) => self.clone(),
+            (Location::List(_), Location::Empty) => prefix.clone(),
+            (Location::List(prefix_list), Location::List(self_list)) => {
+                Location::List(prefix_list.iter().chain(self_list.iter()).cloned().collect())
+            }
+        }
     }
 }
 

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -327,8 +327,7 @@ pub fn pretty_py_line_errors(
 
 /// `PyLineError` are the public version of `ValLineError`, as help and used in `ValidationError`s
 #[pyclass]
-#[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug, Clone)]
 pub struct PyLineError {
     error_type: ErrorType,
     location: Location,

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -24,7 +24,8 @@ use super::types::{ErrorMode, ErrorType};
 use super::value_exception::PydanticCustomError;
 use super::ValError;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 enum WrappedError {
     LineError(PyLineError),
     ValidationError(ValidationError),
@@ -327,7 +328,8 @@ pub fn pretty_py_line_errors(
 
 /// `PyLineError` are the public version of `ValLineError`, as help and used in `ValidationError`s
 #[pyclass]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PyLineError {
     error_type: ErrorType,
     location: Location,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -640,7 +640,7 @@ def test_subclass_validation_error():
             self.body = body
             super().__init__(message, errors, 'python')
 
-        def derive(self, __exceptions: list[InitErrorDetails | ValidationError]) -> 'MyValidationError':
+        def derive(self, __exceptions: 'list[InitErrorDetails | ValidationError]') -> 'MyValidationError':
             return MyValidationError(message=self.title, errors=__exceptions, body=self.body)
 
     e = MyValidationError('testing', [])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -674,22 +674,14 @@ def test_raise_validation_tree():
     )
 
     assert v.error_count() == 3
-    assert v.errors() == [
-        {
-            'type': 'less_than',
-            'loc': (2, 'a'),
-            'msg': 'Input should be less than 1',
-            'input': 8,
-            'ctx': {'lt': 1},
-            'url': 'https://errors.pydantic.dev/0.28.1/v/less_than',
-        },
+    assert v.errors(include_url=False) == [
+        {'type': 'less_than', 'loc': (2, 'a'), 'msg': 'Input should be less than 1', 'input': 8, 'ctx': {'lt': 1}},
         {
             'type': 'greater_than',
             'loc': (2, 'a'),
             'msg': 'Input should be greater than 5',
             'input': 4,
             'ctx': {'gt': 5},
-            'url': 'https://errors.pydantic.dev/0.28.1/v/greater_than',
         },
         {
             'type': 'greater_than',
@@ -697,6 +689,18 @@ def test_raise_validation_tree():
             'msg': 'Input should be greater than 5',
             'input': 2,
             'ctx': {'gt': 5},
-            'url': 'https://errors.pydantic.dev/0.28.1/v/greater_than',
         },
     ]
+    # fmt: off
+    assert repr(v) == f"""\
+3 validation errors for merged
+2.a
+  Input should be less than 1 [type=less_than, input_value=8, input_type=int]
+    For further information visit https://errors.pydantic.dev/{__version__}/v/less_than
+2.a
+  Input should be greater than 5 [type=greater_than, input_value=4, input_type=int]
+    For further information visit https://errors.pydantic.dev/{__version__}/v/greater_than
+1.a
+  Input should be greater than 5 [type=greater_than, input_value=2, input_type=int]
+    For further information visit https://errors.pydantic.dev/{__version__}/v/greater_than"""
+    # fmt: on


### PR DESCRIPTION
#593

This PR implements the internal structure for ValidationError and allows ValidationError to accept other ValidationErrors.
I think the next PR will need to refactor `LineError` and make it public (or introduce a new class that is similar but public). Then we can expose methods to iterate through not only the leaves but also the nodes.

Selected Reviewer: @dmontagu