### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "ahash",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"


### PR DESCRIPTION
We don't really have a story for versioning `pydantic-core` (in particular, we are not promising SemVer) but I found it prudent to make this a minor release since there are some breaking changes.

Selected Reviewer: @davidhewitt