### PR TITLE
allow typing-extensions-4.7.0+ on pypy3.9+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
     'maturin>=1,<2',
-    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy"',
-    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy"'
+    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy" or python_version >= "3.9"',
+    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy" and python_version < "3.9"'
 ]
 build-backend = 'maturin'
 
@@ -33,8 +33,8 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy"',
-    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy"'
+    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy" or python_version >= "3.9"',
+    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy" and python_version < "3.9"'
 ]
 dynamic = [
     'description',


### PR DESCRIPTION
## Change Summary

Remove the PyPy-specific version restriction on typing-extensions when PyPy3.9 or newer is used.  The bug cited
in 12073b84563e3c74da9bbf847f6af88c8c229c12 is specific to PyPy3.7 and PyPy3.8.

## Related issue number

(discussed in https://github.com/pydantic/pydantic-core/commit/12073b84563e3c74da9bbf847f6af88c8c229c12#r120315009)

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt