### PR TITLE
fix context may be None

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -144,7 +144,7 @@ class ValidationInfo(Protocol):
     """
 
     @property
-    def context(self) -> Dict[str, Any] | None:
+    def context(self) -> Any | None:
         """Current validation context."""
         ...
 

--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -144,7 +144,7 @@ class ValidationInfo(Protocol):
     """
 
     @property
-    def context(self) -> Dict[str, Any]:
+    def context(self) -> Dict[str, Any] | None:
         """Current validation context."""
         ...
 


### PR DESCRIPTION
The context kwarg of .model_validate defaults to None

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
