### PR TITLE
Fix scientific floats with uppercase E

### DIFF
--- a/src/input/parse_json.rs
+++ b/src/input/parse_json.rs
@@ -146,7 +146,7 @@ impl<'de> Deserialize<'de> for JsonInput {
 
                                 if let JsonInput::String(s) = &first_value {
                                     // Normalize the string to either an int or float
-                                    let normalized = if s.contains('.') || s.contains('e') {
+                                    let normalized = if s.chars().any(|c| c == '.' || c == 'E' || c == 'e') {
                                         JsonInput::Float(
                                             s.parse()
                                                 .map_err(|e| V::Error::custom(format!("expected a float: {e}")))?,

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -327,7 +327,35 @@ def test_non_finite_constrained_float_values(input_value, allow_inf_nan, expecte
         assert v.validate_python(input_value) == expected
 
 
-def test_validate_scientific_notation_from_json():
+@pytest.mark.parametrize(
+    'input_value,expected',
+    [
+        # lower e, minus
+        ('1.0e-12', 1e-12),
+        ('1e-12', 1e-12),
+        ('12e-1', 12e-1),
+        # upper E, minus
+        ('1.0E-12', 1e-12),
+        ('1E-12', 1e-12),
+        ('12E-1', 12e-1),
+        # lower E, plus
+        ('1.0e+12', 1e12),
+        ('1e+12', 1e12),
+        ('12e+1', 12e1),
+        # upper E, plus
+        ('1.0E+12', 1e12),
+        ('1E+12', 1e12),
+        ('12E+1', 12e1),
+        # lower E, unsigned
+        ('1.0e12', 1e12),
+        ('1e12', 1e12),
+        ('12e1', 12e1),
+        # upper E, unsigned
+        ('1.0E12', 1e12),
+        ('1E12', 1e12),
+        ('12E1', 12e1),
+    ],
+)
+def test_validate_scientific_notation_from_json(input_value, expected):
     v = SchemaValidator({'type': 'float'})
-    assert v.validate_json('1.0e-12') == 1e-12
-    assert v.validate_json('1e-12') == 1e-12
+    assert v.validate_json(input_value) == expected


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

#774 fixed parsing of scientific-notation floats with lowercase e, but not with uppercase E.

## Related issue number

#774

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
----

@dmontagu @adriangb please review