### PR TITLE
Unique check

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1402,6 +1402,7 @@ class SetSchema(TypedDict, total=False):
     items_schema: CoreSchema
     min_length: int
     max_length: int
+    unique: bool
     strict: bool
     ref: str
     metadata: Any
@@ -1413,6 +1414,7 @@ def set_schema(
     *,
     min_length: int | None = None,
     max_length: int | None = None,
+    unique: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -1435,6 +1437,7 @@ def set_schema(
         items_schema: The value must be a set with items that match this schema
         min_length: The value must be a set with at least this many items
         max_length: The value must be a set with at most this many items
+        unique: The value must be a set without any repeated items
         strict: The value must be a set with exactly this many items
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -1445,6 +1448,7 @@ def set_schema(
         items_schema=items_schema,
         min_length=min_length,
         max_length=max_length,
+        unique=unique,
         strict=strict,
         ref=ref,
         metadata=metadata,
@@ -1457,6 +1461,7 @@ class FrozenSetSchema(TypedDict, total=False):
     items_schema: CoreSchema
     min_length: int
     max_length: int
+    unique: bool
     strict: bool
     ref: str
     metadata: Any
@@ -1468,6 +1473,7 @@ def frozenset_schema(
     *,
     min_length: int | None = None,
     max_length: int | None = None,
+    unique: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -1490,6 +1496,7 @@ def frozenset_schema(
         items_schema: The value must be a frozenset with items that match this schema
         min_length: The value must be a frozenset with at least this many items
         max_length: The value must be a frozenset with at most this many items
+        unique: The value must be a frozenset with no repeated items
         strict: The value must be a frozenset with exactly this many items
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -1500,6 +1507,7 @@ def frozenset_schema(
         items_schema=items_schema,
         min_length=min_length,
         max_length=max_length,
+        unique=unique,
         strict=strict,
         ref=ref,
         metadata=metadata,
@@ -3840,6 +3848,7 @@ ErrorType = Literal[
     'finite_number',
     'too_short',
     'too_long',
+    'non_unique',
     'iterable_type',
     'iteration_error',
     'string_type',

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1240,6 +1240,7 @@ class ListSchema(TypedDict, total=False):
     items_schema: CoreSchema
     min_length: int
     max_length: int
+    unique: bool
     strict: bool
     ref: str
     metadata: Any
@@ -1251,6 +1252,7 @@ def list_schema(
     *,
     min_length: int | None = None,
     max_length: int | None = None,
+    unique: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -1271,6 +1273,7 @@ def list_schema(
         items_schema: The value must be a list of items that match this schema
         min_length: The value must be a list with at least this many items
         max_length: The value must be a list with at most this many items
+        unique: The value must be a list without any repeated items
         strict: The value must be a list with exactly this many items
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -1281,6 +1284,7 @@ def list_schema(
         items_schema=items_schema,
         min_length=min_length,
         max_length=max_length,
+        unique=unique,
         strict=strict,
         ref=ref,
         metadata=metadata,
@@ -1292,6 +1296,7 @@ class TuplePositionalSchema(TypedDict, total=False):
     type: Required[Literal['tuple-positional']]
     items_schema: Required[List[CoreSchema]]
     extra_schema: CoreSchema
+    unique: bool
     strict: bool
     ref: str
     metadata: Any
@@ -1301,6 +1306,7 @@ class TuplePositionalSchema(TypedDict, total=False):
 def tuple_positional_schema(
     items_schema: list[CoreSchema],
     *,
+    unique: bool | None = None,
     extra_schema: CoreSchema | None = None,
     strict: bool | None = None,
     ref: str | None = None,
@@ -1322,6 +1328,7 @@ def tuple_positional_schema(
 
     Args:
         items_schema: The value must be a tuple with items that match these schemas
+        unique: The value must be a tuple without any repeated items
         extra_schema: The value must be a tuple with items that match this schema
             This was inspired by JSON schema's `prefixItems` and `items` fields.
             In python's `typing.Tuple`, you can't specify a type for "extra" items -- they must all be the same type
@@ -1334,6 +1341,7 @@ def tuple_positional_schema(
     return _dict_not_none(
         type='tuple-positional',
         items_schema=items_schema,
+        unique=unique,
         extra_schema=extra_schema,
         strict=strict,
         ref=ref,
@@ -1347,6 +1355,7 @@ class TupleVariableSchema(TypedDict, total=False):
     items_schema: CoreSchema
     min_length: int
     max_length: int
+    unique: bool
     strict: bool
     ref: str
     metadata: Any
@@ -1358,6 +1367,7 @@ def tuple_variable_schema(
     *,
     min_length: int | None = None,
     max_length: int | None = None,
+    unique: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -1380,6 +1390,7 @@ def tuple_variable_schema(
         items_schema: The value must be a tuple with items that match this schema
         min_length: The value must be a tuple with at least this many items
         max_length: The value must be a tuple with at most this many items
+        unique: The value must be a tuple without any repeated items
         strict: The value must be a tuple with exactly this many items
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -1390,6 +1401,7 @@ def tuple_variable_schema(
         items_schema=items_schema,
         min_length=min_length,
         max_length=max_length,
+        unique=unique,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -139,6 +139,11 @@ pub enum ErrorType {
         actual_length: usize,
     },
     // ---------------------
+    // generic collection uniqueness error
+    NonUnique {
+        field_type: String,
+    },
+    // ---------------------
     // generic collection and iteration errors
     IterableType,
     IterationError {
@@ -425,6 +430,7 @@ impl ErrorType {
                 max_length: usize,
                 actual_length: usize
             ),
+            Self::NonUnique { .. } => extract_context!(NonUnique, ctx, field_type: String),
             Self::IterationError { .. } => extract_context!(IterationError, ctx, error: String),
             Self::StringTooShort { .. } => extract_context!(StringTooShort, ctx, min_length: usize),
             Self::StringTooLong { .. } => extract_context!(StringTooLong, ctx, max_length: usize),
@@ -502,6 +508,7 @@ impl ErrorType {
             Self::FiniteNumber => "Input should be a finite number",
             Self::TooShort {..} => "{field_type} should have at least {min_length} item{expected_plural} after validation, not {actual_length}",
             Self::TooLong {..} => "{field_type} should have at most {max_length} item{expected_plural} after validation, not {actual_length}",
+            Self::NonUnique {..} => "{field_type} should be unique, but an item appeared more than once",
             Self::IterableType => "Input should be iterable",
             Self::IterationError {..} => "Error iterating over object, error: {error}",
             Self::StringType => "Input should be a valid string",
@@ -647,6 +654,7 @@ impl ErrorType {
                 let expected_plural = plural_s(*max_length);
                 to_string_render!(tmpl, field_type, max_length, actual_length, expected_plural)
             }
+            Self::NonUnique { field_type } => render!(tmpl, field_type),
             Self::IterationError { error } => render!(tmpl, error),
             Self::StringTooShort { min_length } => to_string_render!(tmpl, min_length),
             Self::StringTooLong { max_length } => to_string_render!(tmpl, max_length),
@@ -719,6 +727,7 @@ impl ErrorType {
                 max_length,
                 actual_length,
             } => py_dict!(py, field_type, max_length, actual_length),
+            Self::NonUnique { field_type } => py_dict!(py, field_type),
             Self::IterationError { error } => py_dict!(py, error),
             Self::StringTooShort { min_length } => py_dict!(py, min_length),
             Self::StringTooLong { max_length } => py_dict!(py, max_length),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -18,9 +18,9 @@ pub(crate) use datetime::{
 pub(crate) use input_abstract::{Input, InputType};
 pub(crate) use parse_json::{JsonInput, JsonObject};
 pub(crate) use return_enums::{
-    py_string_str, AttributesGenericIterator, DictGenericIterator, EitherBytes, EitherFloat, EitherInt, EitherString,
-    GenericArguments, GenericIterable, GenericIterator, GenericMapping, Int, JsonArgs, JsonObjectGenericIterator,
-    MappingGenericIterator, PyArgs,
+    py_string_str, unique_check, AttributesGenericIterator, DictGenericIterator, EitherBytes, EitherFloat, EitherInt,
+    EitherString, GenericArguments, GenericIterable, GenericIterator, GenericMapping, Int, JsonArgs,
+    JsonObjectGenericIterator, MappingGenericIterator, PyArgs,
 };
 
 // Defined here as it's not exported by pyo3

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -16,6 +16,7 @@ pub struct FrozenSetValidator {
     item_validator: Box<CombinedValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,
+    unique: bool,
     name: String,
 }
 
@@ -42,6 +43,7 @@ impl Validator for FrozenSetValidator {
             f_set,
             input,
             self.max_length,
+            self.unique,
             "Frozenset",
             &self.item_validator,
             extra,

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -1,8 +1,7 @@
-use ahash::AHashSet;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::errors::{ErrorType, ValError, ValResult};
+use crate::errors::ValResult;
 use crate::input::{unique_check, GenericIterable, Input};
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
@@ -141,7 +140,7 @@ impl Validator for ListValidator {
             None => match seq {
                 GenericIterable::List(list) => {
                     length_check!(input, "List", self.min_length, self.max_length, list);
-                    unique_check!(py, input, "List", self.unique, list, item, item);
+                    unique_check(py, input, "List", self.unique, list, |_, i| i)?;
                     let list_copy = list.get_slice(0, usize::MAX);
                     return Ok(list_copy.into_py(py));
                 }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -15,6 +15,7 @@ pub struct SetValidator {
     item_validator: Box<CombinedValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,
+    unique: bool,
     name: String,
 }
 
@@ -35,13 +36,16 @@ macro_rules! set_build {
                 )?),
             };
             let inner_name = item_validator.get_name();
+            let min_length = schema.get_as(pyo3::intern!(py, "min_length"))?;
             let max_length = schema.get_as(pyo3::intern!(py, "max_length"))?;
+            let unique = schema.get_as(pyo3::intern!(py, "unique"))?.unwrap_or(false);
             let name = format!("{}[{}]", Self::EXPECTED_TYPE, inner_name);
             Ok(Self {
                 strict: crate::build_tools::is_strict(schema, config)?,
                 item_validator,
-                min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
+                min_length,
                 max_length,
+                unique,
                 name,
             }
             .into())
@@ -73,6 +77,7 @@ impl Validator for SetValidator {
             set,
             input,
             self.max_length,
+            self.unique,
             "Set",
             &self.item_validator,
             extra,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -1,4 +1,3 @@
-use ahash::AHashSet;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
@@ -210,7 +209,7 @@ fn validate_tuple_positional<'s, 'data, T: Iterator<Item = PyResult<&'data I>>, 
             }
         }
     }
-    unique_check!(py, input, "Tuple", unique, output);
+    unique_check(py, input, "Tuple", unique, output, |py, i| i.as_ref(py))?;
     Ok(())
 }
 

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -63,7 +63,13 @@ def schema(*, strict: bool = False) -> dict:
                 'field_set_int': {'type': 'model-field', 'schema': {'type': 'set', 'items_schema': {'type': 'int'}}},
                 'field_set_int_con': {
                     'type': 'model-field',
-                    'schema': {'type': 'set', 'items_schema': {'type': 'int'}, 'min_length': 3, 'max_length': 42},
+                    'schema': {
+                        'type': 'set',
+                        'items_schema': {'type': 'int'},
+                        'min_length': 3,
+                        'max_length': 42,
+                        'unique': True,
+                    },
                 },
                 'field_frozenset_any': {'type': 'model-field', 'schema': {'type': 'frozenset'}},
                 'field_frozenset_bytes': {
@@ -77,6 +83,7 @@ def schema(*, strict: bool = False) -> dict:
                         'items_schema': {'type': 'bytes'},
                         'min_length': 3,
                         'max_length': 42,
+                        'unique': True,
                     },
                 },
                 'field_tuple_var_len_any': {'type': 'model-field', 'schema': {'type': 'tuple-variable'}},

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -1,3 +1,6 @@
+import string
+
+
 def schema(*, strict: bool = False) -> dict:
     class MyModel:
         # __slots__ is not required, but it avoids __pydantic_fields_set__ falling into __dict__
@@ -57,7 +60,13 @@ def schema(*, strict: bool = False) -> dict:
                 'field_list_str': {'type': 'model-field', 'schema': {'type': 'list', 'items_schema': {'type': 'str'}}},
                 'field_list_str_con': {
                     'type': 'model-field',
-                    'schema': {'type': 'list', 'items_schema': {'type': 'str'}, 'min_length': 3, 'max_length': 42},
+                    'schema': {
+                        'type': 'list',
+                        'items_schema': {'type': 'str'},
+                        'min_length': 3,
+                        'max_length': 42,
+                        'unique': True,
+                    },
                 },
                 'field_set_any': {'type': 'model-field', 'schema': {'type': 'set'}},
                 'field_set_int': {'type': 'model-field', 'schema': {'type': 'set', 'items_schema': {'type': 'int'}}},
@@ -98,6 +107,7 @@ def schema(*, strict: bool = False) -> dict:
                         'items_schema': {'type': 'float'},
                         'min_length': 3,
                         'max_length': 42,
+                        'unique': True,
                     },
                 },
                 'field_tuple_fix_len': {
@@ -105,6 +115,14 @@ def schema(*, strict: bool = False) -> dict:
                     'schema': {
                         'type': 'tuple-positional',
                         'items_schema': [{'type': 'str'}, {'type': 'int'}, {'type': 'float'}, {'type': 'bool'}],
+                    },
+                },
+                'field_tuple_fix_len_con': {
+                    'type': 'model-field',
+                    'schema': {
+                        'type': 'tuple-positional',
+                        'items_schema': [{'type': 'str'}, {'type': 'int'}, {'type': 'float'}, {'type': 'bool'}],
+                        'unique': True,
                     },
                 },
                 'field_dict_any': {'type': 'model-field', 'schema': {'type': 'dict'}},
@@ -237,7 +255,7 @@ def input_data_lax():
         'field_uuid': '12345678-1234-5678-1234-567812345678',
         'field_list_any': ['a', b'b', True, 1.0, None] * 10,
         'field_list_str': ['a', 'b', 'c'] * 10,
-        'field_list_str_con': ['a', 'b', 'c'] * 10,
+        'field_list_str_con': list(string.ascii_lowercase),
         'field_set_any': {'a', b'b', True, 1.0, None},
         'field_set_int': set(range(100)),
         'field_set_int_con': set(range(42)),
@@ -248,6 +266,7 @@ def input_data_lax():
         'field_tuple_var_len_float': tuple((i + 0.5 for i in range(100))),
         'field_tuple_var_len_float_con': tuple((i + 0.5 for i in range(42))),
         'field_tuple_fix_len': ('a', 1, 1.0, True),
+        'field_tuple_fix_len_con': ('a', 1, 1.1, False),
         'field_dict_any': {'a': 'b', 1: True, 1.0: 1.0},
         'field_dict_str_float': {f'{i}': i + 0.5 for i in range(100)},
         'field_literal_1_int': 1,
@@ -318,6 +337,7 @@ def input_data_wrong():
         'field_tuple_var_len_float': tuple(f'x{i}' for i in range(100)),
         'field_tuple_var_len_float_con': (1.0, 2.0),
         'field_tuple_fix_len': ('a', 1, 1.0, True, 'more'),
+        'field_tuple_fix_len_con': ('a', 1, 1.0, False, 'more'),
         'field_dict_any': {'a', 'b', 1, True, 1.0, 2.0},
         'field_dict_str_float': {(i,): f'x{i}' for i in range(100)},
         'field_literal_1_int': 2,

--- a/tests/benchmarks/test_complete_benchmark.py
+++ b/tests/benchmarks/test_complete_benchmark.py
@@ -2,6 +2,7 @@
 General benchmarks that attempt to cover all field types, through by no means all uses of all field types.
 """
 import json
+import string
 from datetime import date, datetime, time
 from uuid import UUID
 
@@ -18,7 +19,7 @@ def test_complete_valid():
     lax_validator = SchemaValidator(lax_schema)
     output = lax_validator.validate_python(input_data_lax())
     assert isinstance(output, cls)
-    assert len(output.__pydantic_fields_set__) == 40
+    assert len(output.__pydantic_fields_set__) == 41
     output_dict = output.__dict__
     assert output_dict == {
         'field_str': 'fo',
@@ -39,7 +40,7 @@ def test_complete_valid():
         'field_uuid': UUID('12345678-1234-5678-1234-567812345678'),
         'field_list_any': ['a', b'b', True, 1.0, None] * 10,
         'field_list_str': ['a', 'b', 'c'] * 10,
-        'field_list_str_con': ['a', 'b', 'c'] * 10,
+        'field_list_str_con': list(string.ascii_lowercase),
         'field_set_any': {'a', b'b', True, 1.0, None},
         'field_set_int': set(range(100)),
         'field_set_int_con': set(range(42)),
@@ -50,6 +51,7 @@ def test_complete_valid():
         'field_tuple_var_len_float': tuple((i + 0.5 for i in range(100))),
         'field_tuple_var_len_float_con': tuple((i + 0.5 for i in range(42))),
         'field_tuple_fix_len': ('a', 1, 1.0, True),
+        'field_tuple_fix_len_con': ('a', 1, 1.1, False),
         'field_dict_any': {'a': 'b', 1: True, 1.0: 1.0},
         'field_dict_str_float': {f'{i}': i + 0.5 for i in range(100)},
         'field_literal_1_int': 1,
@@ -81,7 +83,7 @@ def test_complete_invalid():
     lax_validator = SchemaValidator(lax_schema)
     with pytest.raises(ValidationError) as exc_info:
         lax_validator.validate_python(input_data_wrong())
-    assert len(exc_info.value.errors(include_url=False)) == 738
+    assert len(exc_info.value.errors(include_url=False)) == 739
 
 
 @pytest.mark.benchmark(group='complete')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -209,6 +209,7 @@ all_errors = [
         'Foobar should have at most 42 items after validation, not 50',
         {'field_type': 'Foobar', 'max_length': 42, 'actual_length': 50},
     ),
+    ('non_unique', 'Foobar should be unique, but an item appeared more than once', {'field_type': 'Foobar'}),
     ('string_type', 'Input should be a valid string', None),
     ('string_sub_type', 'Input should be a string, not an instance of a subclass of str', None),
     ('string_unicode', 'Input should be a valid string, unable to parse raw data as a unicode string', None),

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -163,6 +163,9 @@ def generate_repeats():
             infinite_generator(),
             Err('Frozenset should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
+        ({'unique': False}, [1, 2, 3, 1], {1, 2, 3}),
+        ({'unique': True}, [1, 2, 3], {1, 2, 3}),
+        ({'unique': True}, [1, 2, 3, 1], Err('Frozenset should be unique, but an item appeared more than once')),
     ],
 )
 def test_frozenset_kwargs_python(kwargs: Dict[str, Any], input_value, expected):
@@ -242,12 +245,12 @@ def test_frozenset_as_dict_keys(py_and_json: PyAndJson):
 
 
 def test_repr():
-    v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_length': 42})
+    v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_length': 42, 'unique': True})
     assert plain_repr(v) == (
         'SchemaValidator('
         'title="frozenset[any]",'
         'validator=FrozenSet(FrozenSetValidator{'
-        'strict:true,item_validator:Any(AnyValidator),min_length:Some(42),max_length:None,'
+        'strict:true,item_validator:Any(AnyValidator),min_length:Some(42),max_length:None,unique:true,'
         'name:"frozenset[any]"'
         '}),definitions=[])'
     )

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -162,6 +162,17 @@ def test_list_error(input_value, index):
             infinite_generator(),
             Err('List should have at most 44 items after validation, not 45 [type=too_long,'),
         ),
+        ({'unique': False}, [1, 2, 3, 1], [1, 2, 3, 1]),
+        ({'unique': True}, [1, 2, 3], [1, 2, 3]),
+        ({'unique': True}, (1, 2, 3), [1, 2, 3]),
+        ({'unique': True, 'items_schema': {'type': 'int'}}, [1, 2, 3], [1, 2, 3]),
+        ({'unique': True}, [1, 2, 3, 1], Err('List should be unique, but an item appeared more than once')),
+        ({'unique': True}, (1, 2, 3, 1), Err('List should be unique, but an item appeared more than once')),
+        (
+            {'unique': True, 'items_schema': {'type': 'int'}},
+            [1, 2, 3, 1],
+            Err('List should be unique, but an item appeared more than once'),
+        ),
     ],
 )
 def test_list_length_constraints(kwargs: Dict[str, Any], input_value, expected):

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -143,6 +143,9 @@ def generate_repeats():
             infinite_generator(),
             Err('Set should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
+        ({'unique': False}, [1, 2, 3, 1], {1, 2, 3}),
+        ({'unique': True}, [1, 2, 3], {1, 2, 3}),
+        ({'unique': True}, [1, 2, 3, 1], Err('Set should be unique, but an item appeared more than once')),
     ],
     ids=repr,
 )


### PR DESCRIPTION
## Change Summary

Implements 'unique' validation for `set`, `list`, `tuple-variable` and `tuple-positional`, so something along the lines of `unique_items` in v1 can be implemented again in v2.

Initially I planned to implement this mainly using a `AHashSet`, only resorting to sorting the values for small lists, but it turned out that the sorting ended up more efficient in every single case. Here's a repo where I benchmarked both solutions against a few cases:
https://github.com/rockisch/unique-check-bench

The implementation aggregates values over `__hash__`, and the compares each of them with `__eq__` . This should be fine, given the description of `__hash__` on Python's documentation [[1]](https://docs.python.org/3/reference/datamodel.html#object.__hash__):
> The only required property is that objects which compare equal have the same hash value

Something that I am not currently doing, but could be implemented, is to aggregate all non-hashable values under a single hash (say, `-1`) in the algorithm, so they get compared against all other non-hashable types. This should have little impact on iterator over hashable types (`list[str]`), but would allow iterators over `BaseClass` subclasses to be unique cheked, although in a much less efficient manner. I feel like asking the user to implement `__hash__` themselves is probably the better approach, but it is a possibility.

This is kind of my first contribution to a 'big' open-source project, so let me know if there's anything I missed. Also, not sure if I should already ask for reviewers or wait for someone to take a look at this first.

## Related issue number

fix #296 

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
