### PR TITLE
Add `_ignored` argument to `SchemaValidator`

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -79,7 +79,7 @@ class SchemaValidator:
     `CombinedValidator` which may in turn own more `CombinedValidator`s which make up the full schema validator.
     """
 
-    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None) -> Self:
+    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None, _ignored: Any = None) -> Self:
         """
         Create a new SchemaValidator.
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -36,7 +36,7 @@ impl PyUrl {
 fn build_schema_validator(py: Python, schema_type: &str) -> SchemaValidator {
     let schema: &PyDict = PyDict::new(py);
     schema.set_item("type", schema_type).unwrap();
-    SchemaValidator::py_new(py, schema, None).unwrap()
+    SchemaValidator::py_new(py, schema, None, None).unwrap()
 }
 
 #[pymethods]

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -104,7 +104,6 @@ pub struct SchemaValidator {
     #[pyo3(get)]
     title: PyObject,
     hide_input_in_errors: bool,
-    _ignored: PyObject,
 }
 
 #[pymethods]
@@ -137,7 +136,6 @@ impl SchemaValidator {
             schema: schema.into_py(py),
             title,
             hide_input_in_errors,
-            _ignored: _ignored.into_py(py),
         })
     }
 
@@ -374,7 +372,6 @@ impl<'py> SelfValidator<'py> {
             schema: py.None(),
             title: "Self Schema".into_py(py),
             hide_input_in_errors: false,
-            _ignored: py.None(),
         })
     }
 }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -104,12 +104,13 @@ pub struct SchemaValidator {
     #[pyo3(get)]
     title: PyObject,
     hide_input_in_errors: bool,
+    _ignored: PyObject,
 }
 
 #[pymethods]
 impl SchemaValidator {
     #[new]
-    pub fn py_new(py: Python, schema: &PyAny, config: Option<&PyDict>) -> PyResult<Self> {
+    pub fn py_new(py: Python, schema: &PyAny, config: Option<&PyDict>, _ignored: Option<&PyAny>) -> PyResult<Self> {
         let self_validator = SelfValidator::new(py)?;
         let schema = self_validator.validate_schema(py, schema)?;
 
@@ -136,6 +137,7 @@ impl SchemaValidator {
             schema: schema.into_py(py),
             title,
             hide_input_in_errors,
+            _ignored: _ignored.into_py(py),
         })
     }
 
@@ -372,6 +374,7 @@ impl<'py> SelfValidator<'py> {
             schema: py.None(),
             title: "Self Schema".into_py(py),
             hide_input_in_errors: false,
+            _ignored: py.None(),
         })
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

This PR adds a new `_ignored` keyword argument to the `SchemaValidator`. The goal is to have a key that is going to be ignored, and it will allow compatibility with the logic implemented in https://github.com/pydantic/pydantic/pull/6820/.

## Related issue number

- Related to https://github.com/pydantic/pydantic/pull/6820/

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
