### PR TITLE
fix segfaults on tests in debug builds for PyPy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,22 @@ jobs:
 
   # test with a debug build as it picks up errors which optimised release builds do not
   test-debug:
+    name: test-debug ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.11'
+          - 'pypy3.9'
 
     steps:
       - uses: actions/checkout@v3
       - name: set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - run: pip install -r tests/requirements.txt
       - run: pip install -e . --config-settings=build-args='--profile dev'

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -22,6 +22,7 @@ from _typeshed import SupportsAllComparisons
 __all__ = [
     '__version__',
     'build_profile',
+    '_recursion_limit',
     'ArgsKwargs',
     'SchemaValidator',
     'SchemaSerializer',
@@ -44,6 +45,7 @@ __all__ = [
 ]
 __version__: str
 build_profile: str
+_recursion_limit: int
 
 _T = TypeVar('_T', default=Any, covariant=True)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub fn get_version() -> String {
 fn _pydantic_core(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", get_version())?;
     m.add("build_profile", env!("PROFILE"))?;
+    m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;
     m.add("PydanticUndefined", PydanticUndefinedType::new(py))?;
     m.add_class::<PydanticUndefinedType>()?;
     m.add_class::<PySome>()?;

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -84,7 +84,7 @@ impl Validator for DefinitionRefValidator {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
                 Err(ValError::new(ErrorType::RecursionLoop, input))
             } else {
-                if recursion_guard.incr_depth() > BACKUP_GUARD_LIMIT {
+                if recursion_guard.incr_depth() {
                     return Err(ValError::new(ErrorType::RecursionLoop, input));
                 }
                 let output = validate(self.validator_id, py, input, extra, definitions, recursion_guard);
@@ -112,7 +112,7 @@ impl Validator for DefinitionRefValidator {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
                 Err(ValError::new(ErrorType::RecursionLoop, obj))
             } else {
-                if recursion_guard.incr_depth() > BACKUP_GUARD_LIMIT {
+                if recursion_guard.incr_depth() {
                     return Err(ValError::new(ErrorType::RecursionLoop, obj));
                 }
                 let output = validate_assignment(
@@ -168,15 +168,6 @@ impl Validator for DefinitionRefValidator {
         Ok(())
     }
 }
-
-// see #143 this is a backup in case the identity check recursion guard fails
-// if a single validator "depth" (how many times it's called inside itself) exceeds the limit,
-// we raise a recursion error.
-const BACKUP_GUARD_LIMIT: u16 = if cfg!(PyPy) || cfg!(target_family = "wasm") {
-    123
-} else {
-    255
-};
 
 fn validate<'s, 'data>(
     validator_id: usize,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,10 +1,12 @@
 import json
+import platform
 import re
 from typing import List
 
 import pytest
 from dirty_equals import IsList
 
+import pydantic_core
 from pydantic_core import (
     PydanticSerializationError,
     SchemaSerializer,
@@ -285,6 +287,10 @@ def test_cycle_same():
         to_json(f, fallback=fallback_func_passthrough)
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == 'PyPy' and pydantic_core._pydantic_core.build_profile == 'debug',
+    reason='PyPy does not have enough stack space for Rust debug builds to recurse very deep',
+)
 def test_cycle_change():
     def fallback_func_change_id(obj):
         return Foobar()


### PR DESCRIPTION
## Change Summary

This PR unifies the recursion guard limit between serialization and validation to 255 (thanks @adamreichold for the suggestion to move to a single limit).

I also add `pytest.skip` to a few tests which fail on PyPy with debug builds. This is because Rust debug builds don't optimize their stack space, so we hit trivial stack overflows.

Finally I add a `test-debug` job for PyPy 3.9 - can bump to PyPy 3.10 once the upstream PyO3 bug is fixed.

## Related issue number

Ref #659
This should avoid crashes on debug builds with PyPy. (Doesn't close the full issue, which also exposes a bug in PyO3.)

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
