### PR TITLE
include debug info in Rust benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ lto = "fat"
 codegen-units = 1
 strip = true
 
+[profile.bench]
+debug = true
+strip = false
+
 [dev-dependencies]
 pyo3 = { version = "0.19.0", features = ["auto-initialize"] }
 


### PR DESCRIPTION
To run e.g. `cargo flamegraph` to generate profiles of Rust benchmarks, it's useful to have the debug symbols so that the output actually makes sense.

Given that we use the Python benchmarks in CI, this should purely be useful for local development.