### PR TITLE
fix type annotations for Url & MultiHostUrl build

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -208,7 +208,7 @@ class Url(SupportsAllComparisons):
         path: Optional[str] = None,
         query: Optional[str] = None,
         fragment: Optional[str] = None,
-    ) -> str: ...
+    ) -> Self: ...
 
 class MultiHostUrl(SupportsAllComparisons):
     def __new__(cls, url: str) -> Self: ...
@@ -239,7 +239,7 @@ class MultiHostUrl(SupportsAllComparisons):
         path: Optional[str] = None,
         query: Optional[str] = None,
         fragment: Optional[str] = None,
-    ) -> str: ...
+    ) -> Self: ...
 
 @final
 class SchemaError(Exception):


### PR DESCRIPTION
## Change Summary

These methods have an incorrect type annotation - they return instances of Url and MultiHostUrl.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin