### PR TITLE
Add missing error type 'enum'

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3787,6 +3787,7 @@ ErrorType = Literal[
     'missing',
     'frozen_field',
     'frozen_instance',
+    'enum',
     'extra_forbidden',
     'invalid_key',
     'get_attribute_error',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

I just updated the documentation because the validation error (https://docs.pydantic.dev/latest/usage/validation_errors/) enum was missing there.

skip change file check

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/6439

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
