### PR TITLE
update pydantic-core version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "ahash",
  "base64",


### PR DESCRIPTION
Missed off the latest release.