### PR TITLE
Make Url and MultiHostUrl subclassable

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -12,7 +12,7 @@ use crate::SchemaValidator;
 
 static SCHEMA_DEFINITION_URL: GILOnceCell<SchemaValidator> = GILOnceCell::new();
 
-#[pyclass(name = "Url", module = "pydantic_core._pydantic_core")]
+#[pyclass(name = "Url", module = "pydantic_core._pydantic_core", subclass)]
 #[derive(Clone)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PyUrl {
@@ -147,7 +147,7 @@ impl PyUrl {
     }
 }
 
-#[pyclass(name = "MultiHostUrl", module = "pydantic_core._pydantic_core")]
+#[pyclass(name = "MultiHostUrl", module = "pydantic_core._pydantic_core", subclass)]
 #[derive(Clone)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PyMultiHostUrl {

--- a/tests/serializers/test_url.py
+++ b/tests/serializers/test_url.py
@@ -86,3 +86,13 @@ def test_custom_serializer():
 
     multi_host_url = MultiHostUrl('https://ex.com,ex.org/path')
     assert s.to_python(multi_host_url) == multi_host_url
+
+
+@pytest.mark.parametrize('base_class', [Url, MultiHostUrl])
+def test_url_subclass(base_class):
+    class MyUrl(base_class):
+        def some_method(self):
+            return self.path + '-success'
+
+    m = MyUrl('http://ex.com/path')
+    assert m.some_method() == '/path-success'


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6020

Not sure if there is any reason not to merge it, but I think inability to subclass is one of those unfortunate awkwardnesses of using non-pure-python that seems like it's worth avoiding in this case.

If there's a good reason not to do this, happy to just close the PR; considering it only took 5 mins to put this together I didn't feel it was a waste of time even if we do end up just closing it.