### PR TITLE
make Url and MultiHostUrl pickleable

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -145,6 +145,10 @@ impl PyUrl {
     pub fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> Py<PyAny> {
         self.clone().into_py(py)
     }
+
+    fn __getnewargs__(&self) -> (&str,) {
+        (self.__str__(),)
+    }
 }
 
 #[pyclass(name = "MultiHostUrl", module = "pydantic_core._pydantic_core", subclass)]
@@ -304,6 +308,10 @@ impl PyMultiHostUrl {
 
     pub fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> Py<PyAny> {
         self.clone().into_py(py)
+    }
+
+    fn __getnewargs__(&self) -> (String,) {
+        (self.__str__(),)
     }
 }
 

--- a/tests/serializers/test_url.py
+++ b/tests/serializers/test_url.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from pydantic_core import MultiHostUrl, SchemaSerializer, SchemaValidator, Url, core_schema
@@ -96,3 +98,10 @@ def test_url_subclass(base_class):
 
     m = MyUrl('http://ex.com/path')
     assert m.some_method() == '/path-success'
+
+
+@pytest.mark.parametrize('value', (Url('https://example.com'), MultiHostUrl('https://example.com,example.org/path')))
+def test_url_pickle(value):
+    pickled = pickle.dumps(value)
+    unpickled = pickle.loads(pickled)
+    assert value == unpickled


### PR DESCRIPTION
Implements pickling for `Url` and `MultiHostUrl` as requested in https://github.com/pydantic/pydantic/issues/6010

Selected Reviewer: @samuelcolvin