### PR TITLE
add decimal validator

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -6,6 +6,7 @@ The schema is generated from `python/pydantic_core/core_schema.py`.
 """
 from __future__ import annotations as _annotations
 
+import decimal
 import importlib.util
 import re
 from collections.abc import Callable
@@ -23,6 +24,7 @@ try:
     UnionType = Union[TypingUnionType, TypesUnionType]
 
 except ImportError:
+    TypesUnionType = None
     UnionType = TypingUnionType
 
 
@@ -46,8 +48,8 @@ schema_ref_validator = {'type': 'definition-ref', 'schema_ref': 'root-schema'}
 def get_schema(obj) -> core_schema.CoreSchema:
     if isinstance(obj, str):
         return {'type': obj}
-    elif obj in (datetime, timedelta, date, time, bool, int, float, str):
-        return {'type': obj.__name__}
+    elif obj in (datetime, timedelta, date, time, bool, int, float, str, decimal.Decimal):
+        return {'type': obj.__name__.lower()}
     elif is_typeddict(obj):
         return type_dict_schema(obj)
     elif obj == Any or obj == type:
@@ -57,7 +59,7 @@ def get_schema(obj) -> core_schema.CoreSchema:
 
     origin = get_origin(obj)
     assert origin is not None, f'origin cannot be None, obj={obj}, you probably need to fix generate_self_schema.py'
-    if origin is Union:
+    if origin is Union or origin is TypesUnionType:
         return union_schema(obj)
     elif obj is Callable or origin is Callable:
         return {'type': 'callable'}
@@ -79,6 +81,7 @@ def get_schema(obj) -> core_schema.CoreSchema:
         # can't really use 'is-instance' since this is used for the class_ parameter of 'is-instance' validators
         return {'type': 'any'}
     else:
+        print(origin)
         # debug(obj)
         raise TypeError(f'Unknown type: {obj!r}')
 

--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -24,7 +24,7 @@ try:
     UnionType = Union[TypingUnionType, TypesUnionType]
 
 except ImportError:
-    TypesUnionType = None
+    TypesUnionType = TypingUnionType
     UnionType = TypingUnionType
 
 
@@ -81,7 +81,6 @@ def get_schema(obj) -> core_schema.CoreSchema:
         # can't really use 'is-instance' since this is used for the class_ parameter of 'is-instance' validators
         return {'type': 'any'}
     else:
-        print(origin)
         # debug(obj)
         raise TypeError(f'Unknown type: {obj!r}')
 

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -662,15 +662,14 @@ def float_schema(
 
 class DecimalSchema(TypedDict, total=False):
     type: Required[Literal['decimal']]
-    gt: Union[int, Decimal]
-    ge: Union[int, Decimal]
-    lt: Union[int, Decimal]
-    le: Union[int, Decimal]
+    allow_inf_nan: bool  # whether 'NaN', '+inf', '-inf' should be forbidden. default: False
+    multiple_of: Decimal
+    le: Decimal
+    ge: Decimal
+    lt: Decimal
+    gt: Decimal
     max_digits: int
     decimal_places: int
-    multiple_of: Union[int, Decimal]
-    allow_inf_nan: bool  # whether 'NaN', '+inf', '-inf' should be forbidden. default: False
-    check_digits: bool  # FIXME document. default: False
     strict: bool
     ref: str
     metadata: Any
@@ -679,15 +678,14 @@ class DecimalSchema(TypedDict, total=False):
 
 def decimal_schema(
     *,
-    gt: int | Decimal | None = None,
-    ge: int | Decimal | None = None,
-    lt: int | Decimal | None = None,
-    le: int | Decimal | None = None,
+    allow_inf_nan: bool = None,
+    multiple_of: Decimal | None = None,
+    le: Decimal | None = None,
+    ge: Decimal | None = None,
+    lt: Decimal | None = None,
+    gt: Decimal | None = None,
     max_digits: int | None = None,
     decimal_places: int | None = None,
-    multiple_of: int | Decimal | None = None,
-    allow_inf_nan: bool = None,
-    check_digits: bool = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -706,7 +704,18 @@ def decimal_schema(
     ```
 
     Args:
-        FIXME document
+        allow_inf_nan: Whether to allow inf and nan values
+        multiple_of: The value must be a multiple of this number
+        le: The value must be less than or equal to this number
+        ge: The value must be greater than or equal to this number
+        lt: The value must be strictly less than this number
+        gt: The value must be strictly greater than this number
+        max_digits: The maximum number of decimal digits allowed
+        decimal_places: The maximum number of decimal places allowed
+        strict: Whether the value should be a float or a value that can be converted to a float
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
+        serialization: Custom serialization schema
     """
     return _dict_not_none(
         type='decimal',
@@ -718,7 +727,6 @@ def decimal_schema(
         decimal_places=decimal_places,
         multiple_of=multiple_of,
         allow_inf_nan=allow_inf_nan,
-        check_digits=check_digits,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -8,6 +8,7 @@ from __future__ import annotations as _annotations
 import sys
 from collections.abc import Mapping
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, List, Set, Type, Union
 
 if sys.version_info < (3, 11):
@@ -652,6 +653,72 @@ def float_schema(
         ge=ge,
         lt=lt,
         gt=gt,
+        strict=strict,
+        ref=ref,
+        metadata=metadata,
+        serialization=serialization,
+    )
+
+
+class DecimalSchema(TypedDict, total=False):
+    type: Required[Literal['decimal']]
+    gt: Union[int, Decimal]
+    ge: Union[int, Decimal]
+    lt: Union[int, Decimal]
+    le: Union[int, Decimal]
+    max_digits: int
+    decimal_places: int
+    multiple_of: Union[int, Decimal]
+    allow_inf_nan: bool  # whether 'NaN', '+inf', '-inf' should be forbidden. default: False
+    check_digits: bool  # FIXME document. default: False
+    strict: bool
+    ref: str
+    metadata: Any
+    serialization: SerSchema
+
+
+def decimal_schema(
+    *,
+    gt: int | Decimal | None = None,
+    ge: int | Decimal | None = None,
+    lt: int | Decimal | None = None,
+    le: int | Decimal | None = None,
+    max_digits: int | None = None,
+    decimal_places: int | None = None,
+    multiple_of: int | Decimal | None = None,
+    allow_inf_nan: bool = None,
+    check_digits: bool = None,
+    strict: bool | None = None,
+    ref: str | None = None,
+    metadata: Any = None,
+    serialization: SerSchema | None = None,
+) -> DecimalSchema:
+    """
+    Returns a schema that matches a decimal value, e.g.:
+
+    ```py
+    from decimal import Decimal
+    from pydantic_core import SchemaValidator, core_schema
+
+    schema = core_schema.decimal_schema(le=0.8, ge=0.2)
+    v = SchemaValidator(schema)
+    assert v.validate_python('0.5') == Decimal('0.5')
+    ```
+
+    Args:
+        FIXME document
+    """
+    return _dict_not_none(
+        type='decimal',
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        check_digits=check_digits,
         strict=strict,
         ref=ref,
         metadata=metadata,
@@ -3711,6 +3778,7 @@ if not MYPY:
         BoolSchema,
         IntSchema,
         FloatSchema,
+        DecimalSchema,
         StringSchema,
         BytesSchema,
         DateSchema,
@@ -3765,6 +3833,7 @@ CoreSchemaType = Literal[
     'bool',
     'int',
     'float',
+    'decimal',
     'str',
     'bytes',
     'date',
@@ -3905,6 +3974,11 @@ ErrorType = Literal[
     'uuid_type',
     'uuid_parsing',
     'uuid_version',
+    'decimal_type',
+    'decimal_parsing',
+    'decimal_max_digits',
+    'decimal_max_places',
+    'decimal_whole_digits',
 ]
 
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -8,7 +8,7 @@ mod value_exception;
 
 pub use self::line_error::{InputValue, ValError, ValLineError, ValResult};
 pub use self::location::LocItem;
-pub use self::types::{list_all_errors, ErrorMode, ErrorType, ErrorTypeDefaults};
+pub use self::types::{list_all_errors, ErrorMode, ErrorType, ErrorTypeDefaults, Number};
 pub use self::validation_exception::ValidationError;
 pub use self::value_exception::{PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault};
 

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -217,8 +217,7 @@ error_types! {
     // None errors
     NoneRequired {},
     // ---------------------
-    // generic comparison errors - used for all inequality comparisons except int and float which have their
-    // own type, bounds arguments are Strings so they can be created from any type
+    // generic comparison errors
     GreaterThan {
         gt: {ctx_type: Number, ctx_fn: field_from_context},
     },
@@ -427,6 +426,18 @@ error_types! {
     UuidVersion {
         expected_version: {ctx_type: usize, ctx_fn: field_from_context},
     },
+    // Decimal errors
+    DecimalType {},
+    DecimalParsing {},
+    DecimalMaxDigits {
+        max_digits: {ctx_type: u64, ctx_fn: field_from_context},
+    },
+    DecimalMaxPlaces {
+        decimal_places: {ctx_type: u64, ctx_fn: field_from_context},
+    },
+    DecimalWholeDigits {
+        whole_digits: {ctx_type: u64, ctx_fn: field_from_context},
+    },
 }
 
 macro_rules! render {
@@ -560,9 +571,14 @@ impl ErrorType {
             Self::UrlSyntaxViolation {..} => "Input violated strict URL syntax rules, {error}",
             Self::UrlTooLong {..} => "URL should have at most {max_length} characters",
             Self::UrlScheme {..} => "URL scheme should be {expected_schemes}",
-            Self::UuidType{..} => "UUID input should be a string, bytes or UUID object",
+            Self::UuidType {..} => "UUID input should be a string, bytes or UUID object",
             Self::UuidParsing {..} => "Input should be a valid UUID, {error}",
-            Self::UuidVersion {..} => "UUID version {expected_version} expected"
+            Self::UuidVersion {..} => "UUID version {expected_version} expected",
+            Self::DecimalType {..} => "Decimal input should be an integer, float, string or Decimal object",
+            Self::DecimalParsing {..} => "Input should be a valid decimal",
+            Self::DecimalMaxDigits {..} => "Decimal input should have no more than {max_digits} digits in total",
+            Self::DecimalMaxPlaces {..} => "Decimal input should have no more than {decimal_places} decimal places",
+            Self::DecimalWholeDigits {..} => "Decimal input should have no more than {whole_digits} digits before the decimal point",
         }
     }
 
@@ -692,6 +708,9 @@ impl ErrorType {
             Self::UrlScheme { expected_schemes, .. } => render!(tmpl, expected_schemes),
             Self::UuidParsing { error, .. } => render!(tmpl, error),
             Self::UuidVersion { expected_version, .. } => to_string_render!(tmpl, expected_version),
+            Self::DecimalMaxDigits { max_digits, .. } => to_string_render!(tmpl, max_digits),
+            Self::DecimalMaxPlaces { decimal_places, .. } => to_string_render!(tmpl, decimal_places),
+            Self::DecimalWholeDigits { whole_digits, .. } => to_string_render!(tmpl, whole_digits),
             _ => Ok(tmpl.to_string()),
         }
     }

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -152,6 +152,19 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
         self.strict_float()
     }
 
+    fn validate_decimal(&'a self, strict: bool, decimal_type: &'a PyType) -> ValResult<&'a PyAny> {
+        if strict {
+            self.strict_decimal(decimal_type)
+        } else {
+            self.lax_decimal(decimal_type)
+        }
+    }
+    fn strict_decimal(&'a self, decimal_type: &'a PyType) -> ValResult<&'a PyAny>;
+    #[cfg_attr(has_no_coverage, no_coverage)]
+    fn lax_decimal(&'a self, decimal_type: &'a PyType) -> ValResult<&'a PyAny> {
+        self.strict_decimal(decimal_type)
+    }
+
     fn validate_dict(&'a self, strict: bool) -> ValResult<GenericMapping<'a>> {
         if strict {
             self.strict_dict()

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -114,6 +114,7 @@ combined_serializer! {
         Int: super::type_serializers::simple::IntSerializer;
         Bool: super::type_serializers::simple::BoolSerializer;
         Float: super::type_serializers::simple::FloatSerializer;
+        Decimal: super::type_serializers::decimal::DecimalSerializer;
         Str: super::type_serializers::string::StrSerializer;
         Bytes: super::type_serializers::bytes::BytesSerializer;
         Datetime: super::type_serializers::datetime_etc::DatetimeSerializer;
@@ -229,6 +230,7 @@ impl PyGcTraverse for CombinedSerializer {
             CombinedSerializer::Int(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Bool(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Float(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Decimal(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Str(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Bytes(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Datetime(inner) => inner.py_gc_traverse(visit),

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -1,0 +1,81 @@
+use std::borrow::Cow;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::definitions::DefinitionsBuilder;
+use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, infer_to_python_known};
+use crate::serializers::ob_type::{IsType, ObType};
+
+use super::{
+    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, TypeSerializer,
+};
+
+#[derive(Debug, Clone)]
+pub struct DecimalSerializer {}
+
+impl BuildSerializer for DecimalSerializer {
+    const EXPECTED_TYPE: &'static str = "decimal";
+
+    fn build(
+        _schema: &PyDict,
+        _config: Option<&PyDict>,
+        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
+    ) -> PyResult<CombinedSerializer> {
+        Ok(Self {}.into())
+    }
+}
+
+impl_py_gc_traverse!(DecimalSerializer {});
+
+impl TypeSerializer for DecimalSerializer {
+    fn to_python(
+        &self,
+        value: &PyAny,
+        include: Option<&PyAny>,
+        exclude: Option<&PyAny>,
+        extra: &Extra,
+    ) -> PyResult<PyObject> {
+        let _py = value.py();
+        match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => infer_to_python_known(&ObType::Decimal, value, include, exclude, extra),
+            IsType::False => {
+                extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
+                infer_to_python(value, include, exclude, extra)
+            }
+        }
+    }
+
+    fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
+        match extra.ob_type_lookup.is_type(key, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => infer_json_key_known(&ObType::Decimal, key, extra),
+            IsType::False => {
+                extra.warnings.on_fallback_py(self.get_name(), key, extra)?;
+                infer_json_key(key, extra)
+            }
+        }
+    }
+
+    fn serde_serialize<S: serde::ser::Serializer>(
+        &self,
+        value: &PyAny,
+        serializer: S,
+        include: Option<&PyAny>,
+        exclude: Option<&PyAny>,
+        extra: &Extra,
+    ) -> Result<S::Ok, S::Error> {
+        match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => {
+                infer_serialize_known(&ObType::Decimal, value, serializer, include, exclude, extra)
+            }
+            IsType::False => {
+                extra.warnings.on_fallback_ser::<S>(self.get_name(), value, extra)?;
+                infer_serialize(value, serializer, include, exclude, extra)
+            }
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        Self::EXPECTED_TYPE
+    }
+}

--- a/src/serializers/type_serializers/mod.rs
+++ b/src/serializers/type_serializers/mod.rs
@@ -2,6 +2,7 @@ pub mod any;
 pub mod bytes;
 pub mod dataclass;
 pub mod datetime_etc;
+pub mod decimal;
 pub mod definitions;
 pub mod dict;
 pub mod format;

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -1,0 +1,278 @@
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::types::{IntoPyDict, PyDict, PyTuple, PyType};
+use pyo3::{intern, AsPyPointer};
+use pyo3::{prelude::*, PyTypeInfo};
+
+use crate::build_tools::{is_strict, schema_or_config_same};
+use crate::errors::ValError;
+use crate::errors::ValResult;
+use crate::errors::{ErrorType, InputValue};
+use crate::errors::{ErrorTypeDefaults, Number};
+use crate::input::Input;
+use crate::recursion_guard::RecursionGuard;
+use crate::tools::SchemaDict;
+
+use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+
+#[derive(Debug, Clone)]
+pub struct DecimalValidator {
+    strict: bool,
+    allow_inf_nan: bool,
+    check_digits: bool,
+    multiple_of: Option<Py<PyAny>>,
+    le: Option<Py<PyAny>>,
+    lt: Option<Py<PyAny>>,
+    ge: Option<Py<PyAny>>,
+    gt: Option<Py<PyAny>>,
+    max_digits: Option<u64>,
+    decimal_places: Option<u64>,
+    decimal_type: Py<PyType>,
+}
+
+impl BuildValidator for DecimalValidator {
+    const EXPECTED_TYPE: &'static str = "decimal";
+    fn build(
+        schema: &PyDict,
+        config: Option<&PyDict>,
+        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
+    ) -> PyResult<CombinedValidator> {
+        let py = schema.py();
+        let allow_inf_nan = schema_or_config_same(schema, config, intern!(py, "allow_inf_nan"))?.unwrap_or(false);
+        let decimal_places = schema.get_as(intern!(py, "decimal_places"))?;
+        let max_digits = schema.get_as(intern!(py, "max_digits"))?;
+        if allow_inf_nan && (decimal_places.is_some() || max_digits.is_some()) {
+            return Err(PyValueError::new_err(
+                "allow_inf_nan=True cannot be used with max_digits or decimal_places",
+            ));
+        }
+        Ok(Self {
+            strict: is_strict(schema, config)?,
+            allow_inf_nan,
+            check_digits: decimal_places.is_some() || max_digits.is_some(),
+            decimal_places,
+            multiple_of: schema.get_as(intern!(py, "multiple_of"))?,
+            le: schema.get_as(intern!(py, "le"))?,
+            lt: schema.get_as(intern!(py, "lt"))?,
+            ge: schema.get_as(intern!(py, "ge"))?,
+            gt: schema.get_as(intern!(py, "gt"))?,
+            max_digits,
+            decimal_type: py
+                .import(intern!(py, "decimal"))?
+                .getattr(intern!(py, "Decimal"))?
+                .extract()?,
+        }
+        .into())
+    }
+}
+
+impl_py_gc_traverse!(DecimalValidator {
+    multiple_of,
+    le,
+    lt,
+    ge,
+    gt,
+    decimal_type
+});
+
+impl Validator for DecimalValidator {
+    fn validate<'s, 'data>(
+        &'s self,
+        py: Python<'data>,
+        input: &'data impl Input<'data>,
+        extra: &Extra,
+        _definitions: &'data Definitions<CombinedValidator>,
+        _recursion_guard: &'s mut RecursionGuard,
+    ) -> ValResult<'data, PyObject> {
+        let decimal = input.validate_decimal(
+            extra.strict.unwrap_or(self.strict),
+            // Safety: self and py both outlive this call
+            unsafe { py.from_borrowed_ptr(self.decimal_type.as_ptr()) },
+        )?;
+
+        if !self.allow_inf_nan || self.check_digits {
+            if !decimal.call_method0(intern!(py, "is_finite"))?.extract()? {
+                return Err(ValError::new(ErrorTypeDefaults::FiniteNumber, input));
+            }
+
+            if self.check_digits {
+                let normalized_value = decimal.call_method0(intern!(py, "normalize")).unwrap_or(decimal);
+                let (_, digit_tuple, exponent): (&PyAny, &PyTuple, &PyAny) =
+                    normalized_value.call_method0(intern!(py, "as_tuple"))?.extract()?;
+
+                // finite values have numeric exponent, we checked is_finite above
+                let exponent: i64 = exponent.extract()?;
+                let mut digits: u64 = u64::try_from(digit_tuple.len()).map_err(|e| ValError::InternalErr(e.into()))?;
+                let decimals;
+                if exponent >= 0 {
+                    // A positive exponent adds that many trailing zeros.
+                    digits += exponent as u64;
+                    decimals = 0;
+                } else {
+                    // If the absolute value of the negative exponent is larger than the
+                    // number of digits, then it's the same as the number of digits,
+                    // because it'll consume all the digits in digit_tuple and then
+                    // add abs(exponent) - len(digit_tuple) leading zeros after the
+                    // decimal point.
+                    decimals = exponent.unsigned_abs();
+                    digits = digits.max(decimals);
+                }
+
+                if let Some(max_digits) = self.max_digits {
+                    if digits > max_digits {
+                        return Err(ValError::new(
+                            ErrorType::DecimalMaxDigits {
+                                max_digits,
+                                context: None,
+                            },
+                            input,
+                        ));
+                    }
+                }
+
+                if let Some(decimal_places) = self.decimal_places {
+                    if decimals > decimal_places {
+                        return Err(ValError::new(
+                            ErrorType::DecimalMaxPlaces {
+                                decimal_places,
+                                context: None,
+                            },
+                            input,
+                        ));
+                    }
+
+                    if let Some(max_digits) = self.max_digits {
+                        let whole_digits = digits.saturating_sub(decimals);
+                        let max_whole_digits = max_digits.saturating_sub(decimal_places);
+                        if whole_digits > max_whole_digits {
+                            return Err(ValError::new(
+                                ErrorType::DecimalWholeDigits {
+                                    whole_digits: max_whole_digits,
+                                    context: None,
+                                },
+                                input,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(multiple_of) = &self.multiple_of {
+            // fraction = (decimal / multiple_of) % 1
+            let fraction: &PyAny = unsafe {
+                let division = PyObject::from_owned_ptr_or_err(
+                    py,
+                    pyo3::ffi::PyNumber_TrueDivide(decimal.as_ptr(), multiple_of.as_ptr()),
+                )?;
+                let one = 1.to_object(py);
+                py.from_owned_ptr_or_err(pyo3::ffi::PyNumber_Remainder(division.as_ptr(), one.as_ptr()))?
+            };
+            let zero = 0.to_object(py);
+            if !fraction.eq(&zero)? {
+                return Err(ValError::new(
+                    ErrorType::MultipleOf {
+                        multiple_of: multiple_of.to_string().into(),
+                        context: Some([("multiple_of", multiple_of)].into_py_dict(py).into()),
+                    },
+                    input,
+                ));
+            }
+        }
+
+        if let Some(le) = &self.le {
+            if !decimal.le(le)? {
+                return Err(ValError::new(
+                    ErrorType::LessThanEqual {
+                        le: Number::String(le.to_string()),
+                        context: Some([("le", le)].into_py_dict(py).into()),
+                    },
+                    input,
+                ));
+            }
+        }
+        if let Some(lt) = &self.lt {
+            if !decimal.lt(lt)? {
+                return Err(ValError::new(
+                    ErrorType::LessThan {
+                        lt: Number::String(lt.to_string()),
+                        context: Some([("lt", lt)].into_py_dict(py).into()),
+                    },
+                    input,
+                ));
+            }
+        }
+        if let Some(ge) = &self.ge {
+            if !decimal.ge(ge)? {
+                return Err(ValError::new(
+                    ErrorType::GreaterThanEqual {
+                        ge: Number::String(ge.to_string()),
+                        context: Some([("ge", ge)].into_py_dict(py).into()),
+                    },
+                    input,
+                ));
+            }
+        }
+        if let Some(gt) = &self.gt {
+            if !decimal.gt(gt)? {
+                return Err(ValError::new(
+                    ErrorType::GreaterThan {
+                        gt: Number::String(gt.to_string()),
+                        context: Some([("gt", gt)].into_py_dict(py).into()),
+                    },
+                    input,
+                ));
+            }
+        }
+
+        Ok(decimal.into())
+    }
+
+    fn different_strict_behavior(
+        &self,
+        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
+        _ultra_strict: bool,
+    ) -> bool {
+        true
+    }
+
+    fn get_name(&self) -> &str {
+        Self::EXPECTED_TYPE
+    }
+
+    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
+}
+
+pub(crate) fn create_decimal<'a>(
+    arg: &'a PyAny,
+    input: &'a impl Input<'a>,
+    decimal_type: &'a PyType,
+) -> ValResult<'a, &'a PyAny> {
+    decimal_type.call1((arg,)).map_err(|e| {
+        let decimal_exception = match arg
+            .py()
+            .import("decimal")
+            .and_then(|decimal_module| decimal_module.getattr("DecimalException"))
+        {
+            Ok(decimal_exception) => decimal_exception,
+            Err(e) => return ValError::InternalErr(e),
+        };
+        handle_decimal_new_error(arg.py(), input.as_error_value(), e, decimal_exception)
+    })
+}
+
+fn handle_decimal_new_error<'a>(
+    py: Python<'a>,
+    input: InputValue<'a>,
+    error: PyErr,
+    decimal_exception: &'a PyAny,
+) -> ValError<'a> {
+    if error.matches(py, decimal_exception) {
+        ValError::new_custom_input(ErrorTypeDefaults::DecimalParsing, input)
+    } else if error.matches(py, PyTypeError::type_object(py)) {
+        ValError::new_custom_input(ErrorTypeDefaults::DecimalType, input)
+    } else {
+        ValError::InternalErr(error)
+    }
+}

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -27,6 +27,7 @@ mod custom_error;
 mod dataclass;
 mod date;
 mod datetime;
+pub(crate) mod decimal;
 mod definitions;
 mod dict;
 mod float;
@@ -451,6 +452,8 @@ pub fn build_validator<'a>(
         bool::BoolValidator,
         // floats
         float::FloatBuilder,
+        // decimals
+        decimal::DecimalValidator,
         // tuples
         tuple::TuplePositionalValidator,
         tuple::TupleVariableValidator,
@@ -597,6 +600,8 @@ pub enum CombinedValidator {
     // floats
     Float(float::FloatValidator),
     ConstrainedFloat(float::ConstrainedFloatValidator),
+    // decimals
+    Decimal(decimal::DecimalValidator),
     // lists
     List(list::ListValidator),
     // sets - unique lists

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+
+
 def schema(*, strict: bool = False) -> dict:
     class MyModel:
         # __slots__ is not required, but it avoids __pydantic_fields_set__ falling into __dict__
@@ -31,6 +34,7 @@ def schema(*, strict: bool = False) -> dict:
                     'type': 'model-field',
                     'schema': {'type': 'float', 'ge': 1.0, 'le': 10.0, 'multiple_of': 0.5},
                 },
+                'field_decimal': {'type': 'model-field', 'schema': {'type': 'decimal'}},
                 'field_bool': {'type': 'model-field', 'schema': {'type': 'bool'}},
                 'field_bytes': {'type': 'model-field', 'schema': {'type': 'bytes'}},
                 'field_bytes_con': {
@@ -218,6 +222,7 @@ def input_data_lax():
         'field_int_con': 8,
         'field_float': 1.0,
         'field_float_con': 10.0,
+        'field_decimal': 42.0,
         'field_bool': True,
         'field_bytes': b'foobar',
         'field_bytes_con': b'foobar',
@@ -276,6 +281,7 @@ def input_data_strict():
         field_datetime=datetime(2020, 1, 1, 12, 13, 14),
         field_datetime_con=datetime(2020, 1, 1),
         field_uuid=UUID('12345678-1234-5678-1234-567812345678'),
+        field_decimal=Decimal('42.0'),
     )
     return input_data
 
@@ -288,6 +294,7 @@ def input_data_wrong():
         'field_int_con': 11,
         'field_float': False,
         'field_float_con': 10.1,
+        'field_decimal': 'wrong',
         'field_bool': 4,
         'field_bytes': 42,
         'field_bytes_con': b'foo',

--- a/tests/benchmarks/test_complete_benchmark.py
+++ b/tests/benchmarks/test_complete_benchmark.py
@@ -3,6 +3,7 @@ General benchmarks that attempt to cover all field types, through by no means al
 """
 import json
 from datetime import date, datetime, time
+from decimal import Decimal
 from uuid import UUID
 
 import pytest
@@ -18,7 +19,7 @@ def test_complete_valid():
     lax_validator = SchemaValidator(lax_schema)
     output = lax_validator.validate_python(input_data_lax())
     assert isinstance(output, cls)
-    assert len(output.__pydantic_fields_set__) == 40
+    assert len(output.__pydantic_fields_set__) == 41
     output_dict = output.__dict__
     assert output_dict == {
         'field_str': 'fo',
@@ -27,6 +28,7 @@ def test_complete_valid():
         'field_int_con': 8,
         'field_float': 1.0,
         'field_float_con': 10.0,
+        'field_decimal': Decimal('42.0'),
         'field_bool': True,
         'field_bytes': b'foobar',
         'field_bytes_con': b'foobar',
@@ -81,7 +83,7 @@ def test_complete_invalid():
     lax_validator = SchemaValidator(lax_schema)
     with pytest.raises(ValidationError) as exc_info:
         lax_validator.validate_python(input_data_wrong())
-    assert len(exc_info.value.errors(include_url=False)) == 738
+    assert len(exc_info.value.errors(include_url=False)) == 739
 
 
 @pytest.mark.benchmark(group='complete')

--- a/tests/serializers/test_decimal.py
+++ b/tests/serializers/test_decimal.py
@@ -12,6 +12,14 @@ def test_decimal():
     assert v.to_python(Decimal('123.456'), mode='json') == '123.456'
     assert v.to_json(Decimal('123.456')) == b'"123.456"'
 
+    assert v.to_python(Decimal('123456789123456789123456789.123456789123456789123456789')) == Decimal(
+        '123456789123456789123456789.123456789123456789123456789'
+    )
+    assert (
+        v.to_json(Decimal('123456789123456789123456789.123456789123456789123456789'))
+        == b'"123456789123456789123456789.123456789123456789123456789"'
+    )
+
     with pytest.warns(UserWarning, match='Expected `decimal` but got `int` - serialized value may not be as expected'):
         assert v.to_python(123, mode='json') == 123
 

--- a/tests/serializers/test_decimal.py
+++ b/tests/serializers/test_decimal.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+
+import pytest
+
+from pydantic_core import SchemaSerializer, core_schema
+
+
+def test_decimal():
+    v = SchemaSerializer(core_schema.decimal_schema())
+    assert v.to_python(Decimal('123.456')) == Decimal('123.456')
+
+    assert v.to_python(Decimal('123.456'), mode='json') == '123.456'
+    assert v.to_json(Decimal('123.456')) == b'"123.456"'
+
+    with pytest.warns(UserWarning, match='Expected `decimal` but got `int` - serialized value may not be as expected'):
+        assert v.to_python(123, mode='json') == 123
+
+    with pytest.warns(UserWarning, match='Expected `decimal` but got `int` - serialized value may not be as expected'):
+        assert v.to_json(123) == b'123'
+
+
+def test_decimal_key():
+    v = SchemaSerializer(core_schema.dict_schema(core_schema.decimal_schema(), core_schema.decimal_schema()))
+    assert v.to_python({Decimal('123.456'): Decimal('123.456')}) == {Decimal('123.456'): Decimal('123.456')}
+    assert v.to_python({Decimal('123.456'): Decimal('123.456')}, mode='json') == {'123.456': '123.456'}
+    assert v.to_json({Decimal('123.456'): Decimal('123.456')}) == b'{"123.456":"123.456"}'
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        (Decimal('123.456'), '123.456'),
+        (Decimal('Infinity'), 'Infinity'),
+        (Decimal('-Infinity'), '-Infinity'),
+        (Decimal('NaN'), 'NaN'),
+    ],
+)
+def test_decimal_json(value, expected):
+    v = SchemaSerializer(core_schema.decimal_schema())
+    assert v.to_python(value, mode='json') == expected
+    assert v.to_json(value).decode() == f'"{expected}"'
+
+
+def test_any_decimal_key():
+    v = SchemaSerializer(core_schema.dict_schema())
+    input_value = {Decimal('123.456'): 1}
+
+    assert v.to_python(input_value, mode='json') == {'123.456': 1}
+    assert v.to_json(input_value) == b'{"123.456":1}'

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -373,6 +373,15 @@ all_errors = [
     ('uuid_type', 'UUID input should be a string, bytes or UUID object', None),
     ('uuid_parsing', 'Input should be a valid UUID, Foobar', {'error': 'Foobar'}),
     ('uuid_version', 'UUID version 42 expected', {'expected_version': 42}),
+    ('decimal_type', 'Decimal input should be an integer, float, string or Decimal object', None),
+    ('decimal_parsing', 'Input should be a valid decimal', None),
+    ('decimal_max_digits', 'Decimal input should have no more than 42 digits in total', {'max_digits': 42}),
+    ('decimal_max_places', 'Decimal input should have no more than 42 decimal places', {'decimal_places': 42}),
+    (
+        'decimal_whole_digits',
+        'Decimal input should have no more than 42 digits before the decimal point',
+        {'whole_digits': 42},
+    ),
 ]
 
 

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -279,6 +279,8 @@ all_schema_functions = [
         {'type': 'dataclass', 'schema': {'type': 'int'}, 'fields': ['foobar'], 'cls': MyDataclass, 'slots': True},
     ),
     (core_schema.uuid_schema, args(), {'type': 'uuid'}),
+    (core_schema.decimal_schema, args(), {'type': 'decimal'}),
+    (core_schema.decimal_schema, args(multiple_of=5, gt=1.2), {'type': 'decimal', 'multiple_of': 5, 'gt': 1.2}),
 ]
 
 

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -1,0 +1,416 @@
+import json
+import math
+import re
+from decimal import Decimal
+from typing import Any, Dict
+
+import pytest
+from dirty_equals import FunctionCheck, IsStr
+
+from pydantic_core import SchemaValidator, ValidationError
+
+from ..conftest import Err, PyAndJson, plain_repr
+
+
+@pytest.mark.parametrize(
+    'input_value,expected',
+    [
+        (0, Decimal(0)),
+        (1, Decimal(1)),
+        (42, Decimal(42)),
+        ('42', Decimal(42)),
+        ('42.123', Decimal('42.123')),
+        (42.0, Decimal(42)),
+        (42.5, Decimal('42.5')),
+        (1e10, Decimal('1E10')),
+        (
+            True,
+            Err(
+                'Decimal input should be an integer, float, string or Decimal object [type=decimal_type, input_value=True, input_type=bool]'
+            ),
+        ),
+        (
+            False,
+            Err(
+                'Decimal input should be an integer, float, string or Decimal object [type=decimal_type, input_value=False, input_type=bool]'
+            ),
+        ),
+        ('wrong', Err('Input should be a valid decimal [type=decimal_parsing')),
+        (
+            [1, 2],
+            Err(
+                'Decimal input should be an integer, float, string or Decimal object [type=decimal_type, input_value=[1, 2], input_type=list]'
+            ),
+        ),
+    ],
+)
+def test_decimal(py_and_json: PyAndJson, input_value, expected):
+    v = py_and_json({'type': 'decimal'})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_test(input_value)
+    else:
+        output = v.validate_test(input_value)
+        assert output == expected
+        assert isinstance(output, Decimal)
+
+
+@pytest.mark.parametrize(
+    'input_value,expected',
+    [
+        (Decimal(0), Decimal(0)),
+        (Decimal(1), Decimal(1)),
+        (Decimal(42), Decimal(42)),
+        (Decimal('42.0'), Decimal('42.0')),
+        (Decimal('42.5'), Decimal('42.5')),
+        (42.0, Err('Input should be an instance of Decimal [type=is_instance_of, input_value=42.0, input_type=float]')),
+        ('42', Err("Input should be an instance of Decimal [type=is_instance_of, input_value='42', input_type=str]")),
+        (42, Err('Input should be an instance of Decimal [type=is_instance_of, input_value=42, input_type=int]')),
+        (True, Err('Input should be an instance of Decimal [type=is_instance_of, input_value=True, input_type=bool]')),
+    ],
+    ids=repr,
+)
+def test_decimal_strict_py(input_value, expected):
+    v = SchemaValidator({'type': 'decimal', 'strict': True})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_python(input_value)
+    else:
+        output = v.validate_python(input_value)
+        assert output == expected
+        assert isinstance(output, Decimal)
+
+
+@pytest.mark.parametrize(
+    'input_value,expected',
+    [
+        (0, Decimal(0)),
+        (1, Decimal(1)),
+        (42, Decimal(42)),
+        ('42.0', Decimal('42.0')),
+        ('42.5', Decimal('42.5')),
+        (42.0, Decimal('42.0')),
+        ('42', Decimal('42')),
+        (
+            True,
+            Err(
+                'Decimal input should be an integer, float, string or Decimal object [type=decimal_type, input_value=True, input_type=bool]'
+            ),
+        ),
+    ],
+    ids=repr,
+)
+def test_decimal_strict_json(input_value, expected):
+    v = SchemaValidator({'type': 'decimal', 'strict': True})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_json(json.dumps(input_value))
+    else:
+        output = v.validate_json(json.dumps(input_value))
+        assert output == expected
+        assert isinstance(output, Decimal)
+
+
+@pytest.mark.parametrize(
+    'kwargs,input_value,expected',
+    [
+        ({}, 0, Decimal(0)),
+        ({}, '123.456', Decimal('123.456')),
+        ({'ge': 0}, 0, Decimal(0)),
+        (
+            {'ge': 0},
+            -0.1,
+            Err(
+                'Input should be greater than or equal to 0 [type=greater_than_equal, input_value=-0.1, input_type=float]'
+            ),
+        ),
+        ({'gt': 0}, 0.1, Decimal('0.1')),
+        ({'gt': 0}, 0, Err('Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]')),
+        ({'le': 0}, 0, Decimal(0)),
+        ({'le': 0}, -1, Decimal(-1)),
+        ({'le': 0}, 0.1, Err('Input should be less than or equal to 0')),
+        ({'lt': 0}, 0, Err('Input should be less than 0')),
+        ({'lt': 0.123456}, 1, Err('Input should be less than 0.123456')),
+    ],
+)
+def test_decimal_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_value, expected):
+    v = py_and_json({'type': 'decimal', **kwargs})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_test(input_value)
+    else:
+        output = v.validate_test(input_value)
+        assert output == expected
+        assert isinstance(output, Decimal)
+
+
+@pytest.mark.parametrize(
+    'multiple_of,input_value,error',
+    [
+        (0.5, 0.5, None),
+        (0.5, 1, None),
+        (0.5, 0.6, Err('Input should be a multiple of 0.5')),
+        (0.5, 0.51, Err('Input should be a multiple of 0.5')),
+        (0.5, 0.501, Err('Input should be a multiple of 0.5')),
+        (0.5, 1_000_000.5, None),
+        (0.5, 1_000_000.49, Err('Input should be a multiple of 0.5')),
+        (0.1, 0, None),
+        (0.1, 0.0, None),
+        (0.1, 0.2, None),
+        (0.1, 0.3, None),
+        (0.1, 0.4, None),
+        (0.1, 0.5, None),
+        (0.1, 0.5001, Err('Input should be a multiple of 0.1')),
+        (0.1, 1, None),
+        (0.1, 1.0, None),
+        (0.1, int(5e10), None),
+    ],
+    ids=repr,
+)
+def test_decimal_multiple_of(py_and_json: PyAndJson, multiple_of, input_value, error):
+    v = py_and_json({'type': 'decimal', 'multiple_of': multiple_of})
+    if error:
+        with pytest.raises(ValidationError, match=re.escape(error.message)):
+            v.validate_test(input_value)
+    else:
+        output = v.validate_test(input_value)
+        assert output == Decimal(str(input_value))
+        assert isinstance(output, Decimal)
+
+
+def test_union_decimal_py():
+    v = SchemaValidator(
+        {'type': 'union', 'choices': [{'type': 'decimal', 'strict': True}, {'type': 'decimal', 'multiple_of': 7}]}
+    )
+    assert v.validate_python('14') == 14
+    assert v.validate_python(Decimal(5)) == 5
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python('5')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'is_instance_of',
+            'loc': ('decimal',),
+            'msg': 'Input should be an instance of Decimal',
+            'input': '5',
+            'ctx': {'class': 'Decimal'},
+        },
+        {
+            'type': 'multiple_of',
+            'loc': ('decimal',),
+            'msg': 'Input should be a multiple of 7',
+            'input': '5',
+            'ctx': {'multiple_of': 7},
+        },
+    ]
+
+
+def test_union_decimal_json():
+    v = SchemaValidator(
+        {'type': 'union', 'choices': [{'type': 'decimal', 'strict': True}, {'type': 'decimal', 'multiple_of': 7}]}
+    )
+    assert v.validate_json(json.dumps('14')) == 14
+    assert v.validate_json(json.dumps('5')) == 5
+
+
+def test_union_decimal_simple(py_and_json: PyAndJson):
+    v = py_and_json({'type': 'union', 'choices': [{'type': 'decimal'}, {'type': 'list'}]})
+    assert v.validate_test('5') == 5
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_test('xxx')
+
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'decimal_parsing', 'loc': ('decimal',), 'msg': 'Input should be a valid decimal', 'input': 'xxx'},
+        {
+            'type': 'list_type',
+            'loc': ('list[any]',),
+            'msg': IsStr(regex='Input should be a valid (list|array)'),
+            'input': 'xxx',
+        },
+    ]
+
+
+def test_decimal_repr():
+    v = SchemaValidator({'type': 'decimal'})
+    assert plain_repr(v).startswith(
+        'SchemaValidator(title="decimal",validator=Decimal(DecimalValidator{strict:false,allow_inf_nan:false'
+    )
+    v = SchemaValidator({'type': 'decimal', 'strict': True})
+    assert plain_repr(v).startswith(
+        'SchemaValidator(title="decimal",validator=Decimal(DecimalValidator{strict:true,allow_inf_nan:false'
+    )
+    v = SchemaValidator({'type': 'decimal', 'multiple_of': 7})
+    assert plain_repr(v).startswith('SchemaValidator(title="decimal",validator=Decimal(')
+
+
+@pytest.mark.parametrize('input_value,expected', [(Decimal('1.23'), Decimal('1.23')), (Decimal('1'), Decimal('1.0'))])
+def test_decimal_not_json(input_value, expected):
+    v = SchemaValidator({'type': 'decimal'})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_python(input_value)
+    else:
+        output = v.validate_python(input_value)
+        assert output == expected
+        assert isinstance(output, Decimal)
+
+
+def test_decimal_nan(py_and_json: PyAndJson):
+    v = py_and_json({'type': 'decimal', 'allow_inf_nan': True})
+    assert v.validate_test('inf') == Decimal('inf')
+    assert v.validate_test('-inf') == Decimal('-inf')
+    r = v.validate_test('nan')
+    assert math.isnan(r)
+
+
+def test_decimal_key(py_and_json: PyAndJson):
+    v = py_and_json({'type': 'dict', 'keys_schema': {'type': 'decimal'}, 'values_schema': {'type': 'int'}})
+    assert v.validate_test({'1': 1, '2': 2}) == {Decimal('1'): 1, Decimal('2'): 2}
+    assert v.validate_test({'1.5': 1, '2.4': 2}) == {Decimal('1.5'): 1, Decimal('2.4'): 2}
+    if v.validator_type == 'python':
+        with pytest.raises(ValidationError, match='Input should be an instance of Decimal'):
+            v.validate_test({'1.5': 1, '2.5': 2}, strict=True)
+    else:
+        assert v.validate_test({'1.5': 1, '2.4': 2}, strict=True) == {Decimal('1.5'): 1, Decimal('2.4'): 2}
+
+
+@pytest.mark.parametrize(
+    'input_value,allow_inf_nan,expected',
+    [
+        ('NaN', True, FunctionCheck(math.isnan)),
+        ('NaN', False, Err("Input should be a finite number [type=finite_number, input_value='NaN', input_type=str]")),
+        ('+inf', True, FunctionCheck(lambda x: math.isinf(x) and x > 0)),
+        (
+            '+inf',
+            False,
+            Err("Input should be a finite number [type=finite_number, input_value='+inf', input_type=str]"),
+        ),
+        ('+infinity', True, FunctionCheck(lambda x: math.isinf(x) and x > 0)),
+        (
+            '+infinity',
+            False,
+            Err("Input should be a finite number [type=finite_number, input_value='+infinity', input_type=str]"),
+        ),
+        ('-inf', True, FunctionCheck(lambda x: math.isinf(x) and x < 0)),
+        (
+            '-inf',
+            False,
+            Err("Input should be a finite number [type=finite_number, input_value='-inf', input_type=str]"),
+        ),
+        ('-infinity', True, FunctionCheck(lambda x: math.isinf(x) and x < 0)),
+        (
+            '-infinity',
+            False,
+            Err("Input should be a finite number [type=finite_number, input_value='-infinity', input_type=str]"),
+        ),
+        ('0.7', True, Decimal('0.7')),
+        ('0.7', False, Decimal('0.7')),
+        (
+            'pika',
+            True,
+            Err("Input should be a valid decimal [type=decimal_parsing, input_value='pika', input_type=str]"),
+        ),
+        (
+            'pika',
+            False,
+            Err("Input should be a valid decimal [type=decimal_parsing, input_value='pika', input_type=str]"),
+        ),
+    ],
+)
+def test_non_finite_json_values(py_and_json: PyAndJson, input_value, allow_inf_nan, expected):
+    v = py_and_json({'type': 'decimal', 'allow_inf_nan': allow_inf_nan})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_test(input_value)
+    else:
+        assert v.validate_test(input_value) == expected
+
+
+@pytest.mark.parametrize('strict', (True, False))
+@pytest.mark.parametrize(
+    'input_value,allow_inf_nan,expected',
+    [
+        (Decimal('nan'), True, FunctionCheck(math.isnan)),
+        (
+            Decimal('nan'),
+            False,
+            Err("Input should be a finite number [type=finite_number, input_value=Decimal('NaN'), input_type=Decimal]"),
+        ),
+    ],
+)
+def test_non_finite_decimal_values(strict, input_value, allow_inf_nan, expected):
+    v = SchemaValidator({'type': 'decimal', 'allow_inf_nan': allow_inf_nan, 'strict': strict})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_python(input_value)
+    else:
+        assert v.validate_python(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    'input_value,allow_inf_nan,expected',
+    [
+        (Decimal('+inf'), True, FunctionCheck(lambda x: math.isinf(x) and x > 0)),
+        (
+            Decimal('+inf'),
+            False,
+            Err(
+                "Input should be a finite number [type=finite_number, input_value=Decimal('Infinity'), input_type=Decimal]"
+            ),
+        ),
+        (
+            Decimal('-inf'),
+            True,
+            Err(
+                "Input should be greater than 0 [type=greater_than, input_value=Decimal('-Infinity'), input_type=Decimal]"
+            ),
+        ),
+        (
+            Decimal('-inf'),
+            False,
+            Err(
+                "Input should be a finite number [type=finite_number, input_value=Decimal('-Infinity'), input_type=Decimal]"
+            ),
+        ),
+    ],
+)
+def test_non_finite_constrained_decimal_values(input_value, allow_inf_nan, expected):
+    v = SchemaValidator({'type': 'decimal', 'allow_inf_nan': allow_inf_nan, 'gt': 0})
+    if isinstance(expected, Err):
+        with pytest.raises(ValidationError, match=re.escape(expected.message)):
+            v.validate_python(input_value)
+    else:
+        assert v.validate_python(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    'input_value,expected',
+    [
+        # lower e, minus
+        ('1.0e-12', Decimal('1e-12')),
+        ('1e-12', Decimal('1e-12')),
+        ('12e-1', Decimal('12e-1')),
+        # upper E, minus
+        ('1.0E-12', Decimal('1e-12')),
+        ('1E-12', Decimal('1e-12')),
+        ('12E-1', Decimal('12e-1')),
+        # lower E, plus
+        ('1.0e+12', Decimal(' 1e12')),
+        ('1e+12', Decimal(' 1e12')),
+        ('12e+1', Decimal(' 12e1')),
+        # upper E, plus
+        ('1.0E+12', Decimal(' 1e12')),
+        ('1E+12', Decimal(' 1e12')),
+        ('12E+1', Decimal(' 12e1')),
+        # lower E, unsigned
+        ('1.0e12', Decimal(' 1e12')),
+        ('1e12', Decimal(' 1e12')),
+        ('12e1', Decimal(' 12e1')),
+        # upper E, unsigned
+        ('1.0E12', Decimal(' 1e12')),
+        ('1E12', Decimal(' 1e12')),
+        ('12E1', Decimal(' 12e1')),
+    ],
+)
+def test_validate_scientific_notation_from_json(input_value, expected):
+    v = SchemaValidator({'type': 'decimal'})
+    assert v.validate_json(input_value) == expected


### PR DESCRIPTION
## Change Summary

Adds a Rust implementation of decimal validation and serialization. Needs more tests and benchmarks to confirm it's worth going for this instead of https://github.com/pydantic/pydantic/pull/6327

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu