### PR TITLE
🐛 Raise `PydanticSerializationUnexpectedValue` in root model serializer only if strict check is enabled

### DIFF
--- a/tests/serializers/test_model_root.py
+++ b/tests/serializers/test_model_root.py
@@ -179,3 +179,29 @@ def test_root_model_dump_with_base_model(order):
 
     assert s.to_python(m) == [1, 2, {'value': 'abc'}]
     assert s.to_json(m) == b'[1,2,{"value":"abc"}]'
+
+
+def test_construct_nested():
+    class RModel(RootModel):
+        root: int
+
+    class BModel(BaseModel):
+        value: RModel
+
+    s = SchemaSerializer(
+        core_schema.model_schema(
+            BModel,
+            core_schema.model_fields_schema(
+                {
+                    'value': core_schema.model_field(
+                        core_schema.model_schema(RModel, core_schema.int_schema(), root_model=True)
+                    )
+                }
+            ),
+        )
+    )
+
+    m = BModel(value=42)
+
+    with pytest.raises(AttributeError, match="'int' object has no attribute 'root'"):
+        s.to_python(m)


### PR DESCRIPTION
## Change Summary

Brings back the correct behavior of AttributeError being raised from root model serializer when it will be exposed to user.  

## Related issue number

Follow-up to pydantic/pydantic#6113

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb