### PR TITLE
set up stable Rust toolchain on all rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+
       - name: cache rust
         uses: Swatinem/rust-cache@v2
         with:
@@ -157,6 +160,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cache rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: test-debug
 
       - run: pip install -r tests/requirements.txt
       - run: make build-dev


### PR DESCRIPTION
## Change Summary

Should fix the build failures observed in CI related to the recently-stabilized `OnceLock`.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb