### PR TITLE
Simplify typing_extensions pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     'maturin>=1,<2',
-    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy" or python_version >= "3.9"',
-    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy" and python_version < "3.9"'
+    'typing-extensions >=4.6.0,!=4.7.0'
 ]
 build-backend = 'maturin'
 
@@ -33,8 +32,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'typing-extensions >=4.6.0; platform_python_implementation != "PyPy" or python_version >= "3.9"',
-    'typing-extensions >=4.6.0,<4.7.0; platform_python_implementation == "PyPy" and python_version < "3.9"'
+    'typing-extensions >=4.6.0,!=4.7.0'
 ]
 dynamic = [
     'description',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

typing_extensions 4.7.0 didn't work on PyPy-3.7 and PyPy-3.8, which led you to (very reasonably!) add an upper bound to your typing_extensions dependency on PyPy. However, we've since fixed the PyPy issues in [typing_extensions 4.7.1](https://github.com/python/typing_extensions/releases/tag/4.7.1) by working around [the bug in PyPy-3.7 and PyPy-3.8](https://foss.heptapod.net/pypy/pypy/-/issues/3958) that caused the breakage.

Since typing_extensions 4.7.1 should work fine on PyPy-3.7 and PyPy-3.8, it should be fine to get rid of the upper bound now.

Loosening the pin here will also give typing_extensions the option of running pydantic's tests with typing_extensions's main branch on more PyPy versions in CI as part of our [third-party nightly workflow](https://github.com/python/typing_extensions/blob/main/.github/workflows/third_party.yml). Doing that should hopefully reduce the chance of breakages like this in the future :)

## Related issue number

No issue number, but this is a followup to these PRs:
- https://github.com/pydantic/pydantic-core/pull/716
- https://github.com/pydantic/pydantic-core/pull/723

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
