### PR TITLE
ruff: ignore E501

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ features = ["pyo3/extension-module"]
 [tool.ruff]
 line-length = 120
 extend-select = ['Q', 'RUF100', 'C90', 'I']
+extend-ignore = ['E501']
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 mccabe = { max-complexity = 13 }
 isort = { known-first-party = ['pydantic_core', 'tests'] }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -198,7 +198,7 @@ def test_unicode_error_input_repr() -> None:
     validator = SchemaValidator(schema)
 
     danger_str = 'ÿ' * 1000
-    expected = "1 validation error for int\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='ÿÿÿÿÿÿÿÿÿÿÿÿ...ÿÿÿÿÿÿÿÿÿÿÿ', input_type=str]"  # noqa: E501
+    expected = "1 validation error for int\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='ÿÿÿÿÿÿÿÿÿÿÿÿ...ÿÿÿÿÿÿÿÿÿÿÿ', input_type=str]"
     with pytest.raises(ValidationError) as exc_info:
         validator.validate_python(danger_str)
     actual = repr(exc_info.value).split('For further information visit ')[0].strip()

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -179,12 +179,12 @@ def test_float_repr():
     v = SchemaValidator({'type': 'float'})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),definitions=[])'  # noqa: E501
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:false,allow_inf_nan:true}),definitions=[])'
     )
     v = SchemaValidator({'type': 'float', 'strict': True})
     assert (
         plain_repr(v)
-        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),definitions=[])'  # noqa: E501
+        == 'SchemaValidator(title="float",validator=Float(FloatValidator{strict:true,allow_inf_nan:true}),definitions=[])'
     )
     v = SchemaValidator({'type': 'float', 'multiple_of': 7})
     assert plain_repr(v).startswith('SchemaValidator(title="constrained-float",validator=ConstrainedFloat(')

--- a/tests/validators/test_timedelta.py
+++ b/tests/validators/test_timedelta.py
@@ -149,7 +149,7 @@ def test_timedelta_strict_json(input_value, expected):
             {'le': timedelta(seconds=-86400.123)},
             '-PT86400.122S',
             Err(
-                'Input should be less than or equal to datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=less_than_equal'  # noqa: E501
+                'Input should be less than or equal to datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=less_than_equal'
             ),
         ),
         ({'gt': timedelta(seconds=-86400.123)}, timedelta(seconds=-86400.122), timedelta(seconds=-86400.122)),
@@ -158,7 +158,7 @@ def test_timedelta_strict_json(input_value, expected):
             {'gt': timedelta(seconds=-86400.123)},
             '-PT86400.124S',
             Err(
-                'Input should be greater than datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=greater_than'  # noqa: E501
+                'Input should be greater than datetime.timedelta(days=-2, seconds=86399, microseconds=877000) [type=greater_than'
             ),
         ),
     ],


### PR DESCRIPTION
## Change Summary

Ignores ruff E501 since we use black to manage that.

## Related issue number

We did a similar change in https://github.com/pydantic/pydantic/pull/6552

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb