### PR TITLE
Use return_schema for computed fields

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -415,23 +415,25 @@ SerSchema = Union[
 class ComputedField(TypedDict, total=False):
     type: Required[Literal['computed-field']]
     property_name: Required[str]
-    json_return_type: JsonReturnTypes
+    return_schema: Required[CoreSchema]
     alias: str
+    metadata: Any
 
 
 def computed_field(
-    property_name: str, *, json_return_type: JsonReturnTypes | None = None, alias: str | None = None
+    property_name: str, return_schema: CoreSchema, *, alias: str | None = None, metadata: Any = None
 ) -> ComputedField:
     """
     ComputedFields are properties of a model or dataclass that are included in serialization.
 
     Args:
         property_name: The name of the property on the model or dataclass
-        json_return_type: The type that the property returns if `mode='json'`
+        return_schema: The schema used for the type returned by the computed field
         alias: The name to use in the serialized output
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
     """
     return dict_not_none(
-        type='computed-field', property_name=property_name, json_return_type=json_return_type, alias=alias
+        type='computed-field', property_name=property_name, return_schema=return_schema, alias=alias, metadata=metadata
     )
 
 
@@ -3676,6 +3678,8 @@ CoreSchemaType = Literal[
     'definitions',
     'definition-ref',
 ]
+
+CoreSchemaFieldType = Literal['model-field', 'dataclass-field', 'typed-dict-field', 'computed-field']
 
 
 # used in _pydantic_core.pyi::PydanticKnownError

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -48,7 +48,7 @@ impl BuildSerializer for DataclassArgsBuilder {
             }
         }
 
-        let computed_fields = ComputedFields::new(schema)?;
+        let computed_fields = ComputedFields::new(schema, config, definitions)?;
 
         Ok(GeneralFieldsSerializer::new(fields, fields_mode, computed_fields).into())
     }

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -55,7 +55,7 @@ impl BuildSerializer for ModelFieldsBuilder {
             }
         }
 
-        let computed_fields = ComputedFields::new(schema)?;
+        let computed_fields = ComputedFields::new(schema, config, definitions)?;
 
         Ok(GeneralFieldsSerializer::new(fields, fields_mode, computed_fields).into())
     }

--- a/src/serializers/type_serializers/typed_dict.rs
+++ b/src/serializers/type_serializers/typed_dict.rs
@@ -53,7 +53,7 @@ impl BuildSerializer for TypedDictBuilder {
             }
         }
 
-        let computed_fields = ComputedFields::new(schema)?;
+        let computed_fields = ComputedFields::new(schema, config, definitions)?;
 
         Ok(GeneralFieldsSerializer::new(fields, fields_mode, computed_fields).into())
     }

--- a/tests/serializers/test_dataclasses.py
+++ b/tests/serializers/test_dataclasses.py
@@ -105,7 +105,7 @@ def test_properties():
                 core_schema.dataclass_field(name='a', schema=core_schema.str_schema()),
                 core_schema.dataclass_field(name='b', schema=core_schema.bytes_schema()),
             ],
-            computed_fields=[core_schema.computed_field('c')],
+            computed_fields=[core_schema.computed_field('c', core_schema.str_schema())],
         ),
     )
     s = SchemaSerializer(schema)

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -546,7 +546,7 @@ def test_property():
                     'width': core_schema.model_field(core_schema.int_schema()),
                     'height': core_schema.model_field(core_schema.int_schema()),
                 },
-                computed_fields=[core_schema.computed_field('area', json_return_type='bytes')],
+                computed_fields=[core_schema.computed_field('area', core_schema.bytes_schema())],
             ),
         )
     )
@@ -578,8 +578,8 @@ def test_property_alias():
                     'height': core_schema.model_field(core_schema.int_schema()),
                 },
                 computed_fields=[
-                    core_schema.computed_field('area', alias='Area'),
-                    core_schema.computed_field('volume'),
+                    core_schema.computed_field('area', core_schema.int_schema(), alias='Area'),
+                    core_schema.computed_field('volume', core_schema.int_schema()),
                 ],
             ),
         )
@@ -608,7 +608,7 @@ def test_cached_property_alias():
                     'width': core_schema.model_field(core_schema.int_schema()),
                     'height': core_schema.model_field(core_schema.int_schema()),
                 },
-                computed_fields=[core_schema.computed_field('area')],
+                computed_fields=[core_schema.computed_field('area', core_schema.int_schema())],
             ),
         )
     )
@@ -627,7 +627,7 @@ def test_property_attribute_error():
             Model,
             core_schema.model_fields_schema(
                 {'width': core_schema.model_field(core_schema.int_schema())},
-                computed_fields=[core_schema.computed_field('area', json_return_type='bytes')],
+                computed_fields=[core_schema.computed_field('area', core_schema.bytes_schema())],
             ),
         )
     )
@@ -655,7 +655,7 @@ def test_property_other_error():
             Model,
             core_schema.model_fields_schema(
                 {'width': core_schema.model_field(core_schema.int_schema())},
-                computed_fields=[core_schema.computed_field('area', json_return_type='bytes')],
+                computed_fields=[core_schema.computed_field('area', core_schema.bytes_schema())],
             ),
         )
     )
@@ -684,7 +684,7 @@ def test_property_include_exclude():
             Model,
             core_schema.model_fields_schema(
                 {'a': core_schema.model_field(core_schema.int_schema())},
-                computed_fields=[core_schema.computed_field('b')],
+                computed_fields=[core_schema.computed_field('b', core_schema.list_schema())],
             ),
         )
     )
@@ -734,8 +734,8 @@ def test_property_setter():
             core_schema.model_fields_schema(
                 {'side': core_schema.model_field(core_schema.float_schema())},
                 computed_fields=[
-                    core_schema.computed_field('area', json_return_type='float'),
-                    core_schema.computed_field('random_n', alias='The random number', json_return_type='int'),
+                    core_schema.computed_field('area', core_schema.float_schema()),
+                    core_schema.computed_field('random_n', core_schema.int_schema(), alias='The random number'),
                 ],
             ),
         )


### PR DESCRIPTION
This change provides a way to specify a serialization schema for computed fields (previously, they were treated as Any, which would lead to the FastAPI security problem in pydantic). This is also useful for generating JSON schemas for computed fields.