### PR TITLE
correct name of "AssignmentValidatorCallable"

### DIFF
--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -390,7 +390,7 @@ impl Validator for FunctionWrapValidator {
         let handler = AssignmentValidatorCallable {
             validator: InternalValidator::new(
                 py,
-                "ValidatorCallable",
+                "AssignmentValidatorCallable",
                 &self.validator,
                 definitions,
                 extra,


### PR DESCRIPTION
## Change Summary

I noticed this inconsistency that `AssignmentValidatorCallable` was being created with a name of "ValidatorCallable". Was it intended?

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin