### PR TITLE
fix panic on empty MultiHostUrl

### DIFF
--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -151,7 +151,29 @@ def test_urls_text(url_validator, text):
         assert exc.error_count() == 1
         error = exc.errors(include_url=False)[0]
         assert error['type'] == 'url_parsing'
-        assert error['ctx']['error'] == 'relative URL without a base'
+        if len(text) == 0:
+            assert error['ctx']['error'] == 'input is empty'
+        else:
+            assert error['ctx']['error'] == 'relative URL without a base'
+
+
+@pytest.fixture(scope='module')
+def multi_host_url_validator():
+    return SchemaValidator({'type': 'multi-host-url'})
+
+
+@given(strategies.text())
+def test_multi_host_urls_text(multi_host_url_validator, text):
+    try:
+        multi_host_url_validator.validate_python(text)
+    except ValidationError as exc:
+        assert exc.error_count() == 1
+        error = exc.errors(include_url=False)[0]
+        assert error['type'] == 'url_parsing'
+        if len(text) == 0:
+            assert error['ctx']['error'] == 'input is empty'
+        else:
+            assert error['ctx']['error'] == 'relative URL without a base'
 
 
 @pytest.fixture(scope='module')

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -103,6 +103,8 @@ def url_test_case_helper(
 @pytest.mark.parametrize(
     'url,expected',
     [
+        ('', Err('input is empty')),
+        (':,', Err('relative URL without a base')),
         (
             'http://example.com',
             {
@@ -649,6 +651,7 @@ def multi_host_url_validator_fixture():
 @pytest.mark.parametrize(
     'url,expected',
     [
+        ('', Err('input is empty')),
         (
             'http://example.com',
             {


### PR DESCRIPTION
Fixes the following panic on empty `MultiHostUrl` input:

```
>>> pydantic_core.MultiHostUrl("")
thread '<unnamed>' panicked at 'byte index 18446744073709551615 is out of bounds of ``', src/validators/url.rs:319:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
pyo3_runtime.PanicException: byte index 18446744073709551615 is out of bounds of ``     
```

This is caused by subtraction of -1 to position 0 in an empty string, thus underflowing.

I think the nicest way to solve this for users is to add a specific error message on empty input, so I've implemented that for both `Url` and `MultiHostUrl` (and added corresponding tests).