### PR TITLE
fix windows build crash on generate_self_schema.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
           architecture: ${{ matrix.python-architecture || 'x64' }}
 
       - run: pip install -U twine 'black>=22.3.0,<23' typing_extensions
+
       # generate self-schema now, so we don't have to do so inside docker in maturin build
       - run: python generate_self_schema.py
 
@@ -380,6 +381,7 @@ jobs:
           container: ${{ matrix.container }}
           args: --release --out dist --interpreter ${{ matrix.interpreter || '3.7 3.8 3.9 3.10 3.11 pypy3.7 pypy3.8 pypy3.9' }}
           rust-toolchain: stable
+          docker-options: -e CI
 
       - run: ${{ matrix.ls || 'ls -lh' }} dist/
 

--- a/build.rs
+++ b/build.rs
@@ -6,9 +6,9 @@ use std::str::from_utf8;
 fn generate_self_schema() {
     println!("cargo:rerun-if-changed=pydantic_core/core_schema.py");
     println!("cargo:rerun-if-changed=generate_self_schema.py");
-    if Path::new("./src/self_schema.py").exists() && option_env!("DEBIAN_FRONTEND") == Some("noninteractive") {
-        // self_schema.py already exists and DEBIAN_FRONTEND indicates we're in a maturin build,
-        // skip running generate_self_schema.py
+    if Path::new("./src/self_schema.py").exists() && option_env!("CI") == Some("true") {
+        // self_schema.py already exists and CI indicates we're running on a github actions build,
+        // don't bother generating again
         return;
     }
 


### PR DESCRIPTION
We have a crash when building artifacts on windows caused by #674.

It looks like #173 didn't apply for windows, but fortunately the regeneration of `generate_self_schema.py` was harmlessly using the main interpreter. After #674 the generation is now using the wrong interpreter.

This should fix properly by avoiding regeneration on Windows too.