### PR TITLE
serde for JSON integers larger than 64 bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,20 @@ name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ pyo3 = { version = "0.19.1", features = ["generate-import-lib", "num-bigint"] }
 regex = "1.6.0"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.24.3"
-serde_json = {version = "1.0.87", features = ["preserve_order"]}
+serde_json = {version = "1.0.87", features = ["arbitrary_precision", "preserve_order"]}
 enum_dispatch = "0.3.8"
-serde = "1.0.147"
+serde = { version = "1.0.147", features = ["derive"] }
 # disabled for benchmarks since it makes microbenchmark performance more flakey
 mimalloc = { version = "0.1.30", optional = true, default-features = false, features = ["local_dynamic_tls"] }
 speedate = "0.9.1"

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -10,6 +10,7 @@ use pyo3::types::{
 
 use serde::ser::{Error, Serialize, SerializeMap, SerializeSeq, Serializer};
 
+use crate::input::Int;
 use crate::serializers::errors::SERIALIZATION_ERR_MARKER;
 use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{PydanticSerializer, TypeSerializer};
@@ -406,7 +407,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
 
     let ser_result = match ob_type {
         ObType::None => serializer.serialize_none(),
-        ObType::Int | ObType::IntSubclass => serialize!(i64),
+        ObType::Int | ObType::IntSubclass => serialize!(Int),
         ObType::Bool => serialize!(bool),
         ObType::Float | ObType::FloatSubclass => serialize!(f64),
         ObType::Decimal => value.to_string().serialize(serializer),

--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use serde::Serialize;
 
-use crate::definitions::DefinitionsBuilder;
+use crate::{definitions::DefinitionsBuilder, input::Int};
 
 use super::{
     infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, IsType, ObType,
@@ -163,7 +163,7 @@ pub(crate) fn to_str_json_key(key: &PyAny) -> PyResult<Cow<str>> {
     Ok(key.str()?.to_string_lossy())
 }
 
-build_simple_serializer!(IntSerializer, "int", i64, ObType::Int, to_str_json_key);
+build_simple_serializer!(IntSerializer, "int", Int, ObType::Int, to_str_json_key);
 
 pub(crate) fn bool_json_key(key: &PyAny) -> PyResult<Cow<str>> {
     let v = if key.is_true().unwrap_or(false) {

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -19,11 +19,16 @@ class FloatSubClass(float):
     pass
 
 
+# A number well outside of i64 range
+_BIG_NUMBER_BYTES = b'1' + (b'0' * 40)
+
+
 @pytest.mark.parametrize('custom_type_schema', [None, 'any'])
 @pytest.mark.parametrize(
     'schema_type,value,expected_python,expected_json',
     [
         ('int', 1, 1, b'1'),
+        ('int', int(_BIG_NUMBER_BYTES), int(_BIG_NUMBER_BYTES), _BIG_NUMBER_BYTES),
         ('bool', True, True, b'true'),
         ('bool', False, False, b'false'),
         ('float', 1.0, 1.0, b'1.0'),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -63,6 +63,10 @@ def test_bytes():
         s.validate_json('123')
 
 
+# A number well outside of i64 range
+_BIG_NUMBER_STR = '1' + ('0' * 40)
+
+
 @pytest.mark.parametrize(
     'input_value,expected',
     [
@@ -70,7 +74,9 @@ def test_bytes():
         ('"123"', 123),
         ('123.0', 123),
         ('"123.0"', 123),
+        (_BIG_NUMBER_STR, int(_BIG_NUMBER_STR)),
         ('123.4', Err('Input should be a valid integer, got a number with a fractional part [type=int_from_float,')),
+        ('"123.4"', Err('Input should be a valid integer, unable to parse string as an integer [type=int_parsing,')),
         ('"string"', Err('Input should be a valid integer, unable to parse string as an integer [type=int_parsing,')),
     ],
 )

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -162,13 +162,7 @@ def test_negative_int(input_value, expected):
         (i64_max, i64_max),
         (i64_max + 1, i64_max + 1),
         (i64_max * 2, i64_max * 2),
-        (
-            int(1e30),
-            Err(
-                'Unable to parse input string as an integer, exceeded maximum size '
-                '[type=int_parsing_size, input_value=1e+30, input_type=float]'
-            ),
-        ),
+        (int(1e30), int(1e30)),
         (0, Err('Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]')),
         (-1, Err('Input should be greater than 0 [type=greater_than, input_value=-1, input_type=int]')),
         pytest.param(
@@ -197,10 +191,7 @@ def test_positive_json(input_value, expected):
         (0, Err('Input should be less than 0 [type=less_than, input_value=0, input_type=int]')),
         (-i64_max, -i64_max),
         (-i64_max - 1, -i64_max - 1),
-        (
-            -i64_max * 2,
-            Err(' Unable to parse input string as an integer, exceeded maximum size [type=int_parsing_size'),
-        ),
+        (-i64_max * 2, -i64_max * 2),
     ],
 )
 def test_negative_json(input_value, expected):
@@ -391,8 +382,7 @@ def test_long_python_inequality():
 def test_long_json():
     v = SchemaValidator({'type': 'int'})
 
-    with pytest.raises(ValidationError, match=r'number out of range at line 1 column 401 \[type=json_invalid,'):
-        v.validate_json('-' + '1' * 400)
+    assert v.validate_json('-' + '1' * 400) == int('-' + '1' * 400)
 
     with pytest.raises(ValidationError, match=r'expected ident at line 1 column 2 \[type=json_invalid,'):
         v.validate_json('nan')


### PR DESCRIPTION
## Change Summary

Implements validation and serialization for large JSON integers using the `serde_json/arbitrary_precision` feature.

## Related issue number

https://github.com/pydantic/pydantic/issues/6442

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
