### PR TITLE
update to PyO3 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
+checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
+checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
+checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
+checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
+checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 ]
 
 [dependencies]
-pyo3 = "0.18.2"
+pyo3 = "0.19.0"
 regex = "1.6.0"
 strum = { version = "0.24.1", features = ["derive"] }
 strum_macros = "0.24.3"
@@ -59,9 +59,9 @@ codegen-units = 1
 strip = true
 
 [dev-dependencies]
-pyo3 = { version = "0.18.2", features = ["auto-initialize"] }
+pyo3 = { version = "0.19.0", features = ["auto-initialize"] }
 
 [build-dependencies]
 version_check = "0.9.4"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = "0.18.2"
+pyo3-build-config = "0.19.0"

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -8,7 +8,7 @@ use pyo3::types::{
 };
 #[cfg(not(PyPy))]
 use pyo3::types::{PyDictItems, PyDictKeys, PyDictValues};
-use pyo3::{ffi, intern, AsPyPointer, PyTypeInfo};
+use pyo3::{intern, AsPyPointer, PyTypeInfo};
 
 use crate::errors::{ErrorType, InputValue, LocItem, ValError, ValResult};
 use crate::tools::{extract_i64, safe_repr};
@@ -153,8 +153,7 @@ impl<'a> Input<'a> for PyAny {
         } else if let Ok(tuple) = self.downcast::<PyTuple>() {
             Ok(PyArgs::new(Some(tuple), None).into())
         } else if let Ok(list) = self.downcast::<PyList>() {
-            let tuple = list_as_tuple(list);
-            Ok(PyArgs::new(Some(tuple), None).into())
+            Ok(PyArgs::new(Some(list.to_tuple()), None).into())
         } else {
             Err(ValError::new(ErrorType::ArgumentsType, self))
         }
@@ -296,7 +295,7 @@ impl<'a> Input<'a> for PyAny {
     }
 
     fn ultra_strict_float(&self) -> ValResult<f64> {
-        if matches!(self.is_instance_of::<PyInt>(), Ok(true)) {
+        if self.is_instance_of::<PyInt>() {
             Err(ValError::new(ErrorType::FloatType, self))
         } else if let Ok(float) = self.extract::<f64>() {
             Ok(float)
@@ -694,13 +693,4 @@ fn is_dict_items_type(v: &PyAny) -> bool {
         })
         .as_ref(py);
     v.is_instance(items_type).unwrap_or(false)
-}
-
-pub fn list_as_tuple(list: &PyList) -> &PyTuple {
-    let py_tuple: Py<PyTuple> = unsafe {
-        let ptr = list.as_ptr();
-        let tuple_ptr = ffi::PyList_AsTuple(ptr);
-        Py::from_owned_ptr(list.py(), tuple_ptr)
-    };
-    py_tuple.into_ref(list.py())
 }

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -189,7 +189,7 @@ fn on_error(py: Python, err: PyErr, function_name: &str, extra: &Extra) -> PyRes
         }
     } else if let Ok(err) = exception.extract::<PydanticSerializationError>() {
         py_err!(PydanticSerializationError; "{}", err)
-    } else if exception.is_instance_of::<PyRecursionError>().unwrap_or(false) {
+    } else if exception.is_instance_of::<PyRecursionError>() {
         py_err!(PydanticSerializationError; "Error calling function `{}`: RecursionError", function_name)
     } else {
         let new_err = py_error_type!(PydanticSerializationError; "Error calling function `{}`: {}", function_name, err);


### PR DESCRIPTION
Bumps version of PyO3 to 0.19.0, making the required fixups and adopting use of the new `PyList::to_tuple` method.

Are there any other features which you were waiting for from the new PyO3?