### PR TITLE
expand allowed errors from hypothesis test for url parsing

### DIFF
--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -143,6 +143,10 @@ def url_validator():
     return SchemaValidator({'type': 'url'})
 
 
+# Parsing errors which hypothesis is likely to hit
+_URL_PARSE_ERRORS = {'input is empty', 'relative URL without a base', 'empty host'}
+
+
 @given(strategies.text())
 def test_urls_text(url_validator, text):
     try:
@@ -151,10 +155,7 @@ def test_urls_text(url_validator, text):
         assert exc.error_count() == 1
         error = exc.errors(include_url=False)[0]
         assert error['type'] == 'url_parsing'
-        if len(text) == 0:
-            assert error['ctx']['error'] == 'input is empty'
-        else:
-            assert error['ctx']['error'] == 'relative URL without a base'
+        assert error['ctx']['error'] in _URL_PARSE_ERRORS
 
 
 @pytest.fixture(scope='module')
@@ -170,10 +171,7 @@ def test_multi_host_urls_text(multi_host_url_validator, text):
         assert exc.error_count() == 1
         error = exc.errors(include_url=False)[0]
         assert error['type'] == 'url_parsing'
-        if len(text) == 0:
-            assert error['ctx']['error'] == 'input is empty'
-        else:
-            assert error['ctx']['error'] == 'relative URL without a base'
+        assert error['ctx']['error'] in _URL_PARSE_ERRORS
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Fixes the following failure in these tests:

```
AssertionError: assert 'empty host' == 'relative URL without a base'
```

Selected Reviewer: @adriangb