### PR TITLE
correct MultiHostUrl __repr__

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -277,7 +277,7 @@ impl PyMultiHostUrl {
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Url('{}')", self.__str__())
+        format!("MultiHostUrl('{}')", self.__str__())
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -610,7 +610,7 @@ def test_multi_host_url_ok_single(py_and_json: PyAndJson):
     url: MultiHostUrl = v.validate_test('https://example.com/foo/bar?a=b')
     assert isinstance(url, MultiHostUrl)
     assert str(url) == 'https://example.com/foo/bar?a=b'
-    assert repr(url) == "Url('https://example.com/foo/bar?a=b')"
+    assert repr(url) == "MultiHostUrl('https://example.com/foo/bar?a=b')"
     assert url.scheme == 'https'
     assert url.path == '/foo/bar'
     assert url.query == 'a=b'


### PR DESCRIPTION
I believe this was likely an innocent copy-paste bug?

Selected Reviewer: @adriangb