### PR TITLE
use timedelta repr as constraint in error messages

### DIFF
--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -120,22 +120,23 @@ impl<'a> EitherTimedelta<'a> {
         }
     }
 
-    pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
-        let timedelta = match self {
-            Self::Py(timedelta) => Ok(timedelta),
-            Self::Raw(duration) => {
-                let sign = if duration.positive { 1 } else { -1 };
-                PyDelta::new(
-                    py,
-                    sign * duration.day as i32,
-                    sign * duration.second as i32,
-                    sign * duration.microsecond as i32,
-                    true,
-                )
-            }
-        }?;
-        Ok(timedelta.into_py(py))
+    pub fn try_into_py(&self, py: Python<'a>) -> PyResult<&'a PyDelta> {
+        match self {
+            Self::Py(timedelta) => Ok(*timedelta),
+            Self::Raw(duration) => duration_as_pytimedelta(py, duration),
+        }
     }
+}
+
+pub fn duration_as_pytimedelta<'py>(py: Python<'py>, duration: &Duration) -> PyResult<&'py PyDelta> {
+    let sign = if duration.positive { 1 } else { -1 };
+    PyDelta::new(
+        py,
+        sign * duration.day as i32,
+        sign * duration.second as i32,
+        sign * duration.microsecond as i32,
+        true,
+    )
 }
 
 pub fn pytime_as_time(py_time: &PyAny, py_dt: Option<&PyAny>) -> PyResult<Time> {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,8 +11,8 @@ mod return_enums;
 mod shared;
 
 pub(crate) use datetime::{
-    pydate_as_date, pydatetime_as_datetime, pytime_as_time, pytimedelta_as_duration, EitherDate, EitherDateTime,
-    EitherTime, EitherTimedelta,
+    duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, pytimedelta_as_duration,
+    EitherDate, EitherDateTime, EitherTime, EitherTimedelta,
 };
 pub(crate) use input_abstract::{Input, InputType};
 pub(crate) use parse_json::{JsonInput, JsonObject};

--- a/tests/validators/test_timedelta.py
+++ b/tests/validators/test_timedelta.py
@@ -131,27 +131,35 @@ def test_timedelta_strict_json(input_value, expected):
         ({}, 'P0Y0M3D2WT1H2M3S', timedelta(days=3, weeks=2, hours=1, minutes=2, seconds=3)),
         ({'le': timedelta(days=3)}, 'P2DT1H', timedelta(days=2, hours=1)),
         ({'le': timedelta(days=3)}, 'P3DT0H', timedelta(days=3)),
-        ({'le': timedelta(days=3)}, 'P3DT1H', Err('Input should be less than or equal to P3D')),
+        ({'le': timedelta(days=3)}, 'P3DT1H', Err('Input should be less than or equal to datetime.timedelta(days=3)')),
         ({'lt': timedelta(days=3)}, 'P2DT1H', timedelta(days=2, hours=1)),
-        ({'lt': timedelta(days=3)}, 'P3DT1H', Err('Input should be less than P3D')),
+        ({'lt': timedelta(days=3)}, 'P3DT1H', Err('Input should be less than datetime.timedelta(days=3)')),
         ({'ge': timedelta(days=3)}, 'P3DT1H', timedelta(days=3, hours=1)),
         ({'ge': timedelta(days=3)}, 'P3D', timedelta(days=3)),
-        ({'ge': timedelta(days=3)}, 'P2DT1H', Err('Input should be greater than or equal to P3D')),
+        (
+            {'ge': timedelta(days=3)},
+            'P2DT1H',
+            Err('Input should be greater than or equal to datetime.timedelta(days=3)'),
+        ),
         ({'gt': timedelta(days=3)}, 'P3DT1H', timedelta(days=3, hours=1)),
-        ({'gt': 'P3D'}, 'P2DT1H', Err('Input should be greater than P3D')),
+        ({'gt': 'P3D'}, 'P2DT1H', Err('Input should be greater than datetime.timedelta(days=3)')),
         ({'le': timedelta(seconds=-86400.123)}, '-PT86400.123S', timedelta(seconds=-86400.123)),
         ({'le': timedelta(seconds=-86400.123)}, '-PT86400.124S', timedelta(seconds=-86400.124)),
         (
             {'le': timedelta(seconds=-86400.123)},
             '-PT86400.122S',
-            Err('Input should be less than or equal to -P1DT0.123S [type=less_than_equal'),
+            Err(
+                'Input should be less than or equal to datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=less_than_equal'  # noqa: E501
+            ),
         ),
         ({'gt': timedelta(seconds=-86400.123)}, timedelta(seconds=-86400.122), timedelta(seconds=-86400.122)),
         ({'gt': timedelta(seconds=-86400.123)}, '-PT86400.122S', timedelta(seconds=-86400.122)),
         (
             {'gt': timedelta(seconds=-86400.123)},
             '-PT86400.124S',
-            Err('Input should be greater than -P1DT0.123S [type=greater_than'),
+            Err(
+                'Input should be greater than datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=greater_than'  # noqa: E501
+            ),
         ),
     ],
     ids=repr,


### PR DESCRIPTION
## Change Summary

Changes timedelta validation with constraints to format the constraint as a Python timedelta instead of ISO duration. Most users are likely more familiar with the Python representation.

## Related issue number

Ref https://github.com/pydantic/pydantic/issues/6421

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
