### PR TITLE
Always build PGO using `RUSTFLAGS`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,9 +469,10 @@ jobs:
           pip install -r tests/requirements.txt
           pip install pydantic-core --no-index --no-deps --find-links pgo-wheel --force-reinstall
           pytest tests/benchmarks
+          rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       - name: merge pgo data
-        run: rustup run stable llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
+        run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
 
       - name: build pgo-optimized wheel
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,9 +454,10 @@ jobs:
             --release
             --out pgo-wheel
             --interpreter ${{ matrix.maturin-interpreter || matrix.interpreter }}
-            -- -Cprofile-generate=${{ github.workspace }}/profdata
           rust-toolchain: stable
           docker-options: -e CI
+        env:
+          RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/profdata"
 
       - name: detect rust host
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
@@ -468,10 +469,9 @@ jobs:
           pip install -r tests/requirements.txt
           pip install pydantic-core --no-index --no-deps --find-links pgo-wheel --force-reinstall
           pytest tests/benchmarks
-          rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       - name: merge pgo data
-        run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
+        run: rustup run stable llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
 
       - name: build pgo-optimized wheel
         uses: PyO3/maturin-action@v1
@@ -482,9 +482,10 @@ jobs:
             --release
             --out dist
             --interpreter ${{ matrix.maturin-interpreter || matrix.interpreter }}
-            -- -Cprofile-use=${{ github.workspace }}/merged.profdata
           rust-toolchain: stable
           docker-options: -e CI
+        env:
+          RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"
 
       - run: ${{ matrix.ls || 'ls -lh' }} dist/
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -62,7 +62,7 @@ jobs:
         run: pytest tests/benchmarks
 
       - name: Prepare merged pgo data
-        run: rustup run stable llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
+        run: rustup run stable bash -c '$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata'
 
       - name: Compile pydantic-core for benchmarking
         # --no-default-features to avoid using mimalloc

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -62,7 +62,7 @@ jobs:
         run: pytest tests/benchmarks
 
       - name: Prepare merged pgo data
-        run: rustup run stable bash -c '$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata'
+        run: rustup run stable llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
 
       - name: Compile pydantic-core for benchmarking
         # --no-default-features to avoid using mimalloc


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

There are many ways to pass flags to rustc:

* `cargo rustc`, which only affects your crate and not its dependencies.
* `RUSTFLAGS` environment variable, which affects dependencies as well.

See https://stackoverflow.com/a/38040431

In this case I think `RUSTFLAGS` is a better choice.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
