### PR TITLE
fix python GC traversal for validators and serializers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@ use pyo3::{prelude::*, sync::GILOnceCell};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// parse this first to get access to the contained macro
+#[macro_use]
+mod py_gc;
+
 mod argument_markers;
 mod build_tools;
 mod definitions;

--- a/src/py_gc.rs
+++ b/src/py_gc.rs
@@ -1,0 +1,70 @@
+use ahash::AHashMap;
+use enum_dispatch::enum_dispatch;
+use pyo3::{AsPyPointer, Py, PyTraverseError, PyVisit};
+
+/// Trait implemented by types which can be traversed by the Python GC.
+#[enum_dispatch]
+pub trait PyGcTraverse {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError>;
+}
+
+impl<T> PyGcTraverse for Py<T>
+where
+    Py<T>: AsPyPointer,
+{
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        visit.call(self)
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for Vec<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        for item in self {
+            item.py_gc_traverse(visit)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for AHashMap<String, T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        for item in self.values() {
+            item.py_gc_traverse(visit)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for Box<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        T::py_gc_traverse(self, visit)
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for Option<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match self {
+            Some(item) => T::py_gc_traverse(item, visit),
+            None => Ok(()),
+        }
+    }
+}
+
+/// A crude alternative to a "derive" macro to help with building PyGcTraverse implementations
+macro_rules! impl_py_gc_traverse {
+    ($name:ty { }) => {
+        impl crate::py_gc::PyGcTraverse for $name {
+            fn py_gc_traverse(&self, _visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                Ok(())
+            }
+        }
+    };
+    ($name:ty { $($fields:ident),* }) => {
+        impl crate::py_gc::PyGcTraverse for $name {
+            fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                $(self.$fields.py_gc_traverse(visit)?;)*
+                Ok(())
+            }
+        }
+    };
+}

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -1,11 +1,12 @@
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::{intern, PyTraverseError, PyVisit};
 use serde::ser::SerializeMap;
 use serde::Serialize;
 
 use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{BuildSerializer, CombinedSerializer, PydanticSerializer, TypeSerializer};
 use crate::tools::SchemaDict;
@@ -155,6 +156,16 @@ pub(crate) struct ComputedFieldSerializer<'py> {
     exclude: Option<&'py PyAny>,
     extra: &'py Extra<'py>,
 }
+
+impl_py_gc_traverse!(ComputedField { serializer });
+
+impl PyGcTraverse for ComputedFields {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        self.0.py_gc_traverse(visit)
+    }
+}
+
+impl_py_gc_traverse!(ComputedFieldSerializer<'_> { computed_field });
 
 impl<'py> Serialize for ComputedFieldSerializer<'py> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -28,6 +28,8 @@ pub(super) struct SerField {
     pub required: bool,
 }
 
+impl_py_gc_traverse!(SerField { serializer });
+
 impl SerField {
     pub fn new(
         py: Python,
@@ -141,6 +143,11 @@ macro_rules! option_length {
         }
     };
 }
+
+impl_py_gc_traverse!(GeneralFieldsSerializer {
+    fields,
+    computed_fields
+});
 
 impl TypeSerializer for GeneralFieldsSerializer {
     fn to_python(

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -6,6 +6,7 @@ use pyo3::types::{PyBytes, PyDict};
 use pyo3::{PyTraverseError, PyVisit};
 
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::validators::SelfValidator;
 
 use config::SerializationConfig;
@@ -190,13 +191,6 @@ impl SchemaSerializer {
             slot.py_gc_traverse(&visit)?;
         }
         Ok(())
-    }
-
-    fn __clear__(&mut self) {
-        self.serializer.py_gc_clear();
-        for slot in &mut self.definitions {
-            slot.py_gc_clear();
-        }
     }
 }
 

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -14,6 +14,7 @@ use serde_json::ser::PrettyFormatter;
 use crate::build_tools::py_schema_err;
 use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::tools::{py_err, SchemaDict};
 
 use super::errors::se_err_py_err;
@@ -215,12 +216,50 @@ impl BuildSerializer for CombinedSerializer {
     }
 }
 
+// Implemented by hand because `enum_dispatch` fails with a proc macro compile error =/
+impl PyGcTraverse for CombinedSerializer {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match self {
+            CombinedSerializer::Function(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::FunctionWrap(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Fields(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::None(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Nullable(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Int(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Bool(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Float(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Str(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Bytes(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Datetime(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::TimeDelta(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Date(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Time(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::List(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Set(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::FrozenSet(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Generator(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Dict(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Model(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Dataclass(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Url(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::MultiHostUrl(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Any(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Format(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::ToString(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::WithDefault(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Json(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::JsonOrPython(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Union(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Literal(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Recursive(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::TuplePositional(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::TupleVariable(inner) => inner.py_gc_traverse(visit),
+        }
+    }
+}
+
 #[enum_dispatch(CombinedSerializer)]
 pub(crate) trait TypeSerializer: Send + Sync + Clone + Debug {
-    fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        Ok(())
-    }
-    fn py_gc_clear(&mut self) {}
     fn to_python(
         &self,
         value: &PyAny,

--- a/src/serializers/type_serializers/any.rs
+++ b/src/serializers/type_serializers/any.rs
@@ -26,6 +26,8 @@ impl BuildSerializer for AnySerializer {
     }
 }
 
+impl_py_gc_traverse!(AnySerializer {});
+
 impl TypeSerializer for AnySerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/bytes.rs
+++ b/src/serializers/type_serializers/bytes.rs
@@ -25,6 +25,8 @@ impl BuildSerializer for BytesSerializer {
     }
 }
 
+impl_py_gc_traverse!(BytesSerializer {});
+
 impl TypeSerializer for BytesSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -1,6 +1,6 @@
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyType};
-use pyo3::{intern, PyTraverseError, PyVisit};
 use std::borrow::Cow;
 
 use ahash::AHashMap;
@@ -121,13 +121,9 @@ impl DataclassSerializer {
     }
 }
 
-impl TypeSerializer for DataclassSerializer {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        visit.call(&self.class)?;
-        self.serializer.py_gc_traverse(visit)?;
-        Ok(())
-    }
+impl_py_gc_traverse!(DataclassSerializer { class, serializer });
 
+impl TypeSerializer for DataclassSerializer {
     fn to_python(
         &self,
         value: &PyAny,

--- a/src/serializers/type_serializers/datetime_etc.rs
+++ b/src/serializers/type_serializers/datetime_etc.rs
@@ -40,6 +40,8 @@ macro_rules! build_serializer {
             }
         }
 
+        impl_py_gc_traverse!($struct_name {});
+
         impl TypeSerializer for $struct_name {
             fn to_python(
                 &self,

--- a/src/serializers/type_serializers/definitions.rs
+++ b/src/serializers/type_serializers/definitions.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use crate::definitions::DefinitionsBuilder;
+
 use crate::tools::SchemaDict;
 
 use super::{py_err_se_err, BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
@@ -58,6 +59,8 @@ impl BuildSerializer for DefinitionRefSerializer {
         Ok(Self { serializer_id }.into())
     }
 }
+
+impl_py_gc_traverse!(DefinitionRefSerializer {});
 
 impl TypeSerializer for DefinitionRefSerializer {
     fn to_python(

--- a/src/serializers/type_serializers/dict.rs
+++ b/src/serializers/type_serializers/dict.rs
@@ -65,6 +65,11 @@ impl BuildSerializer for DictSerializer {
     }
 }
 
+impl_py_gc_traverse!(DictSerializer {
+    key_serializer,
+    value_serializer
+});
+
 impl TypeSerializer for DictSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/format.rs
+++ b/src/serializers/type_serializers/format.rs
@@ -104,6 +104,8 @@ impl FormatSerializer {
     }
 }
 
+impl_py_gc_traverse!(FormatSerializer { format_func });
+
 impl TypeSerializer for FormatSerializer {
     fn to_python(
         &self,
@@ -174,6 +176,8 @@ impl BuildSerializer for ToStringSerializer {
         .into())
     }
 }
+
+impl_py_gc_traverse!(ToStringSerializer {});
 
 impl TypeSerializer for ToStringSerializer {
     fn to_python(

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -269,6 +269,12 @@ macro_rules! function_type_serializer {
     };
 }
 
+impl_py_gc_traverse!(FunctionPlainSerializer {
+    func,
+    return_serializer,
+    fallback_serializer
+});
+
 function_type_serializer!(FunctionPlainSerializer);
 
 fn copy_outer_schema(schema: &PyDict) -> PyResult<&PyDict> {
@@ -398,6 +404,12 @@ impl FunctionWrapSerializer {
         self.serializer.as_ref()
     }
 }
+
+impl_py_gc_traverse!(FunctionWrapSerializer {
+    serializer,
+    func,
+    return_serializer
+});
 
 function_type_serializer!(FunctionWrapSerializer);
 

--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -42,6 +42,8 @@ impl BuildSerializer for GeneratorSerializer {
     }
 }
 
+impl_py_gc_traverse!(GeneratorSerializer { item_serializer });
+
 impl TypeSerializer for GeneratorSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/json.rs
+++ b/src/serializers/type_serializers/json.rs
@@ -42,6 +42,8 @@ impl BuildSerializer for JsonSerializer {
     }
 }
 
+impl_py_gc_traverse!(JsonSerializer { serializer });
+
 impl TypeSerializer for JsonSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/json_or_python.rs
+++ b/src/serializers/type_serializers/json_or_python.rs
@@ -45,6 +45,8 @@ impl BuildSerializer for JsonOrPythonSerializer {
     }
 }
 
+impl_py_gc_traverse!(JsonOrPythonSerializer { json, python });
+
 impl TypeSerializer for JsonOrPythonSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/list.rs
+++ b/src/serializers/type_serializers/list.rs
@@ -45,6 +45,8 @@ impl BuildSerializer for ListSerializer {
     }
 }
 
+impl_py_gc_traverse!(ListSerializer { item_serializer });
+
 impl TypeSerializer for ListSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -106,6 +106,8 @@ impl LiteralSerializer {
     }
 }
 
+impl_py_gc_traverse!(LiteralSerializer { expected_py });
+
 impl TypeSerializer for LiteralSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyType};
-use pyo3::{intern, PyTraverseError, PyVisit};
 
 use ahash::AHashMap;
 
@@ -144,13 +144,9 @@ impl ModelSerializer {
     }
 }
 
-impl TypeSerializer for ModelSerializer {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        visit.call(&self.class)?;
-        self.serializer.py_gc_traverse(visit)?;
-        Ok(())
-    }
+impl_py_gc_traverse!(ModelSerializer { class, serializer });
 
+impl TypeSerializer for ModelSerializer {
     fn to_python(
         &self,
         value: &PyAny,

--- a/src/serializers/type_serializers/nullable.rs
+++ b/src/serializers/type_serializers/nullable.rs
@@ -30,6 +30,8 @@ impl BuildSerializer for NullableSerializer {
     }
 }
 
+impl_py_gc_traverse!(NullableSerializer { serializer });
+
 impl TypeSerializer for NullableSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/set_frozenset.rs
+++ b/src/serializers/type_serializers/set_frozenset.rs
@@ -45,6 +45,8 @@ macro_rules! build_serializer {
             }
         }
 
+        impl_py_gc_traverse!($struct_name { item_serializer });
+
         impl TypeSerializer for $struct_name {
             fn to_python(
                 &self,

--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+
 use std::borrow::Cow;
 
 use serde::Serialize;
@@ -29,6 +30,8 @@ impl BuildSerializer for NoneSerializer {
 pub(crate) fn none_json_key() -> PyResult<Cow<'static, str>> {
     Ok(Cow::Borrowed("None"))
 }
+
+impl_py_gc_traverse!(NoneSerializer {});
 
 impl TypeSerializer for NoneSerializer {
     fn to_python(
@@ -97,6 +100,8 @@ macro_rules! build_simple_serializer {
                 Ok(Self {}.into())
             }
         }
+
+        impl_py_gc_traverse!($struct_name {});
 
         impl TypeSerializer for $struct_name {
             fn to_python(

--- a/src/serializers/type_serializers/string.rs
+++ b/src/serializers/type_serializers/string.rs
@@ -25,6 +25,8 @@ impl BuildSerializer for StrSerializer {
     }
 }
 
+impl_py_gc_traverse!(StrSerializer {});
+
 impl TypeSerializer for StrSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/timedelta.rs
+++ b/src/serializers/type_serializers/timedelta.rs
@@ -25,6 +25,8 @@ impl BuildSerializer for TimeDeltaSerializer {
     }
 }
 
+impl_py_gc_traverse!(TimeDeltaSerializer {});
+
 impl TypeSerializer for TimeDeltaSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -47,6 +47,8 @@ impl BuildSerializer for TupleVariableSerializer {
     }
 }
 
+impl_py_gc_traverse!(TupleVariableSerializer { item_serializer });
+
 impl TypeSerializer for TupleVariableSerializer {
     fn to_python(
         &self,
@@ -180,6 +182,11 @@ impl BuildSerializer for TuplePositionalSerializer {
         .into())
     }
 }
+
+impl_py_gc_traverse!(TuplePositionalSerializer {
+    items_serializers,
+    extra_serializer
+});
 
 impl TypeSerializer for TuplePositionalSerializer {
     fn to_python(

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -59,6 +59,8 @@ impl UnionSerializer {
     }
 }
 
+impl_py_gc_traverse!(UnionSerializer { choices });
+
 impl TypeSerializer for UnionSerializer {
     fn to_python(
         &self,

--- a/src/serializers/type_serializers/url.rs
+++ b/src/serializers/type_serializers/url.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::definitions::DefinitionsBuilder;
+
 use crate::url::{PyMultiHostUrl, PyUrl};
 
 use super::{
@@ -27,6 +28,8 @@ macro_rules! build_serializer {
                 Ok(Self {}.into())
             }
         }
+
+        impl_py_gc_traverse!($struct_name {});
 
         impl TypeSerializer for $struct_name {
             fn to_python(

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -34,6 +34,8 @@ impl BuildSerializer for WithDefaultSerializer {
     }
 }
 
+impl_py_gc_traverse!(WithDefaultSerializer { default, serializer });
+
 impl TypeSerializer for WithDefaultSerializer {
     fn to_python(
         &self,

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -3,6 +3,7 @@ use pyo3::types::PyDict;
 
 use crate::errors::ValResult;
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
@@ -22,6 +23,8 @@ impl BuildValidator for AnyValidator {
         Ok(Self.into())
     }
 }
+
+impl_py_gc_traverse!(AnyValidator {});
 
 impl Validator for AnyValidator {
     fn validate<'s, 'data>(

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -9,6 +9,7 @@ use crate::build_tools::schema_or_config_same;
 use crate::errors::{ErrorType, ValError, ValLineError, ValResult};
 use crate::input::{GenericArguments, Input};
 use crate::lookup_key::LookupKey;
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -150,6 +151,14 @@ macro_rules! json_slice {
     };
 }
 pub(super) use json_slice;
+
+impl_py_gc_traverse!(Parameter { validator });
+
+impl_py_gc_traverse!(ArgumentsValidator {
+    parameters,
+    var_args_validator,
+    var_kwargs_validator
+});
 
 impl Validator for ArgumentsValidator {
     fn validate<'s, 'data>(

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -4,6 +4,7 @@ use pyo3::types::PyDict;
 use crate::build_tools::is_strict;
 use crate::errors::ValResult;
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
@@ -27,6 +28,8 @@ impl BuildValidator for BoolValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(BoolValidator {});
 
 impl Validator for BoolValidator {
     fn validate<'s, 'data>(

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -5,6 +5,7 @@ use pyo3::types::PyDict;
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -36,6 +37,8 @@ impl BuildValidator for BytesValidator {
         }
     }
 }
+
+impl_py_gc_traverse!(BytesValidator {});
 
 impl Validator for BytesValidator {
     fn validate<'s, 'data>(
@@ -73,6 +76,8 @@ pub struct BytesConstrainedValidator {
     max_length: Option<usize>,
     min_length: Option<usize>,
 }
+
+impl_py_gc_traverse!(BytesConstrainedValidator {});
 
 impl Validator for BytesConstrainedValidator {
     fn validate<'s, 'data>(

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -5,6 +5,7 @@ use pyo3::types::{PyDict, PyTuple};
 
 use crate::errors::ValResult;
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -64,6 +65,11 @@ impl BuildValidator for CallValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(CallValidator {
+    arguments_validator,
+    return_validator
+});
 
 impl Validator for CallValidator {
     fn validate<'s, 'data>(

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -3,6 +3,7 @@ use pyo3::types::PyDict;
 
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
@@ -21,6 +22,8 @@ impl BuildValidator for CallableValidator {
         Ok(Self.into())
     }
 }
+
+impl_py_gc_traverse!(CallableValidator {});
 
 impl Validator for CallableValidator {
     fn validate<'s, 'data>(

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -67,6 +67,8 @@ fn build_validator_steps<'a>(
     }
 }
 
+impl_py_gc_traverse!(ChainValidator { steps });
+
 impl Validator for ChainValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -85,6 +85,8 @@ impl BuildValidator for CustomErrorValidator {
     }
 }
 
+impl_py_gc_traverse!(CustomErrorValidator { validator });
+
 impl Validator for CustomErrorValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -123,6 +123,10 @@ impl BuildValidator for DataclassArgsValidator {
     }
 }
 
+impl_py_gc_traverse!(Field { validator });
+
+impl_py_gc_traverse!(DataclassArgsValidator { fields });
+
 impl Validator for DataclassArgsValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -466,6 +470,8 @@ impl BuildValidator for DataclassValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(DataclassValidator { class, validator });
 
 impl Validator for DataclassValidator {
     fn validate<'s, 'data>(

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -7,6 +7,7 @@ use strum::EnumMessage;
 use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{EitherDate, Input};
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 use crate::validators::datetime::{NowConstraint, NowOp};
@@ -34,6 +35,8 @@ impl BuildValidator for DateValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(DateValidator {});
 
 impl Validator for DateValidator {
     fn validate<'s, 'data>(

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -10,6 +10,7 @@ use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::build_tools::{py_schema_err, schema_or_config_same};
 use crate::errors::{py_err_string, ErrorType, ValError, ValResult};
 use crate::input::{EitherDateTime, Input};
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -54,6 +55,8 @@ impl BuildValidator for DateTimeValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(DateTimeValidator {});
 
 impl Validator for DateTimeValidator {
     fn validate<'s, 'data>(

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -4,6 +4,7 @@ use pyo3::types::{PyDict, PyList};
 
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -69,6 +70,8 @@ impl BuildValidator for DefinitionRefValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(DefinitionRefValidator {});
 
 impl Validator for DefinitionRefValidator {
     fn validate<'s, 'data>(

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -7,6 +7,7 @@ use crate::errors::{ValError, ValLineError, ValResult};
 use crate::input::{
     DictGenericIterator, GenericMapping, Input, JsonObject, JsonObjectGenericIterator, MappingGenericIterator,
 };
+
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
@@ -58,6 +59,11 @@ impl BuildValidator for DictValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(DictValidator {
+    key_validator,
+    value_validator
+});
 
 impl Validator for DictValidator {
     fn validate<'s, 'data>(

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -60,6 +60,8 @@ impl BuildValidator for FloatValidator {
     }
 }
 
+impl_py_gc_traverse!(FloatValidator {});
+
 impl Validator for FloatValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -104,6 +106,8 @@ pub struct ConstrainedFloatValidator {
     ge: Option<f64>,
     gt: Option<f64>,
 }
+
+impl_py_gc_traverse!(ConstrainedFloatValidator {});
 
 impl Validator for ConstrainedFloatValidator {
     fn validate<'s, 'data>(

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -24,6 +24,8 @@ impl BuildValidator for FrozenSetValidator {
     set_build!();
 }
 
+impl_py_gc_traverse!(FrozenSetValidator { item_validator });
+
 impl Validator for FrozenSetValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -48,6 +48,8 @@ impl BuildValidator for GeneratorValidator {
     }
 }
 
+impl_py_gc_traverse!(GeneratorValidator { item_validator });
+
 impl Validator for GeneratorValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -326,3 +328,11 @@ impl InternalValidator {
             })
     }
 }
+
+impl_py_gc_traverse!(InternalValidator {
+    validator,
+    definitions,
+    data,
+    context,
+    self_instance
+});

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -41,6 +41,8 @@ impl BuildValidator for IntValidator {
     }
 }
 
+impl_py_gc_traverse!(IntValidator {});
+
 impl Validator for IntValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -79,6 +81,8 @@ pub struct ConstrainedIntValidator {
     ge: Option<Int>,
     gt: Option<Int>,
 }
+
+impl_py_gc_traverse!(ConstrainedIntValidator {});
 
 impl Validator for ConstrainedIntValidator {
     fn validate<'s, 'data>(

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -54,6 +54,8 @@ impl BuildValidator for IsInstanceValidator {
     }
 }
 
+impl_py_gc_traverse!(IsInstanceValidator { class });
+
 impl Validator for IsInstanceValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -41,6 +41,8 @@ impl BuildValidator for IsSubclassValidator {
     }
 }
 
+impl_py_gc_traverse!(IsSubclassValidator { class });
+
 impl Validator for IsSubclassValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -42,6 +42,8 @@ impl BuildValidator for JsonValidator {
     }
 }
 
+impl_py_gc_traverse!(JsonValidator { validator });
+
 impl Validator for JsonValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -48,6 +48,8 @@ impl BuildValidator for JsonOrPython {
     }
 }
 
+impl_py_gc_traverse!(JsonOrPython { json, python });
+
 impl Validator for JsonOrPython {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -49,6 +49,11 @@ impl BuildValidator for LaxOrStrictValidator {
     }
 }
 
+impl_py_gc_traverse!(LaxOrStrictValidator {
+    lax_validator,
+    strict_validator
+});
+
 impl Validator for LaxOrStrictValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -110,6 +110,8 @@ impl BuildValidator for ListValidator {
     }
 }
 
+impl_py_gc_traverse!(ListValidator { item_validator });
+
 impl Validator for ListValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -99,13 +99,9 @@ impl BuildValidator for ModelValidator {
     }
 }
 
-impl Validator for ModelValidator {
-    fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-        visit.call(&self.class)?;
-        self.validator.py_gc_traverse(visit)?;
-        Ok(())
-    }
+impl_py_gc_traverse!(ModelValidator { class, validator });
 
+impl Validator for ModelValidator {
     fn validate<'s, 'data>(
         &'s self,
         py: Python<'data>,

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -27,6 +27,8 @@ struct Field {
     frozen: bool,
 }
 
+impl_py_gc_traverse!(Field { validator });
+
 #[derive(Debug, Clone)]
 pub struct ModelFieldsValidator {
     fields: Vec<Field>,
@@ -106,6 +108,11 @@ impl BuildValidator for ModelFieldsValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(ModelFieldsValidator {
+    fields,
+    extra_validator
+});
 
 impl Validator for ModelFieldsValidator {
     fn validate<'s, 'data>(

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -22,6 +22,8 @@ impl BuildValidator for NoneValidator {
     }
 }
 
+impl_py_gc_traverse!(NoneValidator {});
+
 impl Validator for NoneValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -30,6 +30,8 @@ impl BuildValidator for NullableValidator {
     }
 }
 
+impl_py_gc_traverse!(NullableValidator { validator });
+
 impl Validator for NullableValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -55,6 +55,8 @@ impl BuildValidator for SetValidator {
     set_build!();
 }
 
+impl_py_gc_traverse!(SetValidator { item_validator });
+
 impl Validator for SetValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -37,6 +37,8 @@ impl BuildValidator for StrValidator {
     }
 }
 
+impl_py_gc_traverse!(StrValidator {});
+
 impl Validator for StrValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -77,6 +79,8 @@ pub struct StrConstrainedValidator {
     to_lower: bool,
     to_upper: bool,
 }
+
+impl_py_gc_traverse!(StrConstrainedValidator {});
 
 impl Validator for StrConstrainedValidator {
     fn validate<'s, 'data>(

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -38,6 +38,8 @@ impl BuildValidator for TimeValidator {
     }
 }
 
+impl_py_gc_traverse!(TimeValidator {});
+
 impl Validator for TimeValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -64,6 +64,8 @@ impl BuildValidator for TimeDeltaValidator {
     }
 }
 
+impl_py_gc_traverse!(TimeDeltaValidator {});
+
 impl Validator for TimeDeltaValidator {
     fn validate<'s, 'data>(
         &'s self,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -42,6 +42,8 @@ impl BuildValidator for TupleVariableValidator {
     }
 }
 
+impl_py_gc_traverse!(TupleVariableValidator { item_validator });
+
 impl Validator for TupleVariableValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -203,6 +205,11 @@ fn validate_tuple_positional<'s, 'data, T: Iterator<Item = PyResult<&'data I>>, 
     }
     Ok(())
 }
+
+impl_py_gc_traverse!(TuplePositionalValidator {
+    items_validators,
+    extra_validator
+});
 
 impl Validator for TuplePositionalValidator {
     fn validate<'s, 'data>(

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -26,6 +26,8 @@ struct TypedDictField {
     validator: CombinedValidator,
 }
 
+impl_py_gc_traverse!(TypedDictField { validator });
+
 #[derive(Debug, Clone)]
 pub struct TypedDictValidator {
     fields: Vec<TypedDictField>,
@@ -131,6 +133,11 @@ impl BuildValidator for TypedDictValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(TypedDictValidator {
+    fields,
+    extra_validator
+});
 
 impl Validator for TypedDictValidator {
     fn validate<'s, 'data>(

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -57,6 +57,8 @@ impl BuildValidator for UrlValidator {
     }
 }
 
+impl_py_gc_traverse!(UrlValidator {});
+
 impl Validator for UrlValidator {
     fn validate<'s, 'data>(
         &'s self,
@@ -185,6 +187,8 @@ impl BuildValidator for MultiHostUrlValidator {
         .into())
     }
 }
+
+impl_py_gc_traverse!(MultiHostUrlValidator {});
 
 impl Validator for MultiHostUrlValidator {
     fn validate<'s, 'data>(

--- a/tests/validators/test_nullable.py
+++ b/tests/validators/test_nullable.py
@@ -1,6 +1,10 @@
+import gc
+import platform
+import weakref
+
 import pytest
 
-from pydantic_core import SchemaValidator, ValidationError
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 
 def test_nullable():
@@ -33,3 +37,34 @@ def test_union_nullable_bool_int():
     assert v.validate_python(None) is None
     assert v.validate_python(True) is True
     assert v.validate_python(1) == 1
+
+
+@pytest.mark.xfail(
+    condition=platform.python_implementation() == 'PyPy', reason='https://foss.heptapod.net/pypy/pypy/-/issues/3899'
+)
+def test_leak_nullable():
+    def fn():
+        def validate(v, info):
+            return v
+
+        schema = core_schema.general_plain_validator_function(validate)
+        schema = core_schema.nullable_schema(schema)
+
+        # If any of the Rust validators don't implement traversal properly,
+        # there will be an undetectable cycle created by this assignment
+        # which will keep Defaulted alive
+        validate.__pydantic_validator__ = SchemaValidator(schema)
+
+        return validate
+
+    cycle = fn()
+    ref = weakref.ref(cycle)
+    assert ref() is not None
+
+    del cycle
+    gc.collect(0)
+    gc.collect(1)
+    gc.collect(2)
+    gc.collect()
+
+    assert ref() is None


### PR DESCRIPTION
## Change Summary

This PR separates the `py_gc_traverse` methods from serializers and validators out into a separate `PyGcTraverse` trait, forcing all types to provide an implementation.

This gave me a mechanical way to check the traversal for all validators and serializers and implement them fully.

I also added a spattering of tests which attempt to generate cycles and leak them. They fail without this patch which gives me confidence this fixes the original `pydantic` issue listed below.

There is still no guarantee that the traversal implementations are correct, as they're hand-written, but this should make them prevalent enough to force us to remember to look at them.

## Related issue number

https://github.com/pydantic/pydantic/issues/6727

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb