### PR TITLE
Add `plugin_settings` to `CoreConfig`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -93,7 +93,7 @@ class CoreConfig(TypedDict, total=False):
     # used to hide input data from ValidationError repr
     hide_input_in_errors: bool
     # used for plugins to add custom settings
-    plugin_settings: dict[str, Any]
+    plugin_settings: Dict[str, Any]
 
 
 IncExCall: TypeAlias = 'set[int | str] | dict[int | str, IncExCall] | None'

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -60,6 +60,7 @@ class CoreConfig(TypedDict, total=False):
         ser_json_timedelta: The serialization option for `timedelta` values. Default is 'iso8601'.
         ser_json_bytes: The serialization option for `bytes` values. Default is 'utf8'.
         hide_input_in_errors: Whether to hide input data from `ValidationError` representation.
+        plugin_settings: Settings for plugins.
     """
 
     title: str
@@ -91,6 +92,8 @@ class CoreConfig(TypedDict, total=False):
     ser_json_bytes: Literal['utf8', 'base64']  # default: 'utf8'
     # used to hide input data from ValidationError repr
     hide_input_in_errors: bool
+    # used for plugins to add custom settings
+    plugin_settings: dict[str, Any]
 
 
 IncExCall: TypeAlias = 'set[int | str] | dict[int | str, IncExCall] | None'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

This PR adds a new keyword to `CoreConfig`, which will be used for plugins to configure their behavior.

## Related issue number

- Related to https://github.com/pydantic/pydantic/issues/6765

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt