### PR TITLE
🐛 Fix handling of bool literals

### DIFF
--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -44,7 +44,9 @@ impl BuildSerializer for LiteralSerializer {
         let mut repr_args: Vec<String> = Vec::new();
         for item in expected {
             repr_args.push(item.repr()?.extract()?);
-            if let Ok(int) = extract_i64(item) {
+            if let Ok(bool) = item.downcast::<PyBool>() {
+                expected_py.append(bool)?;
+            } else if let Ok(int) = extract_i64(item) {
                 expected_int.insert(int);
             } else if let Ok(py_str) = item.downcast::<PyString>() {
                 expected_str.insert(py_str.to_str()?.to_string());

--- a/tests/serializers/test_literal.py
+++ b/tests/serializers/test_literal.py
@@ -61,3 +61,13 @@ def test_other_literal():
 def test_empty_literal():
     with pytest.raises(SchemaError, match='`expected` should have length > 0'):
         SchemaSerializer(core_schema.literal_schema([]))
+
+
+def test_bool_literal():
+    s = SchemaSerializer(core_schema.literal_schema([False]))
+    assert 'expected_int:{},expected_str:{},expected_py:Some(Py(' in plain_repr(s)
+
+    assert s.to_python(False) is False
+    assert s.to_python(False, mode='json') is False
+    assert s.to_python(True) is True
+    assert s.to_json(False) == b'false'


### PR DESCRIPTION
## Change Summary

Treat bool literals (`Literal[False]`, `Literal[True]`) as generic py objects instead of `int`s.

## Related issue number

See pydantic/pydantic#6601

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu