### PR TITLE
fix borrow error when serializing recursive models

### DIFF
--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -101,7 +101,7 @@ pub(crate) fn infer_to_python_known(
 
     let serialize_with_serializer = || {
         let py_serializer = value.getattr(intern!(py, "__pydantic_serializer__"))?;
-        let serializer: SchemaSerializer = py_serializer.extract()?;
+        let serializer: PyRef<SchemaSerializer> = py_serializer.extract()?;
         let extra = serializer.build_extra(
             py,
             extra.mode,
@@ -464,7 +464,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
             let py_serializer = value
                 .getattr(intern!(py, "__pydantic_serializer__"))
                 .map_err(py_err_se_err)?;
-            let extracted_serializer: SchemaSerializer = py_serializer.extract().map_err(py_err_se_err)?;
+            let extracted_serializer: PyRef<SchemaSerializer> = py_serializer.extract().map_err(py_err_se_err)?;
             let extra = extracted_serializer.build_extra(
                 py,
                 extra.mode,

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -308,11 +308,11 @@ pub(crate) fn to_json_bytes(
     exclude: Option<&PyAny>,
     extra: &Extra,
     indent: Option<usize>,
-    json_size: usize,
+    expected_json_size: usize,
 ) -> PyResult<Vec<u8>> {
     let serializer = PydanticSerializer::new(value, serializer, include, exclude, extra);
 
-    let writer: Vec<u8> = Vec::with_capacity(json_size);
+    let writer: Vec<u8> = Vec::with_capacity(expected_json_size);
     let bytes = match indent {
         Some(indent) => {
             let indent = vec![b' '; indent];

--- a/tests/serializers/test_functions.py
+++ b/tests/serializers/test_functions.py
@@ -627,9 +627,7 @@ def test_recursive_call():
         s.to_json(42)
     # insert_assert(str(exc_info.value))
     assert str(exc_info.value) == (
-        'Error serializing to JSON: '
-        'PydanticSerializationError: Error calling function `bad_recursive`: '
-        'RuntimeError: Already mutably borrowed'
+        'Error serializing to JSON: PydanticSerializationError: Error calling function `bad_recursive`: RecursionError'
     )
 
 

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -141,6 +141,22 @@ def test_model_allow_extra():
         assert j == b'{"bar":"more","foo":1,"c":3}'
 
 
+def test_model_recursive_in_extra():
+    # See https://github.com/pydantic/pydantic/issues/6571
+
+    class Model(BasicModel):
+        __slots__ = '__pydantic_extra__'
+
+    s = SchemaSerializer(
+        core_schema.model_schema(
+            Model, core_schema.model_fields_schema({}, extra_behavior='allow'), extra_behavior='allow'
+        )
+    )
+    Model.__pydantic_serializer__ = s
+
+    assert s.to_json(Model(__pydantic_extra__=dict(other=Model(__pydantic_extra__={})))) == b'{"other":{}}'
+
+
 @pytest.mark.parametrize(
     'params',
     [


### PR DESCRIPTION
## Change Summary

Fixes a borrow error when serializing a recursive model.

The cause was because we took a `&mut` borrow on the `SchemaSerializer` in `to_json` but then attempt to _clone_ (!!) it when we fetch `__pydantic_serializer__`.

I've changed to (a) not take a `&mut borrow` and (b) not clone when fetching `__pydantic_serializer__`.

## Related issue number

https://github.com/pydantic/pydantic/issues/6571

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin