### PR TITLE
optimize Python float validation

### DIFF
--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -72,11 +72,10 @@ impl Validator for FloatValidator {
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
         let either_float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
-        let float: f64 = either_float.try_into()?;
-        if !self.allow_inf_nan && !float.is_finite() {
+        if !self.allow_inf_nan && !either_float.as_f64().is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
-        Ok(float.into_py(py))
+        Ok(either_float.into_py(py))
     }
 
     fn different_strict_behavior(
@@ -119,7 +118,7 @@ impl Validator for ConstrainedFloatValidator {
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, PyObject> {
         let either_float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
-        let float: f64 = either_float.try_into()?;
+        let float: f64 = either_float.as_f64();
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
@@ -155,7 +154,7 @@ impl Validator for ConstrainedFloatValidator {
                 return Err(ValError::new(ErrorType::GreaterThan { gt: gt.into() }, input));
             }
         }
-        Ok(float.into_py(py))
+        Ok(either_float.into_py(py))
     }
 
     fn different_strict_behavior(


### PR DESCRIPTION
## Change Summary

While staring at the last few test failures in #763 I noticed a couple of slight inefficiencies in the Python float validation.

- Can use `PyFloat_AS_DOUBLE` in the case we have exactly a `float` input (might need to check this works on PyPy)
- We were creating a new float in the case we had exactly a `float` input

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin