### PR TITLE
use pydantic's version in error messages

### DIFF
--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -15,7 +15,7 @@ use serde_json::ser::PrettyFormatter;
 
 use crate::build_tools::py_schema_error_type;
 use crate::errors::LocItem;
-use crate::get_version;
+use crate::get_pydantic_version;
 use crate::serializers::{SerMode, SerializationState};
 use crate::tools::{safe_repr, SchemaDict};
 
@@ -113,7 +113,12 @@ static URL_PREFIX: GILOnceCell<String> = GILOnceCell::new();
 
 fn get_url_prefix(py: Python, include_url: bool) -> Option<&str> {
     if include_url {
-        Some(URL_PREFIX.get_or_init(py, || format!("https://errors.pydantic.dev/{}/v/", get_version())))
+        Some(URL_PREFIX.get_or_init(py, || {
+            format!(
+                "https://errors.pydantic.dev/{}/v/",
+                get_pydantic_version(py).unwrap_or("latest")
+            )
+        }))
     } else {
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 
 extern crate core;
 
-use pyo3::prelude::*;
+use std::sync::OnceLock;
+
+use pyo3::{prelude::*, sync::GILOnceCell};
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
@@ -33,14 +35,31 @@ pub use serializers::{
 };
 pub use validators::{PySome, SchemaValidator};
 
-pub fn get_version() -> String {
-    let version = env!("CARGO_PKG_VERSION");
-    // cargo uses "1.0-alpha1" etc. while python uses "1.0.0a1", this is not full compatibility,
-    // but it's good enough for now
-    // see https://docs.rs/semver/1.0.9/semver/struct.Version.html#method.parse for rust spec
-    // see https://peps.python.org/pep-0440/ for python spec
-    // it seems the dot after "alpha/beta" e.g. "-alpha.1" is not necessary, hence why this works
-    version.replace("-alpha", "a").replace("-beta", "b")
+pub fn get_pydantic_core_version() -> &'static str {
+    static PYDANTIC_CORE_VERSION: OnceLock<String> = OnceLock::new();
+
+    PYDANTIC_CORE_VERSION.get_or_init(|| {
+        let version = env!("CARGO_PKG_VERSION");
+        // cargo uses "1.0-alpha1" etc. while python uses "1.0.0a1", this is not full compatibility,
+        // but it's good enough for now
+        // see https://docs.rs/semver/1.0.9/semver/struct.Version.html#method.parse for rust spec
+        // see https://peps.python.org/pep-0440/ for python spec
+        // it seems the dot after "alpha/beta" e.g. "-alpha.1" is not necessary, hence why this works
+        version.replace("-alpha", "a").replace("-beta", "b")
+    })
+}
+
+/// Returns the installed version of pydantic.
+fn get_pydantic_version(py: Python<'_>) -> Option<&'static str> {
+    static PYDANTIC_VERSION: GILOnceCell<Option<String>> = GILOnceCell::new();
+
+    PYDANTIC_VERSION
+        .get_or_init(py, || {
+            py.import("pydantic")
+                .and_then(|pydantic| pydantic.getattr("__version__")?.extract())
+                .ok()
+        })
+        .as_deref()
 }
 
 pub fn build_info() -> String {
@@ -54,7 +73,7 @@ pub fn build_info() -> String {
 
 #[pymodule]
 fn _pydantic_core(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("__version__", get_version())?;
+    m.add("__version__", get_pydantic_core_version())?;
     m.add("build_profile", env!("PROFILE"))?;
     m.add("build_info", build_info())?;
     m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,16 @@ def import_execute(request, tmp_work_path: Path):
     return _import_execute
 
 
+@pytest.fixture
+def pydantic_version():
+    try:
+        import pydantic
+
+        return pydantic.__version__
+    except ImportError:
+        return 'latest'
+
+
 def infinite_generator():
     i = 0
     while True:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, __version__
+from pydantic_core import SchemaError, SchemaValidator
 from pydantic_core import core_schema as cs
 
 
@@ -32,13 +32,13 @@ def test_schema_as_string():
     assert v.validate_python('tRuE') is True
 
 
-def test_schema_wrong_type():
+def test_schema_wrong_type(pydantic_version):
     with pytest.raises(SchemaError) as exc_info:
         SchemaValidator(1)
     assert str(exc_info.value) == (
         'Invalid Schema:\n  Input should be a valid dictionary or object to'
         ' extract fields from [type=model_attributes_type, input_value=1, input_type=int]\n'
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/model_attributes_type'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/model_attributes_type'
     )
     assert exc_info.value.errors() == [
         {

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -10,7 +10,6 @@ from pydantic_core import (
     PydanticOmit,
     SchemaValidator,
     ValidationError,
-    __version__,
     core_schema,
 )
 from pydantic_core._pydantic_core import list_all_errors
@@ -413,7 +412,7 @@ class BadRepr:
         raise RuntimeError('bad repr')
 
 
-def test_error_on_repr():
+def test_error_on_repr(pydantic_version):
     s = SchemaValidator({'type': 'int'})
     with pytest.raises(ValidationError) as exc_info:
         s.validate_python(BadRepr())
@@ -422,7 +421,7 @@ def test_error_on_repr():
         '1 validation error for int\n'
         '  Input should be a valid integer '
         '[type=int_type, input_value=<unprintable BadRepr object>, input_type=BadRepr]\n'
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/int_type'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/int_type'
     )
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'int_type', 'loc': (), 'msg': 'Input should be a valid integer', 'input': IsInstance(BadRepr)}
@@ -439,7 +438,7 @@ def test_error_on_repr():
     )
 
 
-def test_error_json():
+def test_error_json(pydantic_version):
     s = SchemaValidator({'type': 'str', 'min_length': 3})
     with pytest.raises(ValidationError) as exc_info:
         s.validate_python('12')
@@ -462,7 +461,7 @@ def test_error_json():
                 'msg': 'String should have at least 3 characters',
                 'input': '12',
                 'ctx': {'min_length': 3},
-                'url': f'https://errors.pydantic.dev/{__version__}/v/string_too_short',
+                'url': f'https://errors.pydantic.dev/{pydantic_version}/v/string_too_short',
             }
         ]
     )
@@ -620,7 +619,7 @@ def test_raise_validation_error_custom():
     ]
 
 
-def test_loc_with_dots():
+def test_loc_with_dots(pydantic_version):
     v = SchemaValidator(
         core_schema.typed_dict_schema(
             {
@@ -649,5 +648,5 @@ def test_loc_with_dots():
         "`foo.bar`.0\n"
         "  Input should be a valid integer, unable to parse string as an integer "
         "[type=int_parsing, input_value='x', input_type=str]\n"
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/int_parsing'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/int_parsing'
     )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -41,7 +41,7 @@ def test_schema_error():
     assert repr(err) == 'SchemaError("test")'
 
 
-def test_validation_error():
+def test_validation_error(pydantic_version):
     v = SchemaValidator({'type': 'int'})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(1.5)
@@ -67,7 +67,7 @@ def test_validation_error():
             'loc': (),
             'msg': 'Input should be a valid integer, got a number with a fractional part',
             'input': 1.5,
-            'url': f'https://errors.pydantic.dev/{__version__}/v/int_from_float',
+            'url': f'https://errors.pydantic.dev/{pydantic_version}/v/int_from_float',
         }
     ]
 
@@ -108,7 +108,7 @@ def test_custom_title():
     assert exc_info.value.title == 'MyInt'
 
 
-def test_validation_error_multiple():
+def test_validation_error_multiple(pydantic_version):
     class MyModel:
         # this is not required, but it avoids `__pydantic_fields_set__` being included in `__dict__`
         __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
@@ -152,11 +152,11 @@ def test_validation_error_multiple():
         'x\n'
         '  Input should be a valid number, unable to parse string as a number '
         "[type=float_parsing, input_value='xxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxx', input_type=str]\n"
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/float_parsing\n'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/float_parsing\n'
         'y\n'
         '  Input should be a valid integer, unable to parse string as an integer '
         "[type=int_parsing, input_value='y', input_type=str]\n"
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/int_parsing'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/int_parsing'
     )
 
 

--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -6,7 +6,7 @@ from typing import Any, get_type_hints
 
 import pytest
 
-from pydantic_core import ArgsKwargs, SchemaError, SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import ArgsKwargs, SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson, plain_repr
 
@@ -984,7 +984,7 @@ def test_invalid_schema():
         )
 
 
-def test_error_display():
+def test_error_display(pydantic_version):
     v = SchemaValidator(
         core_schema.arguments_schema(
             [
@@ -1013,7 +1013,7 @@ def test_error_display():
         "b\n"
         "  Missing required argument [type=missing_argument, "
         "input_value=ArgsKwargs((), {'a': 1}), input_type=ArgsKwargs]\n"
-        f"    For further information visit https://errors.pydantic.dev/{__version__}/v/missing_argument"
+        f"    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/missing_argument"
     )
     # insert_assert(exc_info.value.json(include_url=False))
     assert exc_info.value.json(include_url=False) == (

--- a/tests/validators/test_bool.py
+++ b/tests/validators/test_bool.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from pydantic_core import SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson, plain_repr
 
@@ -53,7 +53,7 @@ def test_bool_strict(py_and_json: PyAndJson):
         v.validate_test('true')
 
 
-def test_bool_error():
+def test_bool_error(pydantic_version):
     v = SchemaValidator({'type': 'bool'})
 
     with pytest.raises(ValidationError) as exc_info:
@@ -63,7 +63,7 @@ def test_bool_error():
         '1 validation error for bool\n'
         '  Input should be a valid boolean, '
         "unable to interpret input [type=bool_parsing, input_value='wrong', input_type=str]\n"
-        f"    For further information visit https://errors.pydantic.dev/{__version__}/v/bool_parsing"
+        f"    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/bool_parsing"
     )
     assert exc_info.value.errors(include_url=False) == [
         {

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -6,7 +6,7 @@ import pytest
 from dirty_equals import AnyThing, HasAttributes, IsList, IsPartialDict, IsStr, IsTuple
 
 import pydantic_core
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, plain_repr
 from .test_typed_dict import Cls
@@ -818,7 +818,7 @@ def test_error_inside_definition_wrapper():
     )
 
 
-def test_recursive_definitions_schema() -> None:
+def test_recursive_definitions_schema(pydantic_version) -> None:
     s = core_schema.definitions_schema(
         core_schema.definition_reference_schema(schema_ref='a'),
         [
@@ -854,7 +854,7 @@ def test_recursive_definitions_schema() -> None:
             'loc': ('b', 0, 'a'),
             'msg': 'Input should be a valid list',
             'input': {},
-            'url': f'https://errors.pydantic.dev/{__version__}/v/list_type',
+            'url': f'https://errors.pydantic.dev/{pydantic_version}/v/list_type',
         }
     ]
 
@@ -878,7 +878,7 @@ def test_unsorted_definitions_schema() -> None:
         v.validate_python({'x': 'abc'})
 
 
-def test_validate_assignment() -> None:
+def test_validate_assignment(pydantic_version) -> None:
     @dataclass
     class Model:
         x: List['Model']
@@ -916,6 +916,6 @@ def test_validate_assignment() -> None:
             'msg': 'Input should be a dictionary or an instance of Model',
             'input': 123,
             'ctx': {'class_name': 'Model'},
-            'url': f'https://errors.pydantic.dev/{__version__}/v/dataclass_type',
+            'url': f'https://errors.pydantic.dev/{pydantic_version}/v/dataclass_type',
         }
     ]

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pytest
 from dirty_equals import IsStr
 
-from pydantic_core import SchemaValidator, ValidationError, __version__
+from pydantic_core import SchemaValidator, ValidationError
 
 from ..conftest import Err, PyAndJson, plain_repr
 
@@ -340,7 +340,7 @@ def test_int_repr():
     assert plain_repr(v).startswith('SchemaValidator(title="constrained-int",validator=ConstrainedInt(')
 
 
-def test_too_long():
+def test_too_long(pydantic_version):
     v = SchemaValidator({'type': 'int'})
 
     with pytest.raises(ValidationError) as exc_info:
@@ -359,7 +359,7 @@ def test_too_long():
         "1 validation error for int\n"
         "  Unable to parse input string as an integer, exceeded maximum size "
         "[type=int_parsing_size, input_value='111111111111111111111111...11111111111111111111111', input_type=str]\n"
-        f"    For further information visit https://errors.pydantic.dev/{__version__}/v/int_parsing_size"
+        f"    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/int_parsing_size"
     )
 
 

--- a/tests/validators/test_model_fields.py
+++ b/tests/validators/test_model_fields.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Mapping, Union
 import pytest
 from dirty_equals import FunctionCheck, HasRepr, IsStr
 
-from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -105,7 +105,7 @@ def test_with_default():
     )
 
 
-def test_missing_error():
+def test_missing_error(pydantic_version):
     v = SchemaValidator(
         {
             'type': 'model-fields',
@@ -123,7 +123,7 @@ def test_missing_error():
 1 validation error for model-fields
 field_b
   Field required [type=missing, input_value={{'field_a': b'abc'}}, input_type=dict]
-    For further information visit https://errors.pydantic.dev/{__version__}/v/missing"""
+    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/missing"""
     )
 
 

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Mapping, Union
 import pytest
 from dirty_equals import FunctionCheck
 
-from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -90,7 +90,7 @@ def test_with_default():
     assert v.validate_python({'field_a': b'abc', 'field_b': 1}) == {'field_a': 'abc', 'field_b': 1}
 
 
-def test_missing_error():
+def test_missing_error(pydantic_version):
     v = SchemaValidator(
         {
             'type': 'typed-dict',
@@ -107,7 +107,7 @@ def test_missing_error():
         "1 validation error for typed-dict\n"
         "field_b\n"
         "  Field required [type=missing, input_value={'field_a': b'abc'}, input_type=dict]\n"
-        f"    For further information visit https://errors.pydantic.dev/{__version__}/v/missing"
+        f"    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/missing"
     )
 
 

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -1,7 +1,7 @@
 import pytest
 from dirty_equals import IsFloat, IsInt
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, __version__, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
 
 from ..conftest import plain_repr
 
@@ -232,7 +232,7 @@ def test_union_list_bool_int():
     ]
 
 
-def test_no_choices():
+def test_no_choices(pydantic_version):
     with pytest.raises(SchemaError) as exc_info:
         SchemaValidator({'type': 'union'})
 
@@ -240,7 +240,7 @@ def test_no_choices():
         'Invalid Schema:\n'
         'union.choices\n'
         "  Field required [type=missing, input_value={'type': 'union'}, input_type=dict]\n"
-        f'    For further information visit https://errors.pydantic.dev/{__version__}/v/missing'
+        f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/missing'
     )
     assert exc_info.value.error_count() == 1
     assert exc_info.value.errors() == [


### PR DESCRIPTION
## Change Summary

As `pydantic` and `pydantic-core` versions have decoupled, when rendering errors we should use the pydantic package error messages, if available.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb