### PR TITLE
Extend clippy to include `clippy::pedantic`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ lint-rust:
 		-A clippy::cast-precision-loss \
 		-A clippy::cast-sign-loss \
 		-A clippy::doc-markdown \
-		-A clippy::explicit-iter-loop \
 		-A clippy::float-cmp \
 		-A clippy::fn-params-excessive-bools \
 		-A clippy::if-not-else \

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ lint-rust:
 		-A clippy::manual-let-else \
 		-A clippy::match-bool \
 		-A clippy::match-same-arms \
-		-A clippy::match-wildcard-for-single-variants \
 		-A clippy::missing-errors-doc \
 		-A clippy::missing-panics-doc \
 		-A clippy::module-name-repetitions \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ lint-rust:
 		-A clippy::single-match-else \
 		-A clippy::struct-excessive-bools \
 		-A clippy::too-many-lines \
-		-A clippy::trivially-copy-pass-by-ref \
 		-A clippy::unnecessary-wraps \
 		-A clippy::unnested-or-patterns \
 		-A clippy::unused-self \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ lint-rust:
 		-W clippy::pedantic \
 		-W clippy::dbg_macro \
 		-W clippy::print_stdout \
-		-A clippy::cast-lossless \
 		-A clippy::cast-possible-truncation \
 		-A clippy::cast-possible-wrap \
 		-A clippy::cast-precision-loss \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ lint-rust:
 		-A clippy::module-name-repetitions \
 		-A clippy::must-use-candidate \
 		-A clippy::needless-pass-by-value \
-		-A clippy::redundant-closure-for-method-calls \
 		-A clippy::redundant-else \
 		-A clippy::semicolon-if-nothing-returned \
 		-A clippy::similar-names \

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ lint-rust:
 		-A clippy::float-cmp \
 		-A clippy::fn-params-excessive-bools \
 		-A clippy::if-not-else \
-		-A clippy::implicit-clone \
 		-A clippy::inconsistent-struct-constructor \
 		-A clippy::manual-let-else \
 		-A clippy::map-unwrap-or \

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ lint-rust:
 		-A clippy::float-cmp \
 		-A clippy::fn-params-excessive-bools \
 		-A clippy::if-not-else \
-		-A clippy::inconsistent-struct-constructor \
 		-A clippy::manual-let-else \
 		-A clippy::map-unwrap-or \
 		-A clippy::match-bool \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ lint-rust:
 		-A clippy::module-name-repetitions \
 		-A clippy::must-use-candidate \
 		-A clippy::needless-pass-by-value \
-		-A clippy::semicolon-if-nothing-returned \
 		-A clippy::similar-names \
 		-A clippy::single-match-else \
 		-A clippy::struct-excessive-bools \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ lint-rust:
 		-A clippy::module-name-repetitions \
 		-A clippy::must-use-candidate \
 		-A clippy::needless-pass-by-value \
-		-A clippy::redundant-else \
 		-A clippy::semicolon-if-nothing-returned \
 		-A clippy::similar-names \
 		-A clippy::single-match-else \

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ lint-rust:
 		-A clippy::fn-params-excessive-bools \
 		-A clippy::if-not-else \
 		-A clippy::manual-let-else \
-		-A clippy::map-unwrap-or \
 		-A clippy::match-bool \
 		-A clippy::match-same-arms \
 		-A clippy::match-wildcard-for-single-variants \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ lint-rust:
 		-A clippy::cast-precision-loss \
 		-A clippy::cast-sign-loss \
 		-A clippy::doc-markdown \
-		-A clippy::explicit-into-iter-loop \
 		-A clippy::explicit-iter-loop \
 		-A clippy::float-cmp \
 		-A clippy::fn-params-excessive-bools \

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ lint-rust:
 		-A clippy::struct-excessive-bools \
 		-A clippy::too-many-lines \
 		-A clippy::unnecessary-wraps \
-		-A clippy::unnested-or-patterns \
 		-A clippy::unused-self \
 		-A clippy::used-underscore-binding
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,46 @@ lint-rust:
 	cargo fmt --version
 	cargo fmt --all -- --check
 	cargo clippy --version
-	cargo clippy --tests -- -D warnings -A incomplete_features -W clippy::dbg_macro -W clippy::print_stdout
+	cargo clippy --tests -- \
+		-D warnings \
+		-W clippy::pedantic \
+		-W clippy::dbg_macro \
+		-W clippy::print_stdout \
+		-A clippy::cast-lossless \
+		-A clippy::cast-possible-truncation \
+		-A clippy::cast-possible-wrap \
+		-A clippy::cast-precision-loss \
+		-A clippy::cast-sign-loss \
+		-A clippy::doc-markdown \
+		-A clippy::explicit-into-iter-loop \
+		-A clippy::explicit-iter-loop \
+		-A clippy::float-cmp \
+		-A clippy::fn-params-excessive-bools \
+		-A clippy::if-not-else \
+		-A clippy::implicit-clone \
+		-A clippy::inconsistent-struct-constructor \
+		-A clippy::manual-let-else \
+		-A clippy::map-unwrap-or \
+		-A clippy::match-bool \
+		-A clippy::match-same-arms \
+		-A clippy::match-wildcard-for-single-variants \
+		-A clippy::missing-errors-doc \
+		-A clippy::missing-panics-doc \
+		-A clippy::module-name-repetitions \
+		-A clippy::must-use-candidate \
+		-A clippy::needless-pass-by-value \
+		-A clippy::redundant-closure-for-method-calls \
+		-A clippy::redundant-else \
+		-A clippy::semicolon-if-nothing-returned \
+		-A clippy::similar-names \
+		-A clippy::single-match-else \
+		-A clippy::struct-excessive-bools \
+		-A clippy::too-many-lines \
+		-A clippy::trivially-copy-pass-by-ref \
+		-A clippy::unnecessary-wraps \
+		-A clippy::unnested-or-patterns \
+		-A clippy::unused-self \
+		-A clippy::used-underscore-binding
 
 .PHONY: lint
 lint: lint-python lint-rust

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -129,7 +129,7 @@ impl SchemaError {
 
     fn __str__(&self, py: Python) -> String {
         match &self.0 {
-            SchemaErrorEnum::Message(message) => message.to_owned(),
+            SchemaErrorEnum::Message(message) => message.clone(),
             SchemaErrorEnum::ValidationError(error) => error.display(py, Some("Invalid Schema:"), false),
         }
     }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -101,7 +101,7 @@ impl<T: Clone + std::fmt::Debug> DefinitionsBuilder<T> {
     pub fn finish(self) -> PyResult<Vec<T>> {
         // We need to create a vec of defs according to the order in their ids
         let mut defs: Vec<(usize, T)> = Vec::new();
-        for (reference, def) in self.definitions.into_iter() {
+        for (reference, def) in self.definitions {
             match def.value {
                 None => return py_schema_err!("Definitions error: definition {} was never filled", reference),
                 Some(v) => defs.push((def.id, v)),

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -51,7 +51,7 @@ impl<'a> ValError<'a> {
     pub fn with_outer_location(self, loc_item: LocItem) -> Self {
         match self {
             Self::LineErrors(mut line_errors) => {
-                for line_error in line_errors.iter_mut() {
+                for line_error in &mut line_errors {
                     line_error.location.with_outer(loc_item.clone());
                 }
                 Self::LineErrors(line_errors)

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -159,7 +159,7 @@ impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::List(loc) => {
-                let loc_str = loc.iter().rev().map(|i| i.to_string()).collect::<Vec<_>>();
+                let loc_str = loc.iter().rev().map(ToString::to_string).collect::<Vec<_>>();
                 writeln!(f, "{}", loc_str.join("."))
             }
             Self::Empty => Ok(()),

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -366,8 +366,8 @@ macro_rules! extract_context {
     }};
 }
 
-fn plural_s(value: &usize) -> &'static str {
-    if *value == 1 {
+fn plural_s(value: usize) -> &'static str {
+    if value == 1 {
         ""
     } else {
         "s"
@@ -607,7 +607,7 @@ impl ErrorType {
                 min_length,
                 actual_length,
             } => {
-                let expected_plural = plural_s(min_length);
+                let expected_plural = plural_s(*min_length);
                 to_string_render!(tmpl, field_type, min_length, actual_length, expected_plural)
             }
             Self::TooLong {
@@ -615,7 +615,7 @@ impl ErrorType {
                 max_length,
                 actual_length,
             } => {
-                let expected_plural = plural_s(max_length);
+                let expected_plural = plural_s(*max_length);
                 to_string_render!(tmpl, field_type, max_length, actual_length, expected_plural)
             }
             Self::IterationError { error } => render!(tmpl, error),

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -30,8 +30,8 @@ use super::ValError;
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct ValidationError {
     line_errors: Vec<PyLineError>,
-    error_mode: ErrorMode,
     title: PyObject,
+    error_mode: ErrorMode,
     hide_input: bool,
 }
 

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -47,7 +47,7 @@ impl<'a> EitherDate<'a> {
     pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
         let date = match self {
             Self::Py(date) => Ok(date),
-            Self::Raw(date) => PyDate::new(py, date.year as i32, date.month, date.day),
+            Self::Raw(date) => PyDate::new(py, date.year.into(), date.month, date.day),
         }?;
         Ok(date.into_py(py))
     }
@@ -236,7 +236,7 @@ impl<'a> EitherDateTime<'a> {
         let dt = match self {
             Self::Raw(datetime) => PyDateTime::new(
                 py,
-                datetime.date.year as i32,
+                datetime.date.year.into(),
                 datetime.date.month,
                 datetime.date.day,
                 datetime.time.hour,

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -159,7 +159,7 @@ fn validate_iter_to_vec<'a, 's>(
         match validator.validate(py, item, extra, definitions, recursion_guard) {
             Ok(item) => {
                 max_length_check.incr()?;
-                output.push(item)
+                output.push(item);
             }
             Err(ValError::LineErrors(line_errors)) => {
                 max_length_check.incr()?;

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -474,7 +474,7 @@ impl<'py> MappingGenericIterator<'py> {
             .map_err(|e| mapping_err(e, py, input))?
             .iter()
             .map_err(|e| mapping_err(e, py, input))?;
-        Ok(Self { iter, input })
+        Ok(Self { input, iter })
     }
 }
 

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -27,7 +27,7 @@ where
     }
 
     pub fn insert(&mut self, key: K, value: V) {
-        self.vec.push((key, value))
+        self.vec.push((key, value));
     }
 
     pub fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(has_no_coverage, feature(no_coverage))]
-#![allow(clippy::borrow_deref_ref)]
 
 extern crate core;
 

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -43,7 +43,7 @@ impl fmt::Display for LookupKey {
             Self::PathChoices(paths) => write!(
                 f,
                 "{}",
-                paths.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(" | ")
+                paths.iter().map(ToString::to_string).collect::<Vec<_>>().join(" | ")
             ),
         }
     }

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -84,7 +84,7 @@ impl LookupKey {
             };
 
             if let Some(alt_alias) = alt_alias {
-                locs.push(LookupPath::from_str(py, alt_alias, None))
+                locs.push(LookupPath::from_str(py, alt_alias, None));
             }
             Ok(Self::PathChoices(locs))
         }

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -464,7 +464,7 @@ impl PathItem {
                         None
                     }
                 }
-                _ => None,
+                Self::S(..) => None,
             },
             _ => None,
         }

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -47,7 +47,7 @@ impl ComputedFields {
         exclude: Option<&PyAny>,
         extra: &Extra,
     ) -> PyResult<()> {
-        for computed_fields in self.0.iter() {
+        for computed_fields in &self.0 {
             computed_fields.to_python(model, output_dict, filter, include, exclude, extra)?;
         }
         Ok(())
@@ -62,7 +62,7 @@ impl ComputedFields {
         exclude: Option<&PyAny>,
         extra: &Extra,
     ) -> Result<(), S::Error> {
-        for computed_field in self.0.iter() {
+        for computed_field in &self.0 {
             let property_name_py = computed_field.property_name_py.as_ref(model.py());
             if let Some((next_include, next_exclude)) = filter
                 .key_filter(property_name_py, include, exclude)

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -186,10 +186,10 @@ impl ExtraOwned {
             config: extra.config.clone(),
             rec_guard: extra.rec_guard.clone(),
             check: extra.check,
-            model: extra.model.map(|v| v.into()),
-            field_name: extra.field_name.map(|v| v.to_string()),
+            model: extra.model.map(Into::into),
+            field_name: extra.field_name.map(ToString::to_string),
             serialize_unknown: extra.serialize_unknown,
-            fallback: extra.fallback.map(|v| v.into()),
+            fallback: extra.fallback.map(Into::into),
         }
     }
 
@@ -208,7 +208,7 @@ impl ExtraOwned {
             rec_guard: &self.rec_guard,
             check: self.check,
             model: self.model.as_ref().map(|m| m.as_ref(py)),
-            field_name: self.field_name.as_ref().map(|n| n.as_ref()),
+            field_name: self.field_name.as_deref(),
             serialize_unknown: self.serialize_unknown,
             fallback: self.fallback.as_ref().map(|m| m.as_ref(py)),
         }
@@ -335,7 +335,6 @@ impl CollectWarnings {
         if self.active {
             match *self.warnings.borrow() {
                 Some(ref warnings) => {
-                    let warnings = warnings.iter().map(|w| w.as_str()).collect::<Vec<_>>();
                     let message = format!("Pydantic serializer warnings:\n  {}", warnings.join("\n  "));
                     let user_warning_type = py.import("builtins")?.getattr("UserWarning")?;
                     PyErr::warn(py, user_warning_type, &message, 0)

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -147,8 +147,8 @@ pub(crate) enum SerCheck {
 }
 
 impl SerCheck {
-    pub fn enabled(&self) -> bool {
-        *self != SerCheck::None
+    pub fn enabled(self) -> bool {
+        self != SerCheck::None
     }
 }
 

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -285,7 +285,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
                 } else if self.mode == FieldsMode::TypedDictAllow {
                     let output_key = infer_json_key(key, &extra).map_err(py_err_se_err)?;
                     let s = SerializeInfer::new(value, next_include, next_exclude, &extra);
-                    map.serialize_entry(&output_key, &s)?
+                    map.serialize_entry(&output_key, &s)?;
                 }
                 // no error case here since unions (which need the error case) use `to_python(..., mode='json')`
             }
@@ -300,7 +300,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
                 if let Some((next_include, next_exclude)) = filter {
                     let output_key = infer_json_key(key, &td_extra).map_err(py_err_se_err)?;
                     let s = SerializeInfer::new(value, next_include, next_exclude, &td_extra);
-                    map.serialize_entry(&output_key, &s)?
+                    map.serialize_entry(&output_key, &s)?;
                 }
             }
         }

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -163,11 +163,10 @@ trait FilterLogic<T: Eq + Copy> {
                     if is_ellipsis_like(exc_value) {
                         // if the index is in exclude, and the exclude value is `None`, we want to omit this index/item
                         return Ok(None);
-                    } else {
-                        // if the index is in exclude, and the exclude-value is not `None`,
-                        // we want to return `Some((..., Some(next_exclude))`
-                        next_exclude = Some(exc_value);
                     }
+                    // if the index is in exclude, and the exclude-value is not `None`,
+                    // we want to return `Some((..., Some(next_exclude))`
+                    next_exclude = Some(exc_value);
                 }
             } else if let Ok(exclude_set) = exclude.downcast::<PySet>() {
                 if exclude_set.contains(py_key)? || exclude_set.contains(intern!(exclude_set.py(), "__all__"))? {
@@ -369,12 +368,11 @@ fn merge_dicts<'py>(item_dict: &'py PyDict, all_value: &'py PyAny) -> PyResult<&
             if let Some(item_value) = item_dict.get_item(all_key) {
                 if is_ellipsis_like(item_value) {
                     continue;
-                } else {
-                    let item_value_dict = as_dict(item_value)?;
-                    // if the all value is an ellipsis, we don't overwrite the item value
-                    if !is_ellipsis_like(all_value) {
-                        item_dict.set_item(all_key, merge_dicts(item_value_dict, all_value)?)?;
-                    }
+                }
+                let item_value_dict = as_dict(item_value)?;
+                // if the all value is an ellipsis, we don't overwrite the item value
+                if !is_ellipsis_like(all_value) {
+                    item_dict.set_item(all_key, merge_dicts(item_value_dict, all_value)?)?;
                 }
             } else {
                 item_dict.set_item(all_key, all_value)?;

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -46,7 +46,7 @@ fn map_negative_indices(include_or_exclude: &PyAny, len: Option<usize>) -> PyRes
     } else if let Ok(exclude_set) = include_or_exclude.downcast::<PySet>() {
         let mut values = Vec::with_capacity(exclude_set.len());
         for v in exclude_set {
-            values.push(map_negative_index(v, len)?)
+            values.push(map_negative_index(v, len)?);
         }
         Ok(PySet::new(py, values)?)
     } else {

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -271,9 +271,8 @@ pub(crate) fn infer_to_python_known(
                     let next_result = infer_to_python(next_value, include, exclude, extra);
                     extra.rec_guard.pop(value_id, INFER_DEF_REF_ID);
                     return next_result;
-                } else {
-                    value.into_py(py)
                 }
+                value.into_py(py)
             }
             _ => value.into_py(py),
         },

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -497,7 +497,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
                     .map_err(py_err_se_err)?;
                 if let Some((next_include, next_exclude)) = op_next {
                     let item_serializer = SerializeInfer::new(element, next_include, next_exclude, extra);
-                    seq.serialize_element(&item_serializer)?
+                    seq.serialize_element(&item_serializer)?;
                 }
             }
             seq.end()

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -185,7 +185,7 @@ impl SchemaSerializer {
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.serializer.py_gc_traverse(&visit)?;
-        for slot in self.definitions.iter() {
+        for slot in &self.definitions {
             slot.py_gc_traverse(&visit)?;
         }
         Ok(())
@@ -193,7 +193,7 @@ impl SchemaSerializer {
 
     fn __clear__(&mut self) {
         self.serializer.py_gc_clear();
-        for slot in self.definitions.iter_mut() {
+        for slot in &mut self.definitions {
             slot.py_gc_clear();
         }
     }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -177,7 +177,7 @@ impl CombinedSerializer {
                     .map_err(|err| py_schema_error_type!("Error building `function-wrap` serializer:\n  {}", err));
                 }
                 // applies to lists tuples and dicts, does not override the main schema `type`
-                Some("include-exclude-sequence") | Some("include-exclude-dict") => (),
+                Some("include-exclude-sequence" | "include-exclude-dict") => (),
                 // applies specifically to bytes, does not override the main schema `type`
                 Some("base64") => (),
                 Some(ser_type) => {

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -168,7 +168,7 @@ impl BuildSerializer for TuplePositionalSerializer {
 
         let descr = items_serializers
             .iter()
-            .map(|v| v.get_name())
+            .map(TypeSerializer::get_name)
             .collect::<Vec<_>>()
             .join(", ");
         Ok(Self {

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -237,7 +237,7 @@ impl TypeSerializer for TuplePositionalSerializer {
                 let mut py_tuple_iter = py_tuple.iter();
 
                 let mut key_builder = KeyBuilder::new();
-                for serializer in self.items_serializers.iter() {
+                for serializer in &self.items_serializers {
                     let element = match py_tuple_iter.next() {
                         Some(value) => value,
                         None => break,

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -44,7 +44,11 @@ impl UnionSerializer {
             0 => py_schema_err!("One or more union choices required"),
             1 => Ok(choices.into_iter().next().unwrap()),
             _ => {
-                let descr = choices.iter().map(|v| v.get_name()).collect::<Vec<_>>().join(", ");
+                let descr = choices
+                    .iter()
+                    .map(TypeSerializer::get_name)
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 Ok(Self {
                     choices,
                     name: format!("Union[{descr}]"),
@@ -163,7 +167,7 @@ impl TypeSerializer for UnionSerializer {
     }
 
     fn retry_with_lax_check(&self) -> bool {
-        self.choices.iter().any(|c| c.retry_with_lax_check())
+        self.choices.iter().any(TypeSerializer::retry_with_lax_check)
     }
 }
 

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -186,7 +186,7 @@ impl BuildSerializer for TaggedUnionBuilder {
 
         for (_, value) in schema_choices {
             if let Ok(choice_schema) = value.downcast::<PyDict>() {
-                choices.push(CombinedSerializer::build(choice_schema, config, definitions)?)
+                choices.push(CombinedSerializer::build(choice_schema, config, definitions)?);
             }
         }
         UnionSerializer::from_choices(choices)

--- a/src/url.rs
+++ b/src/url.rs
@@ -72,7 +72,7 @@ impl PyUrl {
     pub fn unicode_host(&self) -> Option<String> {
         match self.lib_url.host() {
             Some(url::Host::Domain(domain)) if is_punnycode_domain(&self.lib_url, domain) => decode_punycode(domain),
-            _ => self.lib_url.host_str().map(|h| h.to_string()),
+            _ => self.lib_url.host_str().map(ToString::to_string),
         }
     }
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -339,7 +339,7 @@ fn unicode_url(lib_url: &Url) -> String {
             if let Some(decoded) = decode_punycode(domain) {
                 // replace the range containing the punycode domain with the decoded domain
                 let start = lib_url.scheme().len() + 3;
-                s.replace_range(start..start + domain.len(), &decoded)
+                s.replace_range(start..start + domain.len(), &decoded);
             }
             s
         }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -99,8 +99,8 @@ impl BuildValidator for ArgumentsValidator {
             }
             parameters.push(Parameter {
                 positional,
-                kw_lookup_key,
                 name,
+                kw_lookup_key,
                 kwarg_key,
                 validator,
             });

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -40,7 +40,7 @@ impl BuildValidator for ChainValidator {
                 Ok(step)
             }
             _ => {
-                let descr = steps.iter().map(|v| v.get_name()).collect::<Vec<_>>().join(",");
+                let descr = steps.iter().map(Validator::get_name).collect::<Vec<_>>().join(",");
 
                 Ok(Self {
                     steps,

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -78,8 +78,8 @@ impl BuildValidator for CustomErrorValidator {
         let name = format!("{}[{}]", Self::EXPECTED_TYPE, validator.get_name());
         Ok(Self {
             validator,
-            name,
             custom_error,
+            name,
         }
         .into())
     }

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -129,7 +129,7 @@ fn date_from_datetime<'data>(
                 ValError::LineErrors(mut line_errors) => {
                     // if we got a errors while parsing the datetime,
                     // convert DateTimeParsing -> DateFromDatetimeParsing but keep the rest of the error unchanged
-                    for line_error in line_errors.iter_mut() {
+                    for line_error in &mut line_errors {
                         match line_error.error_type {
                             ErrorType::DatetimeParsing { ref error } => {
                                 line_error.error_type = ErrorType::DateFromDatetimeParsing {

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -96,7 +96,7 @@ impl Validator for DateTimeValidator {
             }
 
             if let Some(ref tz_constraint) = constraints.tz {
-                tz_constraint.tz_check(speedate_dt.time.tz_offset, input)?
+                tz_constraint.tz_check(speedate_dt.time.tz_offset, input)?;
             }
         }
         Ok(datetime.try_into_py(py)?)

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -509,9 +509,9 @@ impl ValidationInfo {
                 Some(field_name) => Ok(
                     Self {
                         config: config.clone_ref(py),
-                        context: extra.context.map(|v| v.into()),
+                        context: extra.context.map(Into::into),
                         field_name: Some(field_name.to_string()),
-                        data: extra.data.map(|v| v.into()),
+                        data: extra.data.map(Into::into),
                         mode: extra.mode,
                     }
                 ),
@@ -520,7 +520,7 @@ impl ValidationInfo {
         } else {
             Ok(Self {
                 config: config.clone_ref(py),
-                context: extra.context.map(|v| v.into()),
+                context: extra.context.map(Into::into),
                 field_name: None,
                 data: None,
                 mode: extra.mode,

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -36,7 +36,7 @@ impl BuildValidator for JsonValidator {
         let name = format!(
             "{}[{}]",
             Self::EXPECTED_TYPE,
-            validator.as_ref().map(|v| v.get_name()).unwrap_or("any")
+            validator.as_ref().map_or("any", |v| v.get_name())
         );
         Ok(Self { validator, name }.into())
     }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -97,7 +97,7 @@ impl BuildValidator for ListValidator {
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
         let item_validator = get_items_schema(schema, config, definitions)?;
-        let inner_name = item_validator.as_ref().map(|v| v.get_name()).unwrap_or("any");
+        let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("{}[{inner_name}]", Self::EXPECTED_TYPE);
         Ok(Self {
             strict: crate::build_tools::is_strict(schema, config)?,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -115,7 +115,7 @@ impl SchemaValidator {
         let mut validator = build_validator(schema, config, &mut definitions_builder)?;
         validator.complete(&definitions_builder)?;
         let mut definitions = definitions_builder.clone().finish()?;
-        for val in definitions.iter_mut() {
+        for val in &mut definitions {
             val.complete(&definitions_builder)?;
         }
         let config_title = match config {
@@ -274,7 +274,7 @@ impl SchemaValidator {
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.validator.py_gc_traverse(&visit)?;
         visit.call(&self.schema)?;
-        for slot in self.definitions.iter() {
+        for slot in &self.definitions {
             slot.py_gc_traverse(&visit)?;
         }
         Ok(())
@@ -282,7 +282,7 @@ impl SchemaValidator {
 
     fn __clear__(&mut self) {
         self.validator.py_gc_clear();
-        for slot in self.definitions.iter_mut() {
+        for slot in &mut self.definitions {
             slot.py_gc_clear();
         }
     }
@@ -368,7 +368,7 @@ impl<'py> SelfValidator<'py> {
         };
         validator.complete(&definitions_builder)?;
         let mut definitions = definitions_builder.clone().finish()?;
-        for val in definitions.iter_mut() {
+        for val in &mut definitions {
             val.complete(&definitions_builder)?;
         }
         Ok(SchemaValidator {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -138,7 +138,7 @@ impl SchemaValidator {
 
     pub fn __reduce__(&self, py: Python) -> PyResult<PyObject> {
         let args = (self.schema.as_ref(py),);
-        let cls = Py::new(py, self.to_owned())?.getattr(py, "__class__")?;
+        let cls = Py::new(py, self.clone())?.getattr(py, "__class__")?;
         Ok((cls, args).into_py(py))
     }
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -69,7 +69,7 @@ impl Validator for TimeValidator {
             check_constraint!(gt, GreaterThan);
 
             if let Some(ref tz_constraint) = constraints.tz {
-                tz_constraint.tz_check(raw_time.tz_offset, input)?
+                tz_constraint.tz_check(raw_time.tz_offset, input)?;
             }
         }
         Ok(time.try_into_py(py)?)

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -119,7 +119,11 @@ impl BuildValidator for TuplePositionalValidator {
             .map(|item| build_validator(item, config, definitions))
             .collect::<PyResult<_>>()?;
 
-        let descr = validators.iter().map(|v| v.get_name()).collect::<Vec<_>>().join(", ");
+        let descr = validators
+            .iter()
+            .map(Validator::get_name)
+            .collect::<Vec<_>>()
+            .join(", ");
         Ok(Self {
             strict: is_strict(schema, config)?,
             items_validators: validators,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -29,7 +29,7 @@ impl BuildValidator for TupleVariableValidator {
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
         let item_validator = get_items_schema(schema, config, definitions)?;
-        let inner_name = item_validator.as_ref().map(|v| v.get_name()).unwrap_or("any");
+        let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("tuple[{inner_name}, ...]");
         Ok(Self {
             strict: is_strict(schema, config)?,

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -46,7 +46,7 @@ impl BuildValidator for UnionValidator {
             0 => py_schema_err!("One or more union choices required"),
             1 if auto_collapse() => Ok(choices.into_iter().next().unwrap()),
             _ => {
-                let descr = choices.iter().map(|v| v.get_name()).collect::<Vec<_>>().join(",");
+                let descr = choices.iter().map(Validator::get_name).collect::<Vec<_>>().join(",");
 
                 Ok(Self {
                     choices,

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -334,7 +334,7 @@ fn parse_multihost_url<'url, 'input>(
     loop {
         let peek = chars.peek();
         match peek {
-            Some(&'/') | Some(&'\\') => {
+            Some(&'/' | &'\\') => {
                 chars.next();
             }
             _ => break,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -26,7 +26,7 @@ mod tests {
             }"#;
             let schema: &PyDict = py.eval(code, None, None).unwrap().extract().unwrap();
             SchemaSerializer::py_new(py, schema, None).unwrap();
-        })
+        });
     }
 
     #[test]
@@ -63,6 +63,6 @@ a = A()
                 .extract(py)
                 .unwrap();
             assert_eq!(serialized, b"{\"b\":\"b\"}");
-        })
+        });
     }
 }


### PR DESCRIPTION
## Change Summary

Adds `-W clippy::pendantic` to our lint job. Because this namespace is extremely prescriptive, I re-enabled all the rules where we currently have lint errors.

I've then run through a bunch of the easy wins and fixed those up. Over time we may want to snipe off some of the other rules, although I expect some to always be permitted.

## Related issue number

Closes #666

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb