### PR TITLE
Allow ordering of constraints

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -134,6 +134,8 @@ def type_dict_schema(typed_dict) -> dict[str, Any]:  # noqa: C901
                 else:
                     raise ValueError(f'Unknown Schema forward ref: {fr_arg}')
             else:
+                if field_type.__forward_arg__ == 'SupportsRichComparison':
+                    return {'type': 'any'}
                 field_type = eval_forward_ref(field_type)
 
         if schema is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ features = ["pyo3/extension-module"]
 [tool.ruff]
 line-length = 120
 extend-select = ['Q', 'RUF100', 'C90', 'I']
+ignore = ['E501']
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 mccabe = { max-complexity = 13 }
 isort = { known-first-party = ['pydantic_core', 'tests'] }

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -129,12 +129,10 @@ pub enum ErrorType {
     // ---------------------
     // generic length errors - used for everything with a length except strings and bytes which need custom messages
     TooShort {
-        field_type: String,
         min_length: usize,
         actual_length: usize,
     },
     TooLong {
-        field_type: String,
         max_length: usize,
         actual_length: usize,
     },
@@ -414,14 +412,12 @@ impl ErrorType {
             Self::TooShort { .. } => extract_context!(
                 TooShort,
                 ctx,
-                field_type: String,
                 min_length: usize,
                 actual_length: usize
             ),
             Self::TooLong { .. } => extract_context!(
                 TooLong,
                 ctx,
-                field_type: String,
                 max_length: usize,
                 actual_length: usize
             ),
@@ -479,8 +475,8 @@ impl ErrorType {
 
     pub fn message_template_python(&self) -> &'static str {
         match self {
-            Self::NoSuchAttribute {..} => "Object has no attribute '{attribute}'",
-            Self::JsonInvalid {..} => "Invalid JSON: {error}",
+            Self::NoSuchAttribute { .. } => "Object has no attribute '{attribute}'",
+            Self::JsonInvalid { .. } => "Invalid JSON: {error}",
             Self::JsonType => "JSON input should be string, bytes or bytearray",
             Self::RecursionLoop => "Recursion error - cyclic reference detected",
             Self::Missing => "Field required",
@@ -488,31 +484,35 @@ impl ErrorType {
             Self::FrozenInstance => "Instance is frozen",
             Self::ExtraForbidden => "Extra inputs are not permitted",
             Self::InvalidKey => "Keys should be strings",
-            Self::GetAttributeError {..} => "Error extracting attribute: {error}",
-            Self::ModelType {..} => "Input should be a valid dictionary or instance of {class_name}",
+            Self::GetAttributeError { .. } => "Error extracting attribute: {error}",
+            Self::ModelType { .. } => "Input should be a valid dictionary or instance of {class_name}",
             Self::ModelAttributesType => "Input should be a valid dictionary or object to extract fields from",
-            Self::DataclassType {..} => "Input should be a dictionary or an instance of {class_name}",
-            Self::DataclassExactType {..} => "Input should be an instance of {class_name}",
+            Self::DataclassType { .. } => "Input should be a dictionary or an instance of {class_name}",
+            Self::DataclassExactType { .. } => "Input should be an instance of {class_name}",
             Self::NoneRequired => "Input should be None",
-            Self::GreaterThan {..} => "Input should be greater than {gt}",
-            Self::GreaterThanEqual {..} => "Input should be greater than or equal to {ge}",
-            Self::LessThan {..} => "Input should be less than {lt}",
-            Self::LessThanEqual {..} => "Input should be less than or equal to {le}",
-            Self::MultipleOf {..} => "Input should be a multiple of {multiple_of}",
+            Self::GreaterThan { .. } => "Input should be greater than {gt}",
+            Self::GreaterThanEqual { .. } => "Input should be greater than or equal to {ge}",
+            Self::LessThan { .. } => "Input should be less than {lt}",
+            Self::LessThanEqual { .. } => "Input should be less than or equal to {le}",
+            Self::MultipleOf { .. } => "Input should be a multiple of {multiple_of}",
             Self::FiniteNumber => "Input should be a finite number",
-            Self::TooShort {..} => "{field_type} should have at least {min_length} item{expected_plural} after validation, not {actual_length}",
-            Self::TooLong {..} => "{field_type} should have at most {max_length} item{expected_plural} after validation, not {actual_length}",
+            Self::TooShort { .. } => {
+                "Data should have at least {min_length} item{expected_plural} after validation, not {actual_length}"
+            }
+            Self::TooLong { .. } => {
+                "Data should have at most {max_length} item{expected_plural} after validation, not {actual_length}"
+            }
             Self::IterableType => "Input should be iterable",
-            Self::IterationError {..} => "Error iterating over object, error: {error}",
+            Self::IterationError { .. } => "Error iterating over object, error: {error}",
             Self::StringType => "Input should be a valid string",
             Self::StringSubType => "Input should be a string, not an instance of a subclass of str",
             Self::StringUnicode => "Input should be a valid string, unable to parse raw data as a unicode string",
-            Self::StringTooShort {..} => "String should have at least {min_length} characters",
-            Self::StringTooLong {..} => "String should have at most {max_length} characters",
-            Self::StringPatternMismatch {..} => "String should match pattern '{pattern}'",
-            Self::Enum {..} => "Input should be {expected}",
+            Self::StringTooShort { .. } => "String should have at least {min_length} characters",
+            Self::StringTooLong { .. } => "String should have at most {max_length} characters",
+            Self::StringPatternMismatch { .. } => "String should match pattern '{pattern}'",
+            Self::Enum { .. } => "Input should be {expected}",
             Self::DictType => "Input should be a valid dictionary",
-            Self::MappingType {..} => "Input should be a valid mapping, error: {error}",
+            Self::MappingType { .. } => "Input should be a valid mapping, error: {error}",
             Self::ListType => "Input should be a valid list",
             Self::TupleType => "Input should be a valid tuple",
             Self::SetType => "Input should be a valid set",
@@ -525,36 +525,38 @@ impl ErrorType {
             Self::FloatType => "Input should be a valid number",
             Self::FloatParsing => "Input should be a valid number, unable to parse string as a number",
             Self::BytesType => "Input should be a valid bytes",
-            Self::BytesTooShort {..} => "Data should have at least {min_length} bytes",
-            Self::BytesTooLong {..} => "Data should have at most {max_length} bytes",
-            Self::ValueError {..} => "Value error, {error}",
-            Self::AssertionError {..} => "Assertion failed, {error}",
-            Self::CustomError {..} => "",  // custom errors are handled separately
-            Self::LiteralError {..} => "Input should be {expected}",
+            Self::BytesTooShort { .. } => "Data should have at least {min_length} bytes",
+            Self::BytesTooLong { .. } => "Data should have at most {max_length} bytes",
+            Self::ValueError { .. } => "Value error, {error}",
+            Self::AssertionError { .. } => "Assertion failed, {error}",
+            Self::CustomError { .. } => "", // custom errors are handled separately
+            Self::LiteralError { .. } => "Input should be {expected}",
             Self::DateType => "Input should be a valid date",
-            Self::DateParsing {..} => "Input should be a valid date in the format YYYY-MM-DD, {error}",
-            Self::DateFromDatetimeParsing {..} => "Input should be a valid date or datetime, {error}",
+            Self::DateParsing { .. } => "Input should be a valid date in the format YYYY-MM-DD, {error}",
+            Self::DateFromDatetimeParsing { .. } => "Input should be a valid date or datetime, {error}",
             Self::DateFromDatetimeInexact => "Datetimes provided to dates should have zero time - e.g. be exact dates",
             Self::DatePast => "Date should be in the past",
             Self::DateFuture => "Date should be in the future",
             Self::TimeType => "Input should be a valid time",
-            Self::TimeParsing {..} => "Input should be in a valid time format, {error}",
+            Self::TimeParsing { .. } => "Input should be in a valid time format, {error}",
             Self::DatetimeType => "Input should be a valid datetime",
-            Self::DatetimeParsing {..} => "Input should be a valid datetime, {error}",
-            Self::DatetimeObjectInvalid {..} => "Invalid datetime object, got {error}",
+            Self::DatetimeParsing { .. } => "Input should be a valid datetime, {error}",
+            Self::DatetimeObjectInvalid { .. } => "Invalid datetime object, got {error}",
             Self::DatetimePast => "Input should be in the past",
             Self::DatetimeFuture => "Input should be in the future",
             Self::TimezoneNaive => "Input should not have timezone info",
             Self::TimezoneAware => "Input should have timezone info",
-            Self::TimezoneOffset {..} => "Timezone offset of {tz_expected} required, got {tz_actual}",
+            Self::TimezoneOffset { .. } => "Timezone offset of {tz_expected} required, got {tz_actual}",
             Self::TimeDeltaType => "Input should be a valid timedelta",
-            Self::TimeDeltaParsing {..} => "Input should be a valid timedelta, {error}",
+            Self::TimeDeltaParsing { .. } => "Input should be a valid timedelta, {error}",
             Self::FrozenSetType => "Input should be a valid frozenset",
-            Self::IsInstanceOf {..} => "Input should be an instance of {class}",
-            Self::IsSubclassOf {..} => "Input should be a subclass of {class}",
+            Self::IsInstanceOf { .. } => "Input should be an instance of {class}",
+            Self::IsSubclassOf { .. } => "Input should be a subclass of {class}",
             Self::CallableType => "Input should be callable",
-            Self::UnionTagInvalid {..} => "Input tag '{tag}' found using {discriminator} does not match any of the expected tags: {expected_tags}",
-            Self::UnionTagNotFound {..} => "Unable to extract tag using discriminator {discriminator}",
+            Self::UnionTagInvalid { .. } => {
+                "Input tag '{tag}' found using {discriminator} does not match any of the expected tags: {expected_tags}"
+            }
+            Self::UnionTagNotFound { .. } => "Unable to extract tag using discriminator {discriminator}",
             Self::ArgumentsType => "Arguments must be a tuple, list or a dictionary",
             Self::MissingArgument => "Missing required argument",
             Self::UnexpectedKeywordArgument => "Unexpected keyword argument",
@@ -563,14 +565,13 @@ impl ErrorType {
             Self::MissingPositionalOnlyArgument => "Missing required positional only argument",
             Self::MultipleArgumentValues => "Got multiple values for argument",
             Self::UrlType => "URL input should be a string or URL",
-            Self::UrlParsing {..} => "Input should be a valid URL, {error}",
-            Self::UrlSyntaxViolation {..} => "Input violated strict URL syntax rules, {error}",
-            Self::UrlTooLong {..} => "URL should have at most {max_length} characters",
-            Self::UrlScheme {..} => "URL scheme should be {expected_schemes}",
+            Self::UrlParsing { .. } => "Input should be a valid URL, {error}",
+            Self::UrlSyntaxViolation { .. } => "Input violated strict URL syntax rules, {error}",
+            Self::UrlTooLong { .. } => "URL should have at most {max_length} characters",
+            Self::UrlScheme { .. } => "URL scheme should be {expected_schemes}",
             Self::UuidType => "UUID input should be a string, bytes or UUID object",
             Self::UuidParsing { .. } => "Input should be a valid UUID, {error}",
-            Self::UuidVersion { .. } => "UUID version {expected_version} expected"
-
+            Self::UuidVersion { .. } => "UUID version {expected_version} expected",
         }
     }
 
@@ -632,20 +633,18 @@ impl ErrorType {
             Self::LessThanEqual { le } => to_string_render!(tmpl, le),
             Self::MultipleOf { multiple_of } => to_string_render!(tmpl, multiple_of),
             Self::TooShort {
-                field_type,
                 min_length,
                 actual_length,
             } => {
                 let expected_plural = plural_s(*min_length);
-                to_string_render!(tmpl, field_type, min_length, actual_length, expected_plural)
+                to_string_render!(tmpl, min_length, actual_length, expected_plural)
             }
             Self::TooLong {
-                field_type,
                 max_length,
                 actual_length,
             } => {
                 let expected_plural = plural_s(*max_length);
-                to_string_render!(tmpl, field_type, max_length, actual_length, expected_plural)
+                to_string_render!(tmpl, max_length, actual_length, expected_plural)
             }
             Self::IterationError { error } => render!(tmpl, error),
             Self::StringTooShort { min_length } => to_string_render!(tmpl, min_length),
@@ -710,15 +709,13 @@ impl ErrorType {
             Self::LessThanEqual { le } => py_dict!(py, le),
             Self::MultipleOf { multiple_of } => py_dict!(py, multiple_of),
             Self::TooShort {
-                field_type,
                 min_length,
                 actual_length,
-            } => py_dict!(py, field_type, min_length, actual_length),
+            } => py_dict!(py, min_length, actual_length),
             Self::TooLong {
-                field_type,
                 max_length,
                 actual_length,
-            } => py_dict!(py, field_type, max_length, actual_length),
+            } => py_dict!(py, max_length, actual_length),
             Self::IterationError { error } => py_dict!(py, error),
             Self::StringTooShort { min_length } => py_dict!(py, min_length),
             Self::StringTooLong { max_length } => py_dict!(py, max_length),

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -306,4 +306,5 @@ pub trait Input<'a>: fmt::Debug + ToPyObject {
     ) -> ValResult<EitherTimedelta> {
         self.strict_timedelta(microseconds_overflow_behavior)
     }
+    fn len(&self, py: Python<'_>) -> PyResult<usize>;
 }

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -334,6 +334,13 @@ impl<'a> Input<'a> for JsonInput {
             _ => Err(ValError::new(ErrorType::TimeDeltaType, self)),
         }
     }
+
+    fn len(&self, py: Python<'_>) -> PyResult<usize> {
+        match self.len() {
+            Some(len) => Ok(len),
+            None => self.to_object(py).as_ref(py).len(),
+        }
+    }
 }
 
 /// Required for Dict keys so the string can behave like an Input
@@ -521,6 +528,10 @@ impl<'a> Input<'a> for String {
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
     ) -> ValResult<EitherTimedelta> {
         self.validate_timedelta(false, microseconds_overflow_behavior)
+    }
+
+    fn len(&self, _py: Python<'_>) -> PyResult<usize> {
+        Ok(self.len())
     }
 }
 

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -646,6 +646,10 @@ impl<'a> Input<'a> for PyAny {
             Err(ValError::new(ErrorType::TimeDeltaType, self))
         }
     }
+
+    fn len(&self, _py: Python) -> PyResult<usize> {
+        self.len()
+    }
 }
 
 /// Best effort check of whether it's likely to make sense to inspect obj for attributes and iterate over it

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -12,8 +12,8 @@ mod shared;
 
 pub use datetime::TzInfo;
 pub(crate) use datetime::{
-    duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, pytimedelta_as_duration,
-    EitherDate, EitherDateTime, EitherTime, EitherTimedelta,
+    pydate_as_date, pydatetime_as_datetime, pytime_as_time, pytimedelta_as_duration, EitherDate, EitherDateTime,
+    EitherTime, EitherTimedelta,
 };
 pub(crate) use input_abstract::{Input, InputType};
 pub(crate) use parse_json::{JsonInput, JsonObject};

--- a/src/input/parse_json.rs
+++ b/src/input/parse_json.rs
@@ -218,3 +218,14 @@ impl<'de> Visitor<'de> for KeyDeserializer {
         unreachable!()
     }
 }
+
+impl JsonInput {
+    pub fn len(&self) -> Option<usize> {
+        match self {
+            Self::Array(v) => Some(v.len()),
+            Self::Object(o) => Some(o.len()),
+            Self::String(s) => Some(s.len()),
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod lookup_key;
 mod recursion_guard;
 mod serializers;
 mod tools;
+// mod types;
 mod url;
 mod validators;
 

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -1,14 +1,13 @@
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
-use crate::errors::{ErrorType, ValError, ValResult};
+use crate::errors::ValResult;
 use crate::input::Input;
 
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
+use super::constraints::LengthConstraint;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
@@ -24,17 +23,10 @@ impl BuildValidator for BytesValidator {
         config: Option<&PyDict>,
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        let use_constrained = schema.get_item(intern!(py, "max_length")).is_some()
-            || schema.get_item(intern!(py, "min_length")).is_some();
-        if use_constrained {
-            BytesConstrainedValidator::build(schema, config)
-        } else {
-            Ok(Self {
-                strict: is_strict(schema, config)?,
-            }
-            .into())
-        }
+        let validator = Self {
+            strict: is_strict(schema, config)?,
+        };
+        LengthConstraint::maybe_wrap(schema, validator.into())
     }
 }
 
@@ -67,69 +59,5 @@ impl Validator for BytesValidator {
 
     fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BytesConstrainedValidator {
-    strict: bool,
-    max_length: Option<usize>,
-    min_length: Option<usize>,
-}
-
-impl_py_gc_traverse!(BytesConstrainedValidator {});
-
-impl Validator for BytesConstrainedValidator {
-    fn validate<'s, 'data>(
-        &'s self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
-        let either_bytes = input.validate_bytes(extra.strict.unwrap_or(self.strict))?;
-        let len = either_bytes.len()?;
-
-        if let Some(min_length) = self.min_length {
-            if len < min_length {
-                return Err(ValError::new(ErrorType::BytesTooShort { min_length }, input));
-            }
-        }
-        if let Some(max_length) = self.max_length {
-            if len > max_length {
-                return Err(ValError::new(ErrorType::BytesTooLong { max_length }, input));
-            }
-        }
-
-        Ok(either_bytes.into_py(py))
-    }
-
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        !ultra_strict
-    }
-
-    fn get_name(&self) -> &str {
-        "constrained-bytes"
-    }
-
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        Ok(())
-    }
-}
-
-impl BytesConstrainedValidator {
-    fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        Ok(Self {
-            strict: is_strict(schema, config)?,
-            min_length: schema.get_as(intern!(py, "min_length"))?,
-            max_length: schema.get_as(intern!(py, "max_length"))?,
-        }
-        .into())
     }
 }

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -7,7 +7,6 @@ use crate::input::Input;
 
 use crate::recursion_guard::RecursionGuard;
 
-use super::constraints::LengthConstraint;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
@@ -23,10 +22,10 @@ impl BuildValidator for BytesValidator {
         config: Option<&PyDict>,
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let validator = Self {
+        Ok(Self {
             strict: is_strict(schema, config)?,
-        };
-        LengthConstraint::maybe_wrap(schema, validator.into())
+        }
+        .into())
     }
 }
 

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -16,6 +16,12 @@ pub struct ChainValidator {
     name: String,
 }
 
+impl ChainValidator {
+    pub fn new(steps: Vec<CombinedValidator>, name: String) -> Self {
+        Self { steps, name }
+    }
+}
+
 impl BuildValidator for ChainValidator {
     const EXPECTED_TYPE: &'static str = "chain";
 

--- a/src/validators/constraints.rs
+++ b/src/validators/constraints.rs
@@ -1,40 +1,42 @@
-use pyo3::prelude::*;
+use pyo3::pyclass::CompareOp;
+use pyo3::{intern, prelude::*};
 
 use pyo3::types::PyDict;
 
+use crate::SchemaError;
 use crate::errors::ValResult;
 use crate::input::Input;
+use crate::py_gc::PyGcTraverse;
 use crate::tools::SchemaDict;
 
 use crate::recursion_guard::RecursionGuard;
 
-use super::chain::ChainValidator;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
-pub struct LengthConstraint {
-    min_length: Option<usize>,
-    max_length: Option<usize>,
+pub enum Constraint {
+    // TODO: optimize these with an EitherInt like thing
+    MinLength(usize),
+    MaxLength(usize),
+    GreaterThan(PyObject),
+    GreaterThanOrEqual(PyObject),
+    LessThan(PyObject),
+    LessThanOrEqual(PyObject),
+    MultipleOf(PyObject),
+    Pattern {
+        match_func: PyObject,
+        original_pattern: String,
+    },
+    // An arbitrary Python callable that accepts
+    // a PyAny and returns a bool or errors
+    Unknown {
+        function: PyObject,
+        error: PyObject,
+    },
 }
 
-impl LengthConstraint {
-    pub fn maybe_wrap(schema: &PyDict, validator: CombinedValidator) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        let min_length: Option<usize> = schema.get_as(pyo3::intern!(py, "min_length"))?;
-        let max_length: Option<usize> = schema.get_as(pyo3::intern!(py, "max_length"))?;
-        match min_length.or(max_length) {
-            Some(_) => Ok(ChainValidator::new(
-                vec![validator, Self { min_length, max_length }.into()],
-                "length_constraint".to_string(),
-            )
-            .into()),
-            None => Ok(validator),
-        }
-    }
-}
-
-impl BuildValidator for LengthConstraint {
-    const EXPECTED_TYPE: &'static str = "bool";
+impl BuildValidator for Constraint {
+    const EXPECTED_TYPE: &'static str = "constraint";
 
     fn build(
         schema: &PyDict,
@@ -42,16 +44,44 @@ impl BuildValidator for LengthConstraint {
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        Ok(CombinedValidator::LengthConstraint(Self {
-            min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
-            max_length: schema.get_as(pyo3::intern!(py, "max_length"))?,
-        }))
+        let constraint: &PyDict = schema.get_as_req(intern!(py, "constraint"))?;
+        match constraint.get_as_req::<&str>(intern!(py, "type"))? {
+            "min-length" => Ok(Constraint::MinLength(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "max-length" => Ok(Constraint::MaxLength(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "gt" => Ok(Constraint::GreaterThan(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "ge" => Ok(Constraint::GreaterThanOrEqual(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "lt" => Ok(Constraint::LessThan(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "le" => Ok(Constraint::LessThanOrEqual(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "multiple-of" => Ok(Constraint::MultipleOf(constraint.get_as_req(intern!(py, "value"))?).into()),
+            "pattern" => {
+                let pattern = constraint.get_as_req::<&str>(intern!(py, "value"))?;
+                let regex_mod = py.import("re")?;
+                let match_func = regex_mod
+                    .getattr(intern!(py, "compile"))?
+                    .call1((pattern,))?
+                    .to_object(py)
+                    .getattr(py, intern!(py, "match"))?;
+                Ok(Constraint::Pattern {
+                    match_func,
+                    original_pattern: pattern.to_string(),
+                }
+                .into())
+            }
+            other => Err(
+                SchemaError::new_err(format!("Unknown constraint type: {}", other)),
+            )
+        }
     }
 }
 
-impl_py_gc_traverse!(LengthConstraint {});
+fn py_obj_multiple_of(py: Python<'_>, multiple_of: &PyObject, value: &PyAny) -> PyResult<bool> {
+    Ok(value
+        .call_method1(intern!(py, "__mod__"), (multiple_of,))?
+        .extract::<i64>()?
+        == 0)
+}
 
-impl Validator for LengthConstraint {
+impl Validator for Constraint {
     fn validate<'s, 'data>(
         &'s self,
         py: Python<'data>,
@@ -60,57 +90,170 @@ impl Validator for LengthConstraint {
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
-        let mut len: Option<usize> = None;
-        if let Some(min_length) = self.min_length {
-            let len = match len {
-                Some(l) => l,
-                None => {
-                    let l = input.len(py)?;
-                    len = Some(l);
-                    l
+        match self {
+            Constraint::MinLength(min_length) => {
+                let len = input.to_object(py).as_ref(py).len()?;
+                match len < *min_length {
+                    true => Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::TooShort {
+                            min_length: *min_length,
+                            actual_length: len,
+                        },
+                        input,
+                    )),
+                    false => Ok(input.to_object(py)),
                 }
-            };
-            if len < min_length {
-                return Err(crate::errors::ValError::new(
-                    crate::errors::ErrorType::TooShort {
-                        min_length,
-                        actual_length: len,
-                    },
-                    input,
-                ));
+            }
+            Constraint::MaxLength(max_length) => {
+                let len = input.to_object(py).as_ref(py).len()?;
+                match len > *max_length {
+                    true => Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::TooLong {
+                            max_length: *max_length,
+                            actual_length: len,
+                        },
+                        input,
+                    )),
+                    false => Ok(input.to_object(py)),
+                }
+            }
+            Constraint::GreaterThan(gt) => {
+                if input
+                    .to_object(py)
+                    .as_ref(py)
+                    .rich_compare(gt.as_ref(py), CompareOp::Gt)?
+                    .is_true()?
+                {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::GreaterThan { gt: gt.extract(py)? },
+                        input,
+                    ))
+                }
+            }
+            Constraint::GreaterThanOrEqual(ge) => {
+                if input
+                    .to_object(py)
+                    .as_ref(py)
+                    .rich_compare(ge.as_ref(py), CompareOp::Ge)?
+                    .is_true()?
+                {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::GreaterThanEqual { ge: ge.extract(py)? },
+                        input,
+                    ))
+                }
+            }
+            Constraint::LessThan(lt) => {
+                if input
+                    .to_object(py)
+                    .as_ref(py)
+                    .rich_compare(lt.as_ref(py), CompareOp::Lt)?
+                    .is_true()?
+                {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::LessThan { lt: lt.extract(py)? },
+                        input,
+                    ))
+                }
+            }
+            Constraint::LessThanOrEqual(le) => {
+                if input
+                    .to_object(py)
+                    .as_ref(py)
+                    .rich_compare(le.as_ref(py), CompareOp::Le)?
+                    .is_true()?
+                {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::LessThanEqual { le: le.extract(py)? },
+                        input,
+                    ))
+                }
+            }
+            Constraint::MultipleOf(multiple_of) => {
+                if py_obj_multiple_of(py, multiple_of, input.to_object(py).as_ref(py))? {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::MultipleOf {
+                            multiple_of: multiple_of.extract(py)?,
+                        },
+                        input,
+                    ))
+                }
+            }
+            Constraint::Pattern {
+                match_func,
+                original_pattern,
+            } => {
+                let pattern = match_func.call1(py, (input.to_object(py),))?.is_true(py)?;
+                if pattern {
+                    Ok(input.to_object(py))
+                } else {
+                    Err(crate::errors::ValError::new(
+                        crate::errors::ErrorType::StringPatternMismatch {
+                            pattern: original_pattern.clone(),
+                        },
+                        input,
+                    ))
+                }
+            }
+            Constraint::Unknown { function, error: _ } => {
+                let result = function.call1(py, (input.to_object(py),))?;
+                if result.is_true(py)? {
+                    Ok(input.to_object(py))
+                } else {
+                    todo!() // return a ValueError with the given error as a line error
+                }
             }
         }
-        if let Some(max_length) = self.max_length {
-            let len = match len {
-                Some(l) => l,
-                None => input.to_object(py).as_ref(py).len()?,
-            };
-            if len > max_length {
-                return Err(crate::errors::ValError::new(
-                    crate::errors::ErrorType::TooLong {
-                        max_length,
-                        actual_length: len,
-                    },
-                    input,
-                ));
-            }
-        }
-        Ok(input.to_object(py))
+    }
+
+    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+        Ok(())
     }
 
     fn different_strict_behavior(
         &self,
         _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
+        _ultra_strict: bool,
     ) -> bool {
-        !ultra_strict
+        false
     }
 
     fn get_name(&self) -> &str {
-        Self::EXPECTED_TYPE
+        match self {
+            Constraint::MinLength(_) => "min_length",
+            Constraint::MaxLength(_) => "max_length",
+            Constraint::GreaterThan(_) => "greater_than",
+            Constraint::GreaterThanOrEqual(_) => "greater_than_or_equal",
+            Constraint::LessThan(_) => "less_than",
+            Constraint::LessThanOrEqual(_) => "less_than_or_equal",
+            Constraint::MultipleOf(_) => "multiple_of",
+            Constraint::Pattern { .. } => "pattern",
+            Constraint::Unknown { .. } => "constraint",
+        }
     }
+}
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        Ok(())
+impl PyGcTraverse for Constraint {
+    fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+        match self {
+            Constraint::GreaterThan(obj) => visit.call(obj),
+            Constraint::GreaterThanOrEqual(obj) => visit.call(obj),
+            Constraint::LessThan(obj) => visit.call(obj),
+            Constraint::LessThanOrEqual(obj) => visit.call(obj),
+            Constraint::MultipleOf(obj) => visit.call(obj),
+            Constraint::Pattern { match_func, .. } => visit.call(match_func),
+            Constraint::Unknown { function, .. } => visit.call(function),
+            _ => Ok(()),
+        }
     }
 }

--- a/src/validators/constraints.rs
+++ b/src/validators/constraints.rs
@@ -1,0 +1,116 @@
+use pyo3::prelude::*;
+
+use pyo3::types::PyDict;
+
+use crate::errors::ValResult;
+use crate::input::Input;
+use crate::tools::SchemaDict;
+
+use crate::recursion_guard::RecursionGuard;
+
+use super::chain::ChainValidator;
+use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+
+#[derive(Debug, Clone)]
+pub struct LengthConstraint {
+    min_length: Option<usize>,
+    max_length: Option<usize>,
+}
+
+impl LengthConstraint {
+    pub fn maybe_wrap(schema: &PyDict, validator: CombinedValidator) -> PyResult<CombinedValidator> {
+        let py = schema.py();
+        let min_length: Option<usize> = schema.get_as(pyo3::intern!(py, "min_length"))?;
+        let max_length: Option<usize> = schema.get_as(pyo3::intern!(py, "max_length"))?;
+        match min_length.or(max_length) {
+            Some(_) => Ok(ChainValidator::new(
+                vec![validator, Self { min_length, max_length }.into()],
+                "length_constraint".to_string(),
+            )
+            .into()),
+            None => Ok(validator),
+        }
+    }
+}
+
+impl BuildValidator for LengthConstraint {
+    const EXPECTED_TYPE: &'static str = "bool";
+
+    fn build(
+        schema: &PyDict,
+        _config: Option<&PyDict>,
+        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
+    ) -> PyResult<CombinedValidator> {
+        let py = schema.py();
+        Ok(CombinedValidator::LengthConstraint(Self {
+            min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
+            max_length: schema.get_as(pyo3::intern!(py, "max_length"))?,
+        }))
+    }
+}
+
+impl_py_gc_traverse!(LengthConstraint {});
+
+impl Validator for LengthConstraint {
+    fn validate<'s, 'data>(
+        &'s self,
+        py: Python<'data>,
+        input: &'data impl Input<'data>,
+        _extra: &Extra,
+        _definitions: &'data Definitions<CombinedValidator>,
+        _recursion_guard: &'s mut RecursionGuard,
+    ) -> ValResult<'data, PyObject> {
+        let mut len: Option<usize> = None;
+        if let Some(min_length) = self.min_length {
+            let len = match len {
+                Some(l) => l,
+                None => {
+                    let l = input.len(py)?;
+                    len = Some(l);
+                    l
+                }
+            };
+            if len < min_length {
+                return Err(crate::errors::ValError::new(
+                    crate::errors::ErrorType::TooShort {
+                        min_length,
+                        actual_length: len,
+                    },
+                    input,
+                ));
+            }
+        }
+        if let Some(max_length) = self.max_length {
+            let len = match len {
+                Some(l) => l,
+                None => input.to_object(py).as_ref(py).len()?,
+            };
+            if len > max_length {
+                return Err(crate::errors::ValError::new(
+                    crate::errors::ErrorType::TooLong {
+                        max_length,
+                        actual_length: len,
+                    },
+                    input,
+                ));
+            }
+        }
+        Ok(input.to_object(py))
+    }
+
+    fn different_strict_behavior(
+        &self,
+        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
+        ultra_strict: bool,
+    ) -> bool {
+        !ultra_strict
+    }
+
+    fn get_name(&self) -> &str {
+        Self::EXPECTED_TYPE
+    }
+
+    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+        Ok(())
+    }
+}

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -78,25 +78,6 @@ impl Validator for DateTimeValidator {
                     return Err(ValError::new(ErrorType::DatetimeObjectInvalid { error }, input));
                 }
             };
-            macro_rules! check_constraint {
-                ($constraint:ident, $error:ident) => {
-                    if let Some(constraint) = &constraints.$constraint {
-                        if !speedate_dt.$constraint(constraint) {
-                            return Err(ValError::new(
-                                ErrorType::$error {
-                                    $constraint: constraint.to_string().into(),
-                                },
-                                input,
-                            ));
-                        }
-                    }
-                };
-            }
-
-            check_constraint!(le, LessThanEqual);
-            check_constraint!(lt, LessThan);
-            check_constraint!(ge, GreaterThanEqual);
-            check_constraint!(gt, GreaterThan);
 
             if let Some(ref now_constraint) = constraints.now {
                 let offset = now_constraint.utc_offset(py)?;

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -11,7 +11,6 @@ use crate::input::{
 use crate::recursion_guard::RecursionGuard;
 
 use super::any::AnyValidator;
-use super::constraints::LengthConstraint;
 
 use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -46,14 +45,13 @@ impl BuildValidator for DictValidator {
             key_validator.get_name(),
             value_validator.get_name()
         );
-        let validator = Self {
+        Ok(Self {
             strict: is_strict(schema, config)?,
             key_validator,
             value_validator,
             name,
         }
-        .into();
-        LengthConstraint::maybe_wrap(schema, validator)
+        .into())
     }
 }
 

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -6,7 +6,6 @@ use crate::build_tools::{is_strict, schema_or_config_same};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -17,23 +16,14 @@ impl BuildValidator for FloatBuilder {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
+        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        let use_constrained = schema.get_item(intern!(py, "multiple_of")).is_some()
-            || schema.get_item(intern!(py, "le")).is_some()
-            || schema.get_item(intern!(py, "lt")).is_some()
-            || schema.get_item(intern!(py, "ge")).is_some()
-            || schema.get_item(intern!(py, "gt")).is_some();
-        if use_constrained {
-            ConstrainedFloatValidator::build(schema, config, definitions)
-        } else {
-            Ok(FloatValidator {
-                strict: is_strict(schema, config)?,
-                allow_inf_nan: schema_or_config_same(schema, config, intern!(py, "allow_inf_nan"))?.unwrap_or(true),
-            }
-            .into())
+        Ok(FloatValidator {
+            strict: is_strict(schema, config)?,
+            allow_inf_nan: schema_or_config_same(schema, config, intern!(py, "allow_inf_nan"))?.unwrap_or(true),
         }
+        .into())
     }
 }
 
@@ -93,105 +83,5 @@ impl Validator for FloatValidator {
 
     fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConstrainedFloatValidator {
-    strict: bool,
-    allow_inf_nan: bool,
-    multiple_of: Option<f64>,
-    le: Option<f64>,
-    lt: Option<f64>,
-    ge: Option<f64>,
-    gt: Option<f64>,
-}
-
-impl_py_gc_traverse!(ConstrainedFloatValidator {});
-
-impl Validator for ConstrainedFloatValidator {
-    fn validate<'s, 'data>(
-        &'s self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
-        let either_float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
-        let float: f64 = either_float.try_into()?;
-        if !self.allow_inf_nan && !float.is_finite() {
-            return Err(ValError::new(ErrorType::FiniteNumber, input));
-        }
-        if let Some(multiple_of) = self.multiple_of {
-            let rem = float % multiple_of;
-            let threshold = float / 1e9;
-            if rem.abs() > threshold && (rem - multiple_of).abs() > threshold {
-                return Err(ValError::new(
-                    ErrorType::MultipleOf {
-                        multiple_of: multiple_of.into(),
-                    },
-                    input,
-                ));
-            }
-        }
-        if let Some(le) = self.le {
-            if float > le {
-                return Err(ValError::new(ErrorType::LessThanEqual { le: le.into() }, input));
-            }
-        }
-        if let Some(lt) = self.lt {
-            if float >= lt {
-                return Err(ValError::new(ErrorType::LessThan { lt: lt.into() }, input));
-            }
-        }
-        if let Some(ge) = self.ge {
-            if float < ge {
-                return Err(ValError::new(ErrorType::GreaterThanEqual { ge: ge.into() }, input));
-            }
-        }
-        if let Some(gt) = self.gt {
-            if float <= gt {
-                return Err(ValError::new(ErrorType::GreaterThan { gt: gt.into() }, input));
-            }
-        }
-        Ok(float.into_py(py))
-    }
-
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
-        true
-    }
-
-    fn get_name(&self) -> &str {
-        "constrained-float"
-    }
-
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        Ok(())
-    }
-}
-
-impl BuildValidator for ConstrainedFloatValidator {
-    const EXPECTED_TYPE: &'static str = "float";
-    fn build(
-        schema: &PyDict,
-        config: Option<&PyDict>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        Ok(Self {
-            strict: is_strict(schema, config)?,
-            allow_inf_nan: schema_or_config_same(schema, config, intern!(py, "allow_inf_nan"))?.unwrap_or(true),
-            multiple_of: schema.get_as(intern!(py, "multiple_of"))?,
-            le: schema.get_as(intern!(py, "le"))?,
-            lt: schema.get_as(intern!(py, "lt"))?,
-            ge: schema.get_as(intern!(py, "ge"))?,
-            gt: schema.get_as(intern!(py, "gt"))?,
-        }
-        .into())
     }
 }

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -4,9 +4,8 @@ use pyo3::types::{PyDict, PyFrozenSet};
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
+use crate::validators::constraints::LengthConstraint;
 
-use super::list::min_length_check;
 use super::set::set_build;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -14,8 +13,6 @@ use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, 
 pub struct FrozenSetValidator {
     strict: bool,
     item_validator: Box<CombinedValidator>,
-    min_length: Option<usize>,
-    max_length: Option<usize>,
     name: String,
 }
 
@@ -41,14 +38,11 @@ impl Validator for FrozenSetValidator {
             py,
             f_set,
             input,
-            self.max_length,
-            "Frozenset",
             &self.item_validator,
             extra,
             definitions,
             recursion_guard,
         )?;
-        min_length_check!(input, "Frozenset", self.min_length, f_set);
         Ok(f_set.into_py(py))
     }
 

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -4,7 +4,6 @@ use pyo3::types::{PyDict, PyFrozenSet};
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::validators::constraints::LengthConstraint;
 
 use super::set::set_build;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -138,7 +138,6 @@ impl ValidatorIterator {
                                 if index >= max_length {
                                     let val_error = ValError::new(
                                         ErrorType::TooLong {
-                                            field_type: "Generator".to_string(),
                                             max_length,
                                             actual_length: index + 1,
                                         },
@@ -163,7 +162,6 @@ impl ValidatorIterator {
                             if $iter.index() < min_length {
                                 let val_error = ValError::new(
                                     ErrorType::TooShort {
-                                        field_type: "Generator".to_string(),
                                         min_length,
                                         actual_length: $iter.index(),
                                     },

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -1,13 +1,10 @@
-use num_bigint::BigInt;
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
-use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::{Input, Int};
+use crate::errors::ValResult;
+use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -24,20 +21,10 @@ impl BuildValidator for IntValidator {
         config: Option<&PyDict>,
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        let use_constrained = schema.get_item(intern!(py, "multiple_of")).is_some()
-            || schema.get_item(intern!(py, "le")).is_some()
-            || schema.get_item(intern!(py, "lt")).is_some()
-            || schema.get_item(intern!(py, "ge")).is_some()
-            || schema.get_item(intern!(py, "gt")).is_some();
-        if use_constrained {
-            ConstrainedIntValidator::build(schema, config)
-        } else {
-            Ok(Self {
-                strict: is_strict(schema, config)?,
-            }
-            .into())
+        Ok(Self {
+            strict: is_strict(schema, config)?,
         }
+        .into())
     }
 }
 
@@ -69,97 +56,5 @@ impl Validator for IntValidator {
 
     fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConstrainedIntValidator {
-    strict: bool,
-    multiple_of: Option<Int>,
-    le: Option<Int>,
-    lt: Option<Int>,
-    ge: Option<Int>,
-    gt: Option<Int>,
-}
-
-impl_py_gc_traverse!(ConstrainedIntValidator {});
-
-impl Validator for ConstrainedIntValidator {
-    fn validate<'s, 'data>(
-        &'s self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
-        let either_int = input.validate_int(extra.strict.unwrap_or(self.strict))?;
-        let int_value = either_int.as_int()?;
-
-        if let Some(ref multiple_of) = self.multiple_of {
-            if &int_value % multiple_of != Int::Big(BigInt::from(0)) {
-                return Err(ValError::new(
-                    ErrorType::MultipleOf {
-                        multiple_of: multiple_of.clone().into(),
-                    },
-                    input,
-                ));
-            }
-        }
-        if let Some(ref le) = self.le {
-            if &int_value > le {
-                return Err(ValError::new(ErrorType::LessThanEqual { le: le.clone().into() }, input));
-            }
-        }
-        if let Some(ref lt) = self.lt {
-            if &int_value >= lt {
-                return Err(ValError::new(ErrorType::LessThan { lt: lt.clone().into() }, input));
-            }
-        }
-        if let Some(ref ge) = self.ge {
-            if &int_value < ge {
-                return Err(ValError::new(
-                    ErrorType::GreaterThanEqual { ge: ge.clone().into() },
-                    input,
-                ));
-            }
-        }
-        if let Some(ref gt) = self.gt {
-            if &int_value <= gt {
-                return Err(ValError::new(ErrorType::GreaterThan { gt: gt.clone().into() }, input));
-            }
-        }
-        Ok(either_int.into_py(py))
-    }
-
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        !ultra_strict
-    }
-
-    fn get_name(&self) -> &str {
-        "constrained-int"
-    }
-
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        Ok(())
-    }
-}
-
-impl ConstrainedIntValidator {
-    fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        Ok(Self {
-            strict: is_strict(schema, config)?,
-            multiple_of: schema.get_as(intern!(py, "multiple_of"))?,
-            le: schema.get_as(intern!(py, "le"))?,
-            lt: schema.get_as(intern!(py, "lt"))?,
-            ge: schema.get_as(intern!(py, "ge"))?,
-            gt: schema.get_as(intern!(py, "gt"))?,
-        }
-        .into())
     }
 }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -5,7 +5,6 @@ use crate::errors::ValResult;
 use crate::input::{GenericIterable, Input};
 use crate::recursion_guard::RecursionGuard;
 
-use super::constraints::LengthConstraint;
 use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
@@ -43,12 +42,12 @@ impl BuildValidator for ListValidator {
         let item_validator = get_items_schema(schema, config, definitions)?;
         let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("{}[{inner_name}]", Self::EXPECTED_TYPE);
-        let list_validator = Self {
+        Ok(Self {
             strict: crate::build_tools::is_strict(schema, config)?,
             item_validator,
             name,
-        };
-        LengthConstraint::maybe_wrap(schema, list_validator.into())
+        }
+        .into())
     }
 }
 

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -4,16 +4,14 @@ use pyo3::types::PyDict;
 use crate::errors::ValResult;
 use crate::input::{GenericIterable, Input};
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
+use super::constraints::LengthConstraint;
 use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ListValidator {
     strict: bool,
     item_validator: Option<Box<CombinedValidator>>,
-    min_length: Option<usize>,
-    max_length: Option<usize>,
     name: String,
 }
 
@@ -34,59 +32,6 @@ pub fn get_items_schema(
     }
 }
 
-macro_rules! length_check {
-    ($input:ident, $field_type:literal, $min_length:expr, $max_length:expr, $obj:ident) => {{
-        let mut op_actual_length: Option<usize> = None;
-        if let Some(min_length) = $min_length {
-            let actual_length = $obj.len();
-            if actual_length < min_length {
-                return Err(crate::errors::ValError::new(
-                    crate::errors::ErrorType::TooShort {
-                        field_type: $field_type.to_string(),
-                        min_length,
-                        actual_length,
-                    },
-                    $input,
-                ));
-            }
-            op_actual_length = Some(actual_length);
-        }
-        if let Some(max_length) = $max_length {
-            let actual_length = op_actual_length.unwrap_or_else(|| $obj.len());
-            if actual_length > max_length {
-                return Err(crate::errors::ValError::new(
-                    crate::errors::ErrorType::TooLong {
-                        field_type: $field_type.to_string(),
-                        max_length,
-                        actual_length,
-                    },
-                    $input,
-                ));
-            }
-        }
-    }};
-}
-pub(crate) use length_check;
-
-macro_rules! min_length_check {
-    ($input:ident, $field_type:literal, $min_length:expr, $obj:ident) => {{
-        if let Some(min_length) = $min_length {
-            let actual_length = $obj.len();
-            if actual_length < min_length {
-                return Err(crate::errors::ValError::new(
-                    crate::errors::ErrorType::TooShort {
-                        field_type: $field_type.to_string(),
-                        min_length,
-                        actual_length,
-                    },
-                    $input,
-                ));
-            }
-        }
-    }};
-}
-pub(crate) use min_length_check;
-
 impl BuildValidator for ListValidator {
     const EXPECTED_TYPE: &'static str = "list";
 
@@ -95,18 +40,15 @@ impl BuildValidator for ListValidator {
         config: Option<&PyDict>,
         definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let py = schema.py();
         let item_validator = get_items_schema(schema, config, definitions)?;
         let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("{}[{inner_name}]", Self::EXPECTED_TYPE);
-        Ok(Self {
+        let list_validator = Self {
             strict: crate::build_tools::is_strict(schema, config)?,
             item_validator,
-            min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
-            max_length: schema.get_as(pyo3::intern!(py, "max_length"))?,
             name,
-        }
-        .into())
+        };
+        LengthConstraint::maybe_wrap(schema, list_validator.into())
     }
 }
 
@@ -124,26 +66,15 @@ impl Validator for ListValidator {
         let seq = input.validate_list(extra.strict.unwrap_or(self.strict))?;
 
         let output = match self.item_validator {
-            Some(ref v) => seq.validate_to_vec(
-                py,
-                input,
-                self.max_length,
-                "List",
-                v,
-                extra,
-                definitions,
-                recursion_guard,
-            )?,
+            Some(ref v) => seq.validate_to_vec(py, input, v, extra, definitions, recursion_guard)?,
             None => match seq {
                 GenericIterable::List(list) => {
-                    length_check!(input, "List", self.min_length, self.max_length, list);
                     let list_copy = list.get_slice(0, usize::MAX);
                     return Ok(list_copy.into_py(py));
                 }
-                _ => seq.to_vec(py, input, "List", self.max_length)?,
+                _ => seq.to_vec(py, input)?,
             },
         };
-        min_length_check!(input, "List", self.min_length, output);
         Ok(output.into_py(py))
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -514,6 +514,8 @@ pub fn build_validator<'a>(
         // recursive (self-referencing) models
         definitions::DefinitionRefValidator,
         definitions::DefinitionsValidatorBuilder,
+        // constraints
+        constraints::Constraint,
     )
 }
 
@@ -592,12 +594,10 @@ pub enum CombinedValidator {
     StrConstrained(string::StrConstrainedValidator),
     // integers
     Int(int::IntValidator),
-    ConstrainedInt(int::ConstrainedIntValidator),
     // booleans
     Bool(bool::BoolValidator),
     // floats
     Float(float::FloatValidator),
-    ConstrainedFloat(float::ConstrainedFloatValidator),
     // lists
     List(list::ListValidator),
     // sets - unique lists
@@ -660,7 +660,7 @@ pub enum CombinedValidator {
     // input dependent
     JsonOrPython(json_or_python::JsonOrPython),
     // constraints
-    LengthConstraint(constraints::LengthConstraint),
+    Constraint(constraints::Constraint),
 }
 
 /// This trait must be implemented by all validators, it allows various validators to be accessed consistently,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -23,6 +23,7 @@ mod bytes;
 mod call;
 mod callable;
 mod chain;
+mod constraints;
 mod custom_error;
 mod dataclass;
 mod date;
@@ -621,7 +622,6 @@ pub enum CombinedValidator {
     Any(any::AnyValidator),
     // bytes
     Bytes(bytes::BytesValidator),
-    ConstrainedBytes(bytes::BytesConstrainedValidator),
     // dates
     Date(date::DateValidator),
     // times
@@ -659,6 +659,8 @@ pub enum CombinedValidator {
     DefinitionRef(definitions::DefinitionRefValidator),
     // input dependent
     JsonOrPython(json_or_python::JsonOrPython),
+    // constraints
+    LengthConstraint(constraints::LengthConstraint),
 }
 
 /// This trait must be implemented by all validators, it allows various validators to be accessed consistently,

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -4,7 +4,6 @@ use pyo3::types::{PyDict, PySet};
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::validators::constraints::LengthConstraint;
 
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -32,13 +31,12 @@ macro_rules! set_build {
             };
             let inner_name = item_validator.get_name();
             let name = format!("{}[{}]", Self::EXPECTED_TYPE, inner_name);
-            let validator = Self {
+            Ok(Self {
                 strict: crate::build_tools::is_strict(schema, config)?,
                 item_validator,
                 name,
             }
-            .into();
-            LengthConstraint::maybe_wrap(schema, validator)
+            .into())
         }
     };
 }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -4,17 +4,14 @@ use pyo3::types::{PyDict, PySet};
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
+use crate::validators::constraints::LengthConstraint;
 
-use super::list::min_length_check;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct SetValidator {
     strict: bool,
     item_validator: Box<CombinedValidator>,
-    min_length: Option<usize>,
-    max_length: Option<usize>,
     name: String,
 }
 
@@ -25,7 +22,6 @@ macro_rules! set_build {
             config: Option<&PyDict>,
             definitions: &mut DefinitionsBuilder<CombinedValidator>,
         ) -> PyResult<CombinedValidator> {
-            let py = schema.py();
             let item_validator = match schema.get_item(pyo3::intern!(schema.py(), "items_schema")) {
                 Some(d) => Box::new(crate::validators::build_validator(d, config, definitions)?),
                 None => Box::new(crate::validators::any::AnyValidator::build(
@@ -35,16 +31,14 @@ macro_rules! set_build {
                 )?),
             };
             let inner_name = item_validator.get_name();
-            let max_length = schema.get_as(pyo3::intern!(py, "max_length"))?;
             let name = format!("{}[{}]", Self::EXPECTED_TYPE, inner_name);
-            Ok(Self {
+            let validator = Self {
                 strict: crate::build_tools::is_strict(schema, config)?,
                 item_validator,
-                min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
-                max_length,
                 name,
             }
-            .into())
+            .into();
+            LengthConstraint::maybe_wrap(schema, validator)
         }
     };
 }
@@ -72,14 +66,11 @@ impl Validator for SetValidator {
             py,
             set,
             input,
-            self.max_length,
-            "Set",
             &self.item_validator,
             extra,
             definitions,
             recursion_guard,
         )?;
-        min_length_check!(input, "Set", self.min_length, set);
         Ok(set.into_py(py))
     }
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -5,7 +5,7 @@ use pyo3::types::{PyDict, PyString, PyTime};
 use speedate::Time;
 
 use crate::build_tools::is_strict;
-use crate::errors::{ErrorType, ValError, ValResult};
+use crate::errors::ValResult;
 use crate::input::{EitherTime, Input};
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
@@ -52,26 +52,6 @@ impl Validator for TimeValidator {
         let time = input.validate_time(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         if let Some(constraints) = &self.constraints {
             let raw_time = time.as_raw()?;
-
-            macro_rules! check_constraint {
-                ($constraint:ident, $error:ident) => {
-                    if let Some(constraint) = &constraints.$constraint {
-                        if !raw_time.$constraint(constraint) {
-                            return Err(ValError::new(
-                                ErrorType::$error {
-                                    $constraint: constraint.to_string().into(),
-                                },
-                                input,
-                            ));
-                        }
-                    }
-                };
-            }
-
-            check_constraint!(le, LessThanEqual);
-            check_constraint!(lt, LessThan);
-            check_constraint!(ge, GreaterThanEqual);
-            check_constraint!(gt, GreaterThan);
 
             if let Some(ref tz_constraint) = constraints.tz {
                 tz_constraint.tz_check(raw_time.tz_offset, input)?;

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -1,13 +1,10 @@
-use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDelta, PyDict};
-use speedate::Duration;
+use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
-use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::{duration_as_pytimedelta, pytimedelta_as_duration, Input};
+use crate::errors::ValResult;
+use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
 use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
@@ -15,16 +12,7 @@ use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, 
 #[derive(Debug, Clone)]
 pub struct TimeDeltaValidator {
     strict: bool,
-    constraints: Option<TimedeltaConstraints>,
     microseconds_precision: speedate::MicrosecondsPrecisionOverflowBehavior,
-}
-
-#[derive(Debug, Clone)]
-struct TimedeltaConstraints {
-    le: Option<Duration>,
-    lt: Option<Duration>,
-    ge: Option<Duration>,
-    gt: Option<Duration>,
 }
 
 impl BuildValidator for TimeDeltaValidator {
@@ -35,29 +23,8 @@ impl BuildValidator for TimeDeltaValidator {
         config: Option<&PyDict>,
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let py: Python<'_> = schema.py();
-        let constraints = TimedeltaConstraints {
-            le: schema
-                .get_as::<&PyDelta>(intern!(py, "le"))?
-                .map(pytimedelta_as_duration),
-            lt: schema
-                .get_as::<&PyDelta>(intern!(py, "lt"))?
-                .map(pytimedelta_as_duration),
-            ge: schema
-                .get_as::<&PyDelta>(intern!(py, "ge"))?
-                .map(pytimedelta_as_duration),
-            gt: schema
-                .get_as::<&PyDelta>(intern!(py, "gt"))?
-                .map(pytimedelta_as_duration),
-        };
-
         Ok(Self {
             strict: is_strict(schema, config)?,
-            constraints: (constraints.le.is_some()
-                || constraints.lt.is_some()
-                || constraints.ge.is_some()
-                || constraints.gt.is_some())
-            .then_some(constraints),
             microseconds_precision: extract_microseconds_precision(schema, config)?,
         }
         .into())
@@ -77,32 +44,6 @@ impl Validator for TimeDeltaValidator {
     ) -> ValResult<'data, PyObject> {
         let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
-        if let Some(constraints) = &self.constraints {
-            let raw_timedelta = timedelta.as_raw();
-
-            macro_rules! check_constraint {
-                ($constraint:ident, $error:ident) => {
-                    if let Some(constraint) = &constraints.$constraint {
-                        if !raw_timedelta.$constraint(constraint) {
-                            return Err(ValError::new(
-                                ErrorType::$error {
-                                    $constraint: duration_as_pytimedelta(py, constraint)?
-                                        .repr()?
-                                        .to_string()
-                                        .into(),
-                                },
-                                py_timedelta.as_ref(),
-                            ));
-                        }
-                    }
-                };
-            }
-
-            check_constraint!(le, LessThanEqual);
-            check_constraint!(lt, LessThan);
-            check_constraint!(ge, GreaterThanEqual);
-            check_constraint!(gt, GreaterThan);
-        }
         Ok(py_timedelta.into())
     }
 

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -8,7 +8,6 @@ use crate::input::{GenericIterable, Input};
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::constraints::LengthConstraint;
 use super::list::get_items_schema;
 use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 
@@ -29,12 +28,12 @@ impl BuildValidator for TupleVariableValidator {
         let item_validator = get_items_schema(schema, config, definitions)?;
         let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("tuple[{inner_name}, ...]");
-        let validator = Self {
+        Ok(Self {
             strict: is_strict(schema, config)?,
             item_validator,
             name,
-        };
-        LengthConstraint::maybe_wrap(schema, validator.into())
+        }
+        .into())
     }
 }
 
@@ -112,7 +111,7 @@ impl BuildValidator for TuplePositionalValidator {
             .map(Validator::get_name)
             .collect::<Vec<_>>()
             .join(", ");
-        let validator = Self {
+        Ok(Self {
             strict: is_strict(schema, config)?,
             items_validators: validators,
             extra_validator: match schema.get_item(intern!(py, "extra_schema")) {
@@ -120,8 +119,8 @@ impl BuildValidator for TuplePositionalValidator {
                 None => None,
             },
             name: format!("tuple[{descr}]"),
-        };
-        LengthConstraint::maybe_wrap(schema, validator.into())
+        }
+        .into())
     }
 }
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,17 +12,17 @@ def test_build_error_type():
 
 
 def test_build_error_internal():
-    with pytest.raises(SchemaError, match='Input should be a valid integer, unable to parse string as an integer'):
-        SchemaValidator({'type': 'str', 'min_length': 'xxx', 'title': 'TestModel'})
+    with pytest.raises(SchemaError, match='Input should be a valid boolean, unable to interpret input'):
+        SchemaValidator({'type': 'str', 'strict': 'xyz'})
 
 
 def test_build_error_deep():
-    with pytest.raises(SchemaError, match='Input should be a valid integer, unable to parse string as an integer'):
+    with pytest.raises(SchemaError, match='Input should be a valid boolean, unable to interpret input'):
         SchemaValidator(
             {
                 'title': 'MyTestModel',
                 'type': 'typed-dict',
-                'fields': {'age': {'schema': {'type': 'int', 'ge': 'not-int'}}},
+                'fields': {'age': {'schema': {'type': 'int', 'strict': 'xyz'}}},
             }
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,23 +4,23 @@ import re
 import pytest
 from dirty_equals import FunctionCheck, HasAttributes, IsInstance
 
-from pydantic_core import CoreConfig, SchemaValidator, ValidationError
+from pydantic_core import CoreConfig, SchemaValidator, ValidationError, core_schema
 
 from .conftest import Err, plain_repr
 
 
 def test_on_field():
-    v = SchemaValidator({'type': 'str', 'min_length': 2, 'max_length': 5})
+    v = SchemaValidator(core_schema.str_schema(min_length=2, max_length=5))
     r = plain_repr(v)
-    assert 'min_length:Some(2)' in r
-    assert 'max_length:Some(5)' in r
+    assert 'MinLength' in r
+    assert 'MaxLength' in r
     assert v.isinstance_python('test') is True
     assert v.isinstance_python('test long') is False
 
 
 def test_on_config():
     v = SchemaValidator({'type': 'str'}, {'str_max_length': 5})
-    assert 'max_length:Some(5)' in plain_repr(v)
+    assert 'MinLength' in plain_repr(v)
     assert v.isinstance_python('test') is True
     assert v.isinstance_python('test long') is False
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -201,14 +201,10 @@ all_errors = [
     ('finite_number', 'Input should be a finite number', None),
     (
         'too_short',
-        'Foobar should have at least 42 items after validation, not 40',
-        {'field_type': 'Foobar', 'min_length': 42, 'actual_length': 40},
+        'Data should have at least 42 items after validation, not 40',
+        {'min_length': 42, 'actual_length': 40},
     ),
-    (
-        'too_long',
-        'Foobar should have at most 42 items after validation, not 50',
-        {'field_type': 'Foobar', 'max_length': 42, 'actual_length': 50},
-    ),
+    ('too_long', 'Data should have at most 42 items after validation, not 50', {'max_length': 42, 'actual_length': 50}),
     ('string_type', 'Input should be a valid string', None),
     ('string_sub_type', 'Input should be a string, not an instance of a subclass of str', None),
     ('string_unicode', 'Input should be a valid string, unable to parse raw data as a unicode string', None),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -77,16 +77,16 @@ def test_validation_error_include_context():
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python([1, 2, 3])
 
-    assert exc_info.value.title == 'list[any]'
+    assert exc_info.value.title == 'length_constraint'
     assert exc_info.value.error_count() == 1
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'List should have at most 2 items after validation, not 3',
+            'msg': 'Data should have at most 2 items after validation, not 3',
             'input': [1, 2, 3],
-            'ctx': {'field_type': 'List', 'max_length': 2, 'actual_length': 3},
+            'ctx': {'max_length': 2, 'actual_length': 3},
         }
     ]
     # insert_assert(exc_info.value.errors(include_url=False, include_context=False))
@@ -94,7 +94,7 @@ def test_validation_error_include_context():
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'List should have at most 2 items after validation, not 3',
+            'msg': 'Data should have at most 2 items after validation, not 3',
             'input': [1, 2, 3],
         }
     ]
@@ -198,7 +198,7 @@ def test_unicode_error_input_repr() -> None:
     validator = SchemaValidator(schema)
 
     danger_str = 'ÿ' * 1000
-    expected = "1 validation error for int\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='ÿÿÿÿÿÿÿÿÿÿÿÿ...ÿÿÿÿÿÿÿÿÿÿÿ', input_type=str]"  # noqa: E501
+    expected = "1 validation error for int\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='ÿÿÿÿÿÿÿÿÿÿÿÿ...ÿÿÿÿÿÿÿÿÿÿÿ', input_type=str]"
     with pytest.raises(ValidationError) as exc_info:
         validator.validate_python(danger_str)
     actual = repr(exc_info.value).split('For further information visit ')[0].strip()

--- a/tests/validators/test_bytes.py
+++ b/tests/validators/test_bytes.py
@@ -49,9 +49,9 @@ def test_lax_bytes_validator():
     [
         ({}, b'foo', b'foo'),
         ({'max_length': 5}, b'foo', b'foo'),
-        ({'max_length': 5}, b'foobar', Err('Data should have at most 5 bytes')),
+        ({'max_length': 5}, b'foobar', Err('Data should have at most 5 items after validation, not 6')),
         ({'min_length': 2}, b'foo', b'foo'),
-        ({'min_length': 2}, b'f', Err('Data should have at least 2 bytes')),
+        ({'min_length': 2}, b'f', Err('Data should have at least 2 items after validation, not 1')),
         ({'min_length': 1, 'max_length': 6, 'strict': True}, b'bytes?', b'bytes?'),
     ],
 )
@@ -69,9 +69,9 @@ def test_constrained_bytes_python_bytes(opts: Dict[str, Any], input, expected):
     [
         ({}, 'foo', b'foo'),
         ({'max_length': 5}, 'foo', b'foo'),
-        ({'max_length': 5}, 'foobar', Err('Data should have at most 5 bytes')),
+        ({'max_length': 5}, 'foobar', Err('Data should have at most 5 items after validation, not 6')),
         ({'min_length': 2}, 'foo', b'foo'),
-        ({'min_length': 2}, 'f', Err('Data should have at least 2 bytes')),
+        ({'min_length': 2}, 'f', Err('Data should have at least 2 items after validation, not 1')),
         ({}, 1, Err('Input should be a valid bytes')),
         ({}, 1.0, Err('Input should be a valid bytes')),
         ({}, [], Err('Input should be a valid bytes')),
@@ -101,9 +101,9 @@ def test_length_ctx():
         v.validate_python(b'1')
     assert exc_info.value.errors(include_url=False) == [
         {
-            'type': 'bytes_too_short',
+            'type': 'too_short',
             'loc': (),
-            'msg': 'Data should have at least 2 bytes',
+            'msg': 'Bytes should have at least 2 items after validation, not 1',
             'input': b'1',
             'ctx': {'min_length': 2},
         }

--- a/tests/validators/test_bytes.py
+++ b/tests/validators/test_bytes.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 import pytest
 
-from pydantic_core import SchemaValidator, ValidationError
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -56,7 +56,7 @@ def test_lax_bytes_validator():
     ],
 )
 def test_constrained_bytes_python_bytes(opts: Dict[str, Any], input, expected):
-    v = SchemaValidator({'type': 'bytes', **opts})
+    v = SchemaValidator(core_schema.bytes_schema(**opts))
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input)

--- a/tests/validators/test_dict.py
+++ b/tests/validators/test_dict.py
@@ -208,13 +208,13 @@ def test_mapping_error_yield_1(mapping_items):
         (
             {'min_length': 3},
             {1: '2', 3: '4'},
-            Err('Dictionary should have at least 3 items after validation, not 2 [type=too_short,'),
+            Err('Data should have at least 3 items after validation, not 2 [type=too_short,'),
         ),
         ({'max_length': 4}, {'1': 1, '2': 2, '3': 3.0}, {'1': 1, '2': 2, '3': 3.0}),
         (
             {'max_length': 3},
             {'1': 1, '2': 2, '3': 3.0, '4': [1, 2, 3, 4]},
-            Err('Dictionary should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
     ],
 )

--- a/tests/validators/test_dict.py
+++ b/tests/validators/test_dict.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pytest
 from dirty_equals import HasRepr, IsStr
 
-from pydantic_core import SchemaValidator, ValidationError
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -219,7 +219,7 @@ def test_mapping_error_yield_1(mapping_items):
     ],
 )
 def test_dict_length_constraints(kwargs: Dict[str, Any], input_value, expected):
-    v = SchemaValidator({'type': 'dict', **kwargs})
+    v = SchemaValidator(core_schema.dict_schema(**kwargs))
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -179,12 +179,12 @@ def test_float_repr():
     v = SchemaValidator({'type': 'float'})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),definitions=[])'  # noqa: E501
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),definitions=[])'
     )
     v = SchemaValidator({'type': 'float', 'strict': True})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),definitions=[])'  # noqa: E501
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),definitions=[])'
     )
     v = SchemaValidator({'type': 'float', 'multiple_of': 7})
     assert plain_repr(v).startswith('SchemaValidator(title="constrained-float",validator=ConstrainedFloat(')

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -139,29 +139,26 @@ def generate_repeats():
         ({'strict': True}, {1, 2, 3}, Err('Input should be a valid frozenset [type=frozen_set_type,')),
         ({'strict': True}, 'abc', Err('Input should be a valid frozenset [type=frozen_set_type,')),
         ({'min_length': 3}, {1, 2, 3}, {1, 2, 3}),
-        (
-            {'min_length': 3},
-            {1, 2},
-            Err('Frozenset should have at least 3 items after validation, not 2 [type=too_short,'),
-        ),
+        ({'min_length': 3}, {1, 2}, Err('Data should have at least 3 items after validation, not 2 [type=too_short,')),
         ({'max_length': 3}, {1, 2, 3}, {1, 2, 3}),
         (
             {'max_length': 3},
             {1, 2, 3, 4},
-            Err('Frozenset should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         (
             {'items_schema': {'type': 'int'}, 'max_length': 3},
             {1, 2, 3, 4},
-            Err('Frozenset should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         # length check after set creation
         ({'max_length': 3}, [1, 1, 2, 2, 3, 3], {1, 2, 3}),
         ({'max_length': 3}, generate_repeats(), {1, 2, 3}),
-        (
+        pytest.param(
             {'max_length': 3},
             infinite_generator(),
-            Err('Frozenset should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
+            marks=pytest.mark.timeout(5),
         ),
     ],
 )
@@ -243,13 +240,10 @@ def test_frozenset_as_dict_keys(py_and_json: PyAndJson):
 
 def test_repr():
     v = SchemaValidator({'type': 'frozenset', 'strict': True, 'min_length': 42})
-    assert plain_repr(v) == (
-        'SchemaValidator('
-        'title="frozenset[any]",'
-        'validator=FrozenSet(FrozenSetValidator{'
-        'strict:true,item_validator:Any(AnyValidator),min_length:Some(42),max_length:None,'
-        'name:"frozenset[any]"'
-        '}),definitions=[])'
+    # insert_assert(plain_repr(v))
+    assert (
+        plain_repr(v)
+        == 'SchemaValidator(title="length_constraint",validator=Chain(ChainValidator{steps:[FrozenSet(FrozenSetValidator{strict:true,item_validator:Any(AnyValidator),name:"frozenset[any]"}),LengthConstraint(LengthConstraint{min_length:Some(42),max_length:None}),],name:"length_constraint"}),definitions=[])'
     )
 
 

--- a/tests/validators/test_generator.py
+++ b/tests/validators/test_generator.py
@@ -118,9 +118,9 @@ def test_too_long(py_and_json: PyAndJson):
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'Generator should have at most 2 items after validation, not 3',
+            'msg': 'Data should have at most 2 items after validation, not 3',
             'input': [1, 2, 3],
-            'ctx': {'field_type': 'Generator', 'max_length': 2, 'actual_length': 3},
+            'ctx': {'max_length': 2, 'actual_length': 3},
         }
     ]
 
@@ -136,9 +136,9 @@ def test_too_short(py_and_json: PyAndJson):
         {
             'type': 'too_short',
             'loc': (),
-            'msg': 'Generator should have at least 2 items after validation, not 1',
+            'msg': 'Data should have at least 2 items after validation, not 1',
             'input': [1],
-            'ctx': {'field_type': 'Generator', 'min_length': 2, 'actual_length': 1},
+            'ctx': {'min_length': 2, 'actual_length': 1},
         }
     ]
 
@@ -167,8 +167,8 @@ def test_generator_too_long():
             'type': 'too_long',
             'loc': (),
             'input': HasRepr(IsStr(regex='<generator object gen at .+>')),
-            'msg': 'Generator should have at most 2 items after validation, not 3',
-            'ctx': {'field_type': 'Generator', 'max_length': 2, 'actual_length': 3},
+            'msg': 'Data should have at most 2 items after validation, not 3',
+            'ctx': {'max_length': 2, 'actual_length': 3},
         }
     ]
 
@@ -192,7 +192,7 @@ def test_generator_too_short():
             'type': 'too_short',
             'input': HasRepr(IsStr(regex='<generator object gen at .+>')),
             'loc': (),
-            'msg': 'Generator should have at least 4 items after validation, not 3',
-            'ctx': {'field_type': 'Generator', 'min_length': 4, 'actual_length': 3},
+            'msg': 'Data should have at least 4 items after validation, not 3',
+            'ctx': {'min_length': 4, 'actual_length': 3},
         }
     ]

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -338,8 +338,9 @@ def test_int_repr():
     # insert_assert(plain_repr(v))
     assert (
         plain_repr(v)
-        == 'SchemaValidator(title="chain[int,multiple_of]",validator=Chain(ChainValidator{steps:[Int(IntValidator{strict:false}),Constraint(MultipleOf(Py(0x0000000102ec41b0))),],name:"chain[int,multiple_of]"}),definitions=[])'
+        == 'SchemaValidator(title="chain[int,multiple_of]",validator=Chain(ChainValidator{steps:[Int(IntValidator{strict:false}),Constraint(MultipleOf(Py(0x0000000104a081b0))),],name:"chain[int,multiple_of]"}),definitions=[])'
     )
+
 
 
 

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -143,24 +143,25 @@ def test_list_error(input_value, index):
     [
         ({}, [1, 2, 3, 4], [1, 2, 3, 4]),
         ({'min_length': 3}, [1, 2, 3, 4], [1, 2, 3, 4]),
-        ({'min_length': 3}, [1, 2], Err('List should have at least 3 items after validation, not 2 [type=too_short,')),
-        ({'min_length': 1}, [], Err('List should have at least 1 item after validation, not 0 [type=too_short,')),
+        ({'min_length': 3}, [1, 2], Err('Data should have at least 3 items after validation, not 2 [type=too_short,')),
+        ({'min_length': 1}, [], Err('Data should have at least 1 item after validation, not 0 [type=too_short,')),
         ({'max_length': 4}, [1, 2, 3, 4], [1, 2, 3, 4]),
         (
             {'max_length': 3},
             [1, 2, 3, 4],
-            Err('List should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         (
             {'max_length': 3},
             [1, 2, 3, 4, 5, 6, 7],
-            Err('List should have at most 3 items after validation, not 7 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 7 [type=too_long,'),
         ),
-        ({'max_length': 1}, [1, 2], Err('List should have at most 1 item after validation, not 2 [type=too_long,')),
-        (
+        ({'max_length': 1}, [1, 2], Err('Data should have at most 1 item after validation, not 2 [type=too_long,')),
+        pytest.param(
             {'max_length': 44},
             infinite_generator(),
-            Err('List should have at most 44 items after validation, not 45 [type=too_long,'),
+            Err('Data should have at most 44 items after validation, not 45 [type=too_long,'),
+            marks=pytest.mark.timeout(5),
         ),
     ],
 )
@@ -177,7 +178,7 @@ def test_list_length_constraints(kwargs: Dict[str, Any], input_value, expected):
     'input_value,expected',
     [
         ([1, 2, 3, 4], [1, 2, 3, 4]),
-        ([1, 2, 3, 4, 5], Err('List should have at most 4 items after validation, not 5 [type=too_long,')),
+        ([1, 2, 3, 4, 5], Err('Data should have at most 4 items after validation, not 5 [type=too_long,')),
         ([1, 2, 3, 'x', 4], [1, 2, 3, 4]),
     ],
 )
@@ -205,9 +206,9 @@ def test_length_ctx():
         {
             'type': 'too_short',
             'loc': (),
-            'msg': 'List should have at least 2 items after validation, not 1',
+            'msg': 'Data should have at least 2 items after validation, not 1',
             'input': [1],
-            'ctx': {'field_type': 'List', 'min_length': 2, 'actual_length': 1},
+            'ctx': {'min_length': 2, 'actual_length': 1},
         }
     ]
 
@@ -219,9 +220,9 @@ def test_length_ctx():
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'List should have at most 3 items after validation, not 4',
+            'msg': 'Data should have at most 3 items after validation, not 4',
             'input': [1, 2, 3, 4],
-            'ctx': {'field_type': 'List', 'max_length': 3, 'actual_length': 4},
+            'ctx': {'max_length': 3, 'actual_length': 4},
         }
     ]
 
@@ -365,6 +366,7 @@ def test_bad_iter(items_schema):
 
 
 @pytest.mark.parametrize('error_in_func', [True, False])
+@pytest.mark.timeout(5)
 def test_max_length_fail_fast(error_in_func: bool) -> None:
     calls: list[int] = []
 
@@ -391,9 +393,9 @@ def test_max_length_fail_fast(error_in_func: bool) -> None:
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'List should have at most 10 items after validation, not 11',
+            'msg': 'Data should have at most 10 items after validation, not 11',
             'input': data,
-            'ctx': {'field_type': 'List', 'max_length': 10, 'actual_length': 11},
+            'ctx': {'max_length': 10, 'actual_length': 11},
         }
     )
 

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -122,26 +122,27 @@ def generate_repeats():
         ({'strict': True}, frozenset([1, 2, 3]), Err('Input should be a valid set [type=set_type,')),
         ({'strict': True}, 'abc', Err('Input should be a valid set [type=set_type,')),
         ({'min_length': 3}, {1, 2, 3}, {1, 2, 3}),
-        ({'min_length': 3}, {1, 2}, Err('Set should have at least 3 items after validation, not 2 [type=too_short,')),
+        ({'min_length': 3}, {1, 2}, Err('Data should have at least 3 items after validation, not 2 [type=too_short,')),
         (
             {'max_length': 3},
             {1, 2, 3, 4},
-            Err('Set should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         (
             {'max_length': 3},
             [1, 2, 3, 4],
-            Err('Set should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         ({'max_length': 3, 'items_schema': {'type': 'int'}}, {1, 2, 3, 4}, Err('type=too_long,')),
         ({'max_length': 3, 'items_schema': {'type': 'int'}}, [1, 2, 3, 4], Err('type=too_long,')),
         # length check after set creation
         ({'max_length': 3}, [1, 1, 2, 2, 3, 3], {1, 2, 3}),
         ({'max_length': 3}, generate_repeats(), {1, 2, 3}),
-        (
+        pytest.param(
             {'max_length': 3},
             infinite_generator(),
-            Err('Set should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
+            marks=pytest.mark.timeout(5),
         ),
     ],
     ids=repr,

--- a/tests/validators/test_timedelta.py
+++ b/tests/validators/test_timedelta.py
@@ -149,7 +149,7 @@ def test_timedelta_strict_json(input_value, expected):
             {'le': timedelta(seconds=-86400.123)},
             '-PT86400.122S',
             Err(
-                'Input should be less than or equal to datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=less_than_equal'  # noqa: E501
+                'Input should be less than or equal to datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=less_than_equal'
             ),
         ),
         ({'gt': timedelta(seconds=-86400.123)}, timedelta(seconds=-86400.122), timedelta(seconds=-86400.122)),
@@ -158,7 +158,7 @@ def test_timedelta_strict_json(input_value, expected):
             {'gt': timedelta(seconds=-86400.123)},
             '-PT86400.124S',
             Err(
-                'Input should be greater than datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=greater_than'  # noqa: E501
+                'Input should be greater than datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=greater_than'
             ),
         ),
     ],

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -68,9 +68,9 @@ def test_empty_positional_tuple():
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'Tuple should have at most 0 items after validation, not 1',
+            'msg': 'Data should have at most 0 items after validation, not 1',
             'input': (1,),
-            'ctx': {'field_type': 'Tuple', 'max_length': 0, 'actual_length': 1},
+            'ctx': {'max_length': 0, 'actual_length': 1},
         }
     ]
 
@@ -98,22 +98,23 @@ def test_tuple_strict_fails_without_tuple(wrong_coll_type: Type[Any], mode, item
     [
         ({}, (1, 2, 3, 4), (1, 2, 3, 4)),
         ({'min_length': 3}, (1, 2, 3, 4), (1, 2, 3, 4)),
-        ({'min_length': 3}, (1, 2), Err('Tuple should have at least 3 items after validation, not 2 [type=too_short,')),
+        ({'min_length': 3}, (1, 2), Err('Data should have at least 3 items after validation, not 2 [type=too_short,')),
         ({'max_length': 4}, (1, 2, 3, 4), (1, 2, 3, 4)),
         (
             {'max_length': 3},
             (1, 2, 3, 4),
-            Err('Tuple should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
         (
             {'max_length': 3},
             [1, 2, 3, 4],
-            Err('Tuple should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
         ),
-        (
+        pytest.param(
             {'max_length': 3},
             infinite_generator(),
-            Err('Tuple should have at most 3 items after validation, not 4 [type=too_long,'),
+            Err('Data should have at most 3 items after validation, not 4 [type=too_long,'),
+            marks=pytest.mark.timeout(5),
         ),
     ],
     ids=repr,
@@ -248,9 +249,9 @@ def test_extra_arguments(py_and_json: PyAndJson):
         {
             'type': 'too_long',
             'loc': (),
-            'msg': 'Tuple should have at most 2 items after validation, not 4',
+            'msg': 'Data should have at most 2 items after validation, not 4',
             'input': [1, 2, 3, 4],
-            'ctx': {'field_type': 'Tuple', 'max_length': 2, 'actual_length': 4},
+            'ctx': {'max_length': 2, 'actual_length': 4},
         }
     ]
 
@@ -480,7 +481,7 @@ def test_frozenset_from_dict_items(input_value, items_schema, expected):
     'input_value,expected',
     [
         ([1, 2, 3, 4], (1, 2, 3, 4)),
-        ([1, 2, 3, 4, 5], Err('Tuple should have at most 4 items after validation, not 5 [type=too_long,')),
+        ([1, 2, 3, 4, 5], Err('Data should have at most 4 items after validation, not 5 [type=too_long,')),
         ([1, 2, 3, 'x', 4], (1, 2, 3, 4)),
     ],
 )


### PR DESCRIPTION
This moves constraints out of the parsing validators and into their own thing so that they can be re-ordered and to simplify core schema creation on the pydantic Python side.