### PR TITLE
🚸 Expose `PydanticUndefinedType`

### DIFF
--- a/pydantic_core/__init__.py
+++ b/pydantic_core/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     'MultiHostUrl',
     'ArgsKwargs',
     'PydanticUndefined',
+    'PydanticUndefinedType',
     'SchemaError',
     'ErrorDetails',
     'InitErrorDetails',

--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -267,7 +267,9 @@ class ArgsKwargs:
     @property
     def kwargs(self) -> 'dict[str, Any] | None': ...
 
-PydanticUndefined: object
+class PydanticUndefinedType: ...
+
+PydanticUndefined: PydanticUndefinedType
 
 def list_all_errors() -> 'list[ErrorTypeInfo]':
     """

--- a/src/argument_markers.rs
+++ b/src/argument_markers.rs
@@ -63,14 +63,14 @@ impl ArgsKwargs {
     }
 }
 
-static UNDEFINED_CELL: GILOnceCell<Py<UndefinedType>> = GILOnceCell::new();
+static UNDEFINED_CELL: GILOnceCell<Py<PydanticUndefinedType>> = GILOnceCell::new();
 
 #[pyclass(module = "pydantic_core._pydantic_core", frozen)]
 #[derive(Debug)]
-pub struct UndefinedType {}
+pub struct PydanticUndefinedType {}
 
 #[pymethods]
-impl UndefinedType {
+impl PydanticUndefinedType {
     #[new]
     pub fn py_new(_py: Python) -> PyResult<Self> {
         Err(PyNotImplementedError::new_err(
@@ -81,7 +81,7 @@ impl UndefinedType {
     #[staticmethod]
     pub fn new(py: Python) -> Py<Self> {
         UNDEFINED_CELL
-            .get_or_init(py, || UndefinedType {}.into_py(py).extract(py).unwrap())
+            .get_or_init(py, || PydanticUndefinedType {}.into_py(py).extract(py).unwrap())
             .clone()
     }
 
@@ -102,8 +102,8 @@ impl UndefinedType {
     }
 }
 
-impl UndefinedType {
+impl PydanticUndefinedType {
     pub fn py_undefined() -> Py<Self> {
-        Python::with_gil(UndefinedType::new)
+        Python::with_gil(PydanticUndefinedType::new)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod validators;
 
 // required for benchmarks
 pub use self::url::{PyMultiHostUrl, PyUrl};
-pub use argument_markers::{ArgsKwargs, UndefinedType};
+pub use argument_markers::{ArgsKwargs, PydanticUndefinedType};
 pub use build_tools::SchemaError;
 pub use errors::{list_all_errors, PydanticCustomError, PydanticKnownError, PydanticOmit, ValidationError};
 pub use serializers::{
@@ -46,7 +46,8 @@ pub fn get_version() -> String {
 fn _pydantic_core(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", get_version())?;
     m.add("build_profile", env!("PROFILE"))?;
-    m.add("PydanticUndefined", UndefinedType::new(py))?;
+    m.add("PydanticUndefined", PydanticUndefinedType::new(py))?;
+    m.add_class::<PydanticUndefinedType>()?;
     m.add_class::<PySome>()?;
     m.add_class::<SchemaValidator>()?;
     m.add_class::<ValidationError>()?;

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -14,7 +14,7 @@ use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{py_error_on_minusone, Input};
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::{py_err, SchemaDict};
-use crate::UndefinedType;
+use crate::PydanticUndefinedType;
 
 const ROOT_FIELD: &str = "root";
 const DUNDER_DICT: &str = "__dict__";
@@ -259,7 +259,7 @@ impl ModelValidator {
             .validate(py, input, &new_extra, definitions, recursion_guard)?;
 
         if self.root_model {
-            let fields_set = if input.to_object(py).is(&UndefinedType::py_undefined()) {
+            let fields_set = if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {
                 PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?
@@ -309,7 +309,7 @@ impl ModelValidator {
         let instance_ref = instance.as_ref(py);
 
         if self.root_model {
-            let fields_set = if input.to_object(py).is(&UndefinedType::py_undefined()) {
+            let fields_set = if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {
                 PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -10,7 +10,7 @@ use crate::errors::{LocItem, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
-use crate::UndefinedType;
+use crate::PydanticUndefinedType;
 
 static COPY_DEEPCOPY: GILOnceCell<PyObject> = GILOnceCell::new();
 
@@ -121,7 +121,7 @@ impl Validator for WithDefaultValidator {
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        if input.to_object(py).is(&UndefinedType::py_undefined()) {
+        if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {
             Ok(self
                 .default_value(py, None::<usize>, extra, definitions, recursion_guard)?
                 .unwrap())


### PR DESCRIPTION
## Change Summary

The goal here is to expose the `PydanticUndefinedType`. I'm unsure if this is the best way to do it.

The motivation is that FastAPI wants the type of `PydanticUndefined`, and I can't get that since `PydanticUndefined` is an `object()`. See [FastAPI code](https://github.com/tiangolo/fastapi/blob/6dc975da9dd4804c1fa3a9c8533bd339b63eee0e/fastapi/_compat.py#L50-L51) for more details.

## Checklist

* [X] Unit tests for the changes exist
* [X] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt