### PR TITLE
run stubtest on _pydantic_core.pyi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       # used to lint js code
       - uses: actions/setup-node@v3

--- a/.mypy-stubtest-allowlist
+++ b/.mypy-stubtest-allowlist
@@ -1,0 +1,4 @@
+# TODO: __init__ signature inherited from BaseException, probably needs investigating
+pydantic_core._pydantic_core.PydanticOmit.__init__
+# TODO: don't want to expose this staticmethod, requires https://github.com/PyO3/pyo3/issues/2384
+pydantic_core._pydantic_core.PydanticUndefinedType.new

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := all
 black = black python/pydantic_core tests generate_self_schema.py wasm-preview/run_tests.py
 ruff = ruff python/pydantic_core tests generate_self_schema.py wasm-preview/run_tests.py
+mypy-stubtest = python -m mypy.stubtest pydantic_core._pydantic_core --allowlist .mypy-stubtest-allowlist
 
 .PHONY: install
 install:
@@ -46,6 +47,7 @@ format:
 lint-python:
 	$(ruff)
 	$(black) --check --diff
+	$(mypy-stubtest)
 	griffe dump -f -d google -LWARNING -o/dev/null python/pydantic_core
 
 .PHONY: lint-rust

--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -21,7 +21,7 @@ from ._pydantic_core import (
     to_json,
     to_jsonable_python,
 )
-from .core_schema import CoreConfig, CoreSchema, CoreSchemaType
+from .core_schema import CoreConfig, CoreSchema, CoreSchemaType, ErrorType
 
 if _sys.version_info < (3, 11):
     from typing_extensions import NotRequired as _NotRequired
@@ -33,7 +33,7 @@ if _sys.version_info < (3, 9):
 else:
     from typing import TypedDict as _TypedDict
 
-__all__ = (
+__all__ = [
     '__version__',
     'CoreConfig',
     'CoreSchema',
@@ -57,7 +57,7 @@ __all__ = (
     'PydanticSerializationUnexpectedValue',
     'to_json',
     'to_jsonable_python',
-)
+]
 
 
 class ErrorDetails(_TypedDict):
@@ -73,3 +73,19 @@ class InitErrorDetails(_TypedDict):
     loc: _NotRequired['tuple[int | str, ...]']
     input: _Any
     ctx: _NotRequired['dict[str, str | int | float]']
+
+
+class ErrorTypeInfo(_TypedDict):
+    type: ErrorType
+    message_template_python: str
+    example_message_python: str
+    message_template_json: _NotRequired[str]
+    example_message_json: _NotRequired[str]
+    example_context: 'dict[str, str | int | float] | None'
+
+
+class MultiHostHost(_TypedDict):
+    username: 'str | None'
+    password: 'str | None'
+    host: 'str | None'
+    port: 'int | None'

--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys as _sys
 from typing import Any as _Any
 
@@ -62,17 +64,17 @@ __all__ = [
 
 class ErrorDetails(_TypedDict):
     type: str
-    loc: 'tuple[int | str, ...]'
+    loc: tuple[int | str, ...]
     msg: str
     input: _Any
-    ctx: _NotRequired['dict[str, str | int | float]']
+    ctx: _NotRequired[dict[str, str | int | float]]
 
 
 class InitErrorDetails(_TypedDict):
-    type: 'str | PydanticCustomError'
-    loc: _NotRequired['tuple[int | str, ...]']
+    type: str | PydanticCustomError
+    loc: _NotRequired[tuple[int | str, ...]]
     input: _Any
-    ctx: _NotRequired['dict[str, str | int | float]']
+    ctx: _NotRequired[dict[str, str | int | float]]
 
 
 class ErrorTypeInfo(_TypedDict):
@@ -81,11 +83,11 @@ class ErrorTypeInfo(_TypedDict):
     example_message_python: str
     message_template_json: _NotRequired[str]
     example_message_json: _NotRequired[str]
-    example_context: 'dict[str, str | int | float] | None'
+    example_context: dict[str, str | int | float] | None
 
 
 class MultiHostHost(_TypedDict):
-    username: 'str | None'
-    password: 'str | None'
-    host: 'str | None'
-    port: 'int | None'
+    username: str | None
+    password: str | None
+    host: str | None
+    port: int | None

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import sys
 from collections.abc import Mapping
 from datetime import date, datetime, time, timedelta
-from typing import Any, Callable, Dict, Hashable, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, List, Optional, Set, Type, Union
 
 if sys.version_info < (3, 11):
     from typing_extensions import Protocol, Required, TypeAlias
@@ -15,10 +15,16 @@ if sys.version_info < (3, 9):
 else:
     from typing import Literal, TypedDict
 
-try:
+if TYPE_CHECKING:
     from pydantic_core import PydanticUndefined
-except ImportError:
-    PydanticUndefined = object()
+else:
+    # The initial build of pydantic_core requires PydanticUndefined to generate
+    # the core schema; so we need to conditionally skip it. mypy doesn't like
+    # this at all, hence the TYPE_CHECKING branch above.
+    try:
+        from pydantic_core import PydanticUndefined
+    except ImportError:
+        PydanticUndefined = object()
 
 
 def dict_not_none(**kwargs: Any) -> Any:

--- a/src/argument_markers.rs
+++ b/src/argument_markers.rs
@@ -93,6 +93,7 @@ impl PydanticUndefinedType {
         UNDEFINED_CELL.get(py).unwrap().clone()
     }
 
+    #[pyo3(signature = (_memo, /))]
     fn __deepcopy__(&self, py: Python, _memo: &PyAny) -> Py<Self> {
         self.__copy__(py)
     }

--- a/src/url.rs
+++ b/src/url.rs
@@ -142,6 +142,7 @@ impl PyUrl {
         true // an empty string is not a valid URL
     }
 
+    #[pyo3(signature = (_memo, /))]
     pub fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> Py<PyAny> {
         self.clone().into_py(py)
     }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -82,7 +82,8 @@ impl PySome {
     }
 
     #[classmethod]
-    pub fn __class_getitem__(cls: &PyType, _args: &PyAny) -> Py<PyType> {
+    #[pyo3(signature = (_item, /))]
+    pub fn __class_getitem__(cls: &PyType, _item: &PyAny) -> Py<PyType> {
         cls.into_py(cls.py())
     }
 

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -2,3 +2,4 @@ black==23.3.0
 griffe==0.27.3
 pyright==1.1.296
 ruff==0.0.264
+mypy==1.4.1


### PR DESCRIPTION
## Change Summary

This PR adds use of mypy's `stubtest` tool to validate the `.pyi` file for `pydantic-core`, and fixes the errors detected.

Most of this is mechanical fixups which are good to have correct but not interesting to debate. The interesting things of note:
 - Two errors related to methods I didn't want in the stub, see TODO notes in `.mypy-stubtest-allowlist`.
 - I moved the `TypedDict` definitions to `pydantic_core/__init__.py` as these were reported at missing at runtime, and I think it's fair users may want to import these.
 - Many classes marked `@final`, because PyO3 types are final by default. **We should review if we want to allow subtyping any of them.**

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb