### PR TITLE
use vectorcall calling convention for performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod errors;
 mod input;
 mod lazy_index_map;
 mod lookup_key;
+mod py_vectorcall;
 mod recursion_guard;
 mod serializers;
 mod tools;

--- a/src/py_vectorcall.rs
+++ b/src/py_vectorcall.rs
@@ -1,0 +1,55 @@
+use pyo3::{prelude::*, AsPyPointer};
+
+pub fn py_vectorcall<'py>(obj: &'py PyAny, args: &[&PyAny]) -> PyResult<&'py PyAny> {
+    match args.len() {
+        0 => obj.call0(),
+        // match length i with total args slice of i+1 (+1 for self arg to fill in by python if needed)
+        1 => py_vectorcall_fixed_size_with_offset::<2>(obj, args),
+        2 => py_vectorcall_fixed_size_with_offset::<3>(obj, args),
+        3 => py_vectorcall_fixed_size_with_offset::<4>(obj, args),
+        4 => py_vectorcall_fixed_size_with_offset::<5>(obj, args),
+        5 => py_vectorcall_fixed_size_with_offset::<6>(obj, args),
+        _ => py_vectorcall_variable_size(obj, args),
+    }
+}
+
+fn py_vectorcall_fixed_size_with_offset<'py, const N: usize>(obj: &'py PyAny, args: &[&PyAny]) -> PyResult<&'py PyAny> {
+    let nargs = args.len();
+    // N should be the number of args, plus one, so that we can allocate an empty pointer
+    // for vectorcall to use as the self argument
+    debug_assert!(N >= 1);
+    debug_assert_eq!(nargs + 1, N);
+    let mut args_ptrs = [std::ptr::null_mut(); N];
+    let args_slice = &mut args_ptrs[1..];
+    for (arg_ptr, arg) in args_slice.iter_mut().zip(args) {
+        *arg_ptr = arg.as_ptr();
+    }
+    // TODO add offset to denote vectorcall allowed to use args_ptrs[0]
+    let nargsf = nargs;
+    unsafe {
+        obj.py().from_owned_ptr_or_err(pyo3::ffi::PyObject_Vectorcall(
+            obj.as_ptr(),
+            args_slice.as_ptr(),
+            nargsf,
+            std::ptr::null_mut(),
+        ))
+    }
+}
+
+fn py_vectorcall_variable_size<'py>(obj: &'py PyAny, args: &[&PyAny]) -> PyResult<&'py PyAny> {
+    let nargs = args.len();
+    let mut args_ptrs: Vec<*mut pyo3::ffi::PyObject> = std::iter::once(std::ptr::null_mut())
+        .chain(args.iter().map(|arg| arg.as_ptr()))
+        .collect();
+    // TODO add offset to denote vectorcall allowed to use args_ptrs[0]
+    let args = unsafe { args_ptrs.as_mut_ptr().offset(1) };
+    let nargsf = nargs;
+    unsafe {
+        obj.py().from_owned_ptr_or_err(pyo3::ffi::PyObject_Vectorcall(
+            obj.as_ptr(),
+            args,
+            nargsf,
+            std::ptr::null_mut(),
+        ))
+    }
+}

--- a/src/serializers/type_serializers/format.rs
+++ b/src/serializers/type_serializers/format.rs
@@ -8,6 +8,7 @@ use serde::ser::Error;
 
 use crate::build_tools::py_schema_err;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_vectorcall::py_vectorcall;
 use crate::tools::SchemaDict;
 
 use super::simple::none_json_key;
@@ -89,8 +90,8 @@ impl BuildSerializer for FormatSerializer {
 impl FormatSerializer {
     fn call(&self, value: &PyAny) -> Result<PyObject, String> {
         let py = value.py();
-        self.format_func
-            .call1(py, (value, self.formatting_string.as_ref(py)))
+        py_vectorcall(self.format_func.as_ref(py), &[value, self.formatting_string.as_ref(py)])
+            .map(Into::into)
             .map_err(|e| {
                 format!(
                     "Error calling `format(value, {})`: {}",

--- a/src/url.rs
+++ b/src/url.rs
@@ -7,10 +7,11 @@ use idna::punycode::decode_to_string;
 use pyo3::exceptions::PyValueError;
 use pyo3::once_cell::GILOnceCell;
 use pyo3::pyclass::CompareOp;
-use pyo3::types::{PyDict, PyType};
+use pyo3::types::{PyDict, PyString, PyType};
 use pyo3::{intern, prelude::*};
 use url::Url;
 
+use crate::py_vectorcall::py_vectorcall;
 use crate::tools::SchemaDict;
 use crate::SchemaValidator;
 
@@ -188,7 +189,7 @@ impl PyUrl {
             url.push('#');
             url.push_str(fragment);
         }
-        cls.call1((url,))
+        py_vectorcall(cls, &[PyString::new(cls.py(), &url)])
     }
 }
 
@@ -416,7 +417,7 @@ impl PyMultiHostUrl {
             url.push('#');
             url.push_str(fragment);
         }
-        cls.call1((url,))
+        py_vectorcall(cls, &[PyString::new(cls.py(), &url)])
     }
 }
 

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -11,6 +11,7 @@ use crate::build_tools::schema_or_config_same;
 use crate::errors::{LocItem, ValError, ValResult};
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
+use crate::py_vectorcall::py_vectorcall;
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 use crate::PydanticUndefinedType;
@@ -170,7 +171,7 @@ impl Validator for WithDefaultValidator {
             Some(stored_dft) => {
                 let dft: Py<PyAny> = if self.copy_default {
                     let deepcopy_func = COPY_DEEPCOPY.get_or_init(py, || get_deepcopy(py).unwrap());
-                    deepcopy_func.call1(py, (&stored_dft,))?.into_py(py)
+                    py_vectorcall(deepcopy_func.as_ref(py), &[stored_dft.as_ref(py)])?.into_py(py)
                 } else {
                     stored_dft
                 };


### PR DESCRIPTION
## Change Summary

Uses Python's "vectorcall" calling convention instead of `PyAny::call1` to avoid creating intermediate tuples. Only works on supported Python versions. (3.9+, I think, let's confirm with CI.)

In the long term I'd like to add a feature to upstream PyO3 which does this and _also_ supports keyword arguments. Seems like we don't generally use keyword arguments so not relevant to us here. Probably also with a more generic interface than just a slice-of-any as input.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
