### PR TITLE
Serialize submodels as unions without erroring

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -200,7 +200,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
                     let value = infer_to_python(value, next_include, next_exclude, &extra)?;
                     output_dict.set_item(key, value)?;
                 } else if extra.check.enabled() {
-                    return Err(PydanticSerializationUnexpectedValue::new_err(None));
+                    // return Err(PydanticSerializationUnexpectedValue::new_err(None));
                 }
             }
         }

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -110,7 +110,7 @@ fn has_extra(schema: &PyDict, config: Option<&PyDict>) -> PyResult<bool> {
 impl ModelSerializer {
     fn allow_value(&self, value: &PyAny, extra: &Extra) -> PyResult<bool> {
         match extra.check {
-            SerCheck::Strict => Ok(value.get_type().is(self.class.as_ref(value.py()))),
+            SerCheck::Strict => value.is_instance(self.class.as_ref(value.py())),
             SerCheck::Lax => value.is_instance(self.class.as_ref(value.py())),
             SerCheck::None => value.hasattr(intern!(value.py(), "__dict__")),
         }


### PR DESCRIPTION
This resolves the issue discussed in https://github.com/pydantic/pydantic/issues/5839. But I'm not sure it's the right way to handle it. Looking for feedback before fixing tests/etc.