### PR TITLE
add `build_info` to `_pydantic_core`

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -22,6 +22,7 @@ from _typeshed import SupportsAllComparisons
 __all__ = [
     '__version__',
     'build_profile',
+    'build_info',
     '_recursion_limit',
     'ArgsKwargs',
     'SchemaValidator',
@@ -45,6 +46,7 @@ __all__ = [
 ]
 __version__: str
 build_profile: str
+build_info: str
 _recursion_limit: int
 
 _T = TypeVar('_T', default=Any, covariant=True)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,24 @@ pub fn get_version() -> String {
     version.replace("-alpha", "a").replace("-beta", "b")
 }
 
+pub fn build_info() -> String {
+    let mut flags = vec![env!("PROFILE")];
+    if let Some(rust_flags) = option_env!("RUSTFLAGS") {
+        if rust_flags.contains("-Cprofile-use=") {
+            flags.push("pgo");
+        }
+    }
+    if cfg!(feature = "mimalloc") {
+        flags.push("mimalloc");
+    }
+    flags.join(" ")
+}
+
 #[pymodule]
 fn _pydantic_core(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", get_version())?;
     m.add("build_profile", env!("PROFILE"))?;
+    m.add("build_info", build_info())?;
     m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;
     m.add("PydanticUndefined", PydanticUndefinedType::new(py))?;
     m.add_class::<PydanticUndefinedType>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,16 +44,12 @@ pub fn get_version() -> String {
 }
 
 pub fn build_info() -> String {
-    let mut flags = vec![env!("PROFILE")];
-    if let Some(rust_flags) = option_env!("RUSTFLAGS") {
-        if rust_flags.contains("-Cprofile-use=") {
-            flags.push("pgo");
-        }
-    }
-    if cfg!(feature = "mimalloc") {
-        flags.push("mimalloc");
-    }
-    flags.join(" ")
+    format!(
+        "profile={} pgo={} mimalloc={}",
+        env!("PROFILE"),
+        option_env!("RUSTFLAGS").unwrap_or("").contains("-Cprofile-use="),
+        cfg!(feature = "mimalloc")
+    )
 }
 
 #[pymodule]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,7 +6,14 @@ import pytest
 from typing_extensions import get_args
 
 from pydantic_core import CoreSchema, CoreSchemaType, PydanticUndefined, core_schema
-from pydantic_core._pydantic_core import SchemaError, SchemaValidator, ValidationError, __version__, build_profile
+from pydantic_core._pydantic_core import (
+    SchemaError,
+    SchemaValidator,
+    ValidationError,
+    __version__,
+    build_info,
+    build_profile,
+)
 
 
 @pytest.mark.parametrize('obj', [ValidationError, SchemaValidator, SchemaError])
@@ -21,6 +28,10 @@ def test_version():
 
 def test_build_profile():
     assert build_profile in ('debug', 'release')
+
+
+def test_build_info():
+    assert isinstance(build_info, str)
 
 
 def test_schema_error():


### PR DESCRIPTION
Useful to check if `PGO` was used. We should add this to `pydantic.version.version_info()`.

Selected Reviewer: @davidhewitt