### PR TITLE
use github continue-on-error to avoid red CI with test-pydantic-integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
 
   test-pydantic-integration:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v3
@@ -336,14 +337,14 @@ jobs:
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
-    needs: [coverage, test-python, test-os, test-debug, test-pydantic-integration, lint, bench, build-wasm-emscripten]
+    needs: [coverage, test-python, test-os, test-debug, lint, bench, build-wasm-emscripten]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-failures: coverage, test-pydantic-integration
+          allowed-failures: coverage
 
   build-sdist:
     name: build sdist


### PR DESCRIPTION
## Change Summary

At the moment CI is red on all runs because of `test-pydantic-integration`. I believe that using GHA's `continue-on-error` setting will have the same functionality as the `alls-green` check however will also mean the PR gets a green tick.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu