### PR TITLE
introduce "bound validators" for int, str, float

### DIFF
--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -120,11 +120,11 @@ macro_rules! build_validate {
             let output = PyDict::new(py);
             let mut errors: Vec<ValLineError> = Vec::new();
 
-            let key_validator = self.key_validator.as_ref();
-            let value_validator = self.value_validator.as_ref();
+            let key_validator = self.key_validator.bound_validator(extra);
+            let value_validator = self.value_validator.bound_validator(extra);
             for item_result in <$iter>::new(dict)? {
                 let (key, value) = item_result?;
-                let output_key = match key_validator.validate(py, key, extra, definitions, recursion_guard) {
+                let output_key = match key_validator.bound_validate(py, key, extra, definitions, recursion_guard) {
                     Ok(value) => Some(value),
                     Err(ValError::LineErrors(line_errors)) => {
                         for err in line_errors {
@@ -139,7 +139,8 @@ macro_rules! build_validate {
                     Err(ValError::Omit) => continue,
                     Err(err) => return Err(err),
                 };
-                let output_value = match value_validator.validate(py, value, extra, definitions, recursion_guard) {
+                let output_value = match value_validator.bound_validate(py, value, extra, definitions, recursion_guard)
+                {
                     Ok(value) => Some(value),
                     Err(ValError::LineErrors(line_errors)) => {
                         for err in line_errors {


### PR DESCRIPTION
This attempts to optimize validators for collections (currently just `list` and `dict` in this draft, could be extended to all of them) by making an extra "binding" step before validating a collection.  The bound validator has the final strictness determined form both schema and extra.

The idea is that this should help avoid branches for laxness / strictness on each step of the collection validation. Seems to offer a modest speedup.

This design may fall apart if there's more ways to set strictness than by the schema and the extra (e.g. at runtime, maybe some validator chooses its strictness based on a function call).

Pushed this as a draft now because it would be interesting to gather feedback before pushing a load more additional complexity.