### PR TITLE
Remove unused bool error

### DIFF
--- a/pydantic_core/core_schema.py
+++ b/pydantic_core/core_schema.py
@@ -3772,7 +3772,6 @@ ErrorType = Literal[
     'get_attribute_error',
     'model_class_type',
     'none_required',
-    'bool',
     'greater_than',
     'greater_than_equal',
     'less_than',

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -98,8 +98,6 @@ pub enum ErrorType {
     // ---------------------
     // None errors
     NoneRequired,
-    // boolean errors
-    Bool,
     // ---------------------
     // generic comparison errors - used for all inequality comparisons except int and float which have their
     // own type, bounds arguments are Strings so they can be created from any type
@@ -471,7 +469,6 @@ impl ErrorType {
             Self::GetAttributeError {..} => "Error extracting attribute: {error}",
             Self::ModelClassType {..} => "Input should be an instance of {class_name}",
             Self::NoneRequired => "Input should be None",
-            Self::Bool => "Input should be a valid boolean",
             Self::GreaterThan {..} => "Input should be greater than {gt}",
             Self::GreaterThanEqual {..} => "Input should be greater than or equal to {ge}",
             Self::LessThan {..} => "Input should be less than {lt}",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -189,7 +189,6 @@ all_errors = [
     ('get_attribute_error', 'Error extracting attribute: foo', {'error': 'foo'}),
     ('model_class_type', 'Input should be an instance of foo', {'class_name': 'foo'}),
     ('none_required', 'Input should be None', None),
-    ('bool', 'Input should be a valid boolean', None),
     ('greater_than', 'Input should be greater than 42.1', {'gt': 42.1}),
     ('greater_than', 'Input should be greater than 42.1', {'gt': '42.1'}),
     ('greater_than', 'Input should be greater than 2020-01-01', {'gt': '2020-01-01'}),


### PR DESCRIPTION
It seems the `Bool` error was replaced with `BoolParsing` and `BoolType`, but never removed. This PR removes it

Selected Reviewer: @davidhewitt