### PR TITLE
make an enum-as-output for validators

### DIFF
--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -1,5 +1,8 @@
 use num_bigint::BigInt;
-use pyo3::PyObject;
+use pyo3::{
+    types::{PyDict, PyList},
+    IntoPy, PyObject, Python, ToPyObject,
+};
 
 use crate::lazy_index_map::LazyIndexMap;
 
@@ -15,7 +18,53 @@ pub enum DataValue {
     Float(f64),
     String(String),
     Array(Vec<DataValue>),
-    Object(DataObject),
+    Object(Box<DataObject>),
     Py(PyObject),
 }
 pub type DataObject = LazyIndexMap<String, DataValue>;
+
+impl ToPyObject for DataValue {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        match self {
+            Self::Null => py.None(),
+            Self::Bool(b) => b.into_py(py),
+            Self::Int(i) => i.into_py(py),
+            Self::BigInt(b) => b.to_object(py),
+            Self::Uint(i) => i.into_py(py),
+            Self::Float(f) => f.into_py(py),
+            Self::String(s) => s.into_py(py),
+            Self::Array(v) => PyList::new(py, v.iter().map(|v| v.to_object(py))).into_py(py),
+            Self::Object(o) => {
+                let dict = PyDict::new(py);
+                for (k, v) in o.iter() {
+                    dict.set_item(k, v.to_object(py)).unwrap();
+                }
+                dict.into_py(py)
+            }
+            Self::Py(o) => o.clone_ref(py),
+        }
+    }
+}
+
+impl IntoPy<PyObject> for DataValue {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            Self::Null => py.None(),
+            Self::Bool(b) => b.into_py(py),
+            Self::Int(i) => i.into_py(py),
+            Self::BigInt(b) => b.to_object(py),
+            Self::Uint(i) => i.into_py(py),
+            Self::Float(f) => f.into_py(py),
+            Self::String(s) => s.into_py(py),
+            Self::Array(v) => PyList::new(py, v.into_iter().map(|v| v.into_py(py))).into_py(py),
+            Self::Object(o) => {
+                let dict = PyDict::new(py);
+                for (k, v) in *o {
+                    dict.set_item(k, v.into_py(py)).unwrap();
+                }
+                dict.into_py(py)
+            }
+            Self::Py(o) => o.into_py(py),
+        }
+    }
+}

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -4,6 +4,7 @@ use pyo3::PyObject;
 use crate::lazy_index_map::LazyIndexMap;
 
 /// similar to serde `Value` but with int and float split
+// FIXME remove clone, don't want to accidentally duplicate Vecs
 #[derive(Clone, Debug)]
 pub enum DataValue {
     Null,

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -1,0 +1,20 @@
+use num_bigint::BigInt;
+use pyo3::PyObject;
+
+use crate::lazy_index_map::LazyIndexMap;
+
+/// similar to serde `Value` but with int and float split
+#[derive(Clone, Debug)]
+pub enum DataValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    BigInt(BigInt),
+    Uint(u64),
+    Float(f64),
+    String(String),
+    Array(Vec<DataValue>),
+    Object(DataObject),
+    Py(PyObject),
+}
+pub type DataObject = LazyIndexMap<String, DataValue>;

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -196,7 +196,7 @@ impl<'a> Input<'a> for DataValue {
 
     fn validate_dict(&'a self, _strict: bool) -> ValResult<GenericMapping<'a>> {
         match self {
-            DataValue::Object(dict) => Ok(dict.into()),
+            DataValue::Object(dict) => Ok(dict.as_ref().into()),
             DataValue::Py(obj) => obj
                 .as_ref(unsafe { Python::assume_gil_acquired() })
                 .validate_dict(_strict),
@@ -281,7 +281,7 @@ impl<'a> Input<'a> for DataValue {
 
     fn validate_iter(&self) -> ValResult<GenericIterator> {
         match self {
-            DataValue::Array(a) => Ok(a.clone().into()),
+            DataValue::Array(a) => Ok(a.clone().into()), // FIXME this clone copies the whole iterator, potentially awful for performance
             DataValue::String(s) => Ok(string_to_vec(s).into()),
             DataValue::Object(object) => {
                 // return keys iterator to match python's behavior

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -330,7 +330,7 @@ impl<'a> Input<'a> for PyAny {
             if (float == 0.0 || float == 1.0) && PyBool::is_exact_type_of(self) {
                 Err(ValError::new(ErrorType::FloatType, self))
             } else {
-                Ok(EitherFloat::Py(self))
+                Ok(EitherFloat::F64(float))
             }
         } else {
             Err(ValError::new(ErrorType::FloatType, self))

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -65,3 +65,12 @@ where
         self.vec.iter()
     }
 }
+
+impl<K, V> IntoIterator for LazyIndexMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod py_gc;
 
 mod argument_markers;
 mod build_tools;
+mod data_value;
 mod definitions;
 mod errors;
 mod input;

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -1,8 +1,8 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::errors::ValResult;
 use crate::input::Input;
+use crate::{data_value::DataValue, errors::ValResult};
 
 use crate::recursion_guard::RecursionGuard;
 
@@ -34,9 +34,9 @@ impl Validator for AnyValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         // Ok(input.clone().into_py(py))
-        Ok(input.to_object(py))
+        Ok(DataValue::Py(input.to_object(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -35,7 +35,6 @@ impl Validator for AnyValidator {
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, DataValue> {
-        // Ok(input.clone().into_py(py))
         Ok(DataValue::Py(input.to_object(py)))
     }
 

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -236,7 +236,7 @@ impl Validator for ArgumentsValidator {
                                 if let Some(ref kwarg_key) = parameter.kwarg_key {
                                     output_kwargs.set_item(kwarg_key, value)?;
                                 } else {
-                                    output_args.push(DataValue::Py(value));
+                                    output_args.push(value);
                                 }
                             } else if let Some(ref lookup_key) = parameter.kw_lookup_key {
                                 let error_type = if parameter.positional {

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -1,9 +1,9 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::build_tools::is_strict;
 use crate::errors::ValResult;
 use crate::input::Input;
+use crate::{build_tools::is_strict, data_value::DataValue};
 
 use crate::recursion_guard::RecursionGuard;
 
@@ -39,10 +39,12 @@ impl Validator for BoolValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
-        Ok(input.validate_bool(extra.strict.unwrap_or(self.strict))?.into_py(py))
+        Ok(DataValue::Py(
+            input.validate_bool(extra.strict.unwrap_or(self.strict))?.into_py(py),
+        ))
     }
 
     fn different_strict_behavior(

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -34,7 +34,7 @@ impl_py_gc_traverse!(BoolValidator {});
 impl Validator for BoolValidator {
     fn validate<'s, 'data>(
         &'s self,
-        py: Python<'data>,
+        _py: Python<'data>,
         input: &'data impl Input<'data>,
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
@@ -42,8 +42,8 @@ impl Validator for BoolValidator {
     ) -> ValResult<'data, DataValue> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
-        Ok(DataValue::Py(
-            input.validate_bool(extra.strict.unwrap_or(self.strict))?.into_py(py),
+        Ok(DataValue::Bool(
+            input.validate_bool(extra.strict.unwrap_or(self.strict))?,
         ))
     }
 

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
@@ -48,9 +49,9 @@ impl Validator for BytesValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_bytes = input.validate_bytes(extra.strict.unwrap_or(self.strict))?;
-        Ok(either_bytes.into_py(py))
+        Ok(DataValue::Py(either_bytes.into_py(py)))
     }
 
     fn different_strict_behavior(
@@ -87,7 +88,7 @@ impl Validator for BytesConstrainedValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_bytes = input.validate_bytes(extra.strict.unwrap_or(self.strict))?;
         let len = either_bytes.len()?;
 
@@ -102,7 +103,7 @@ impl Validator for BytesConstrainedValidator {
             }
         }
 
-        Ok(either_bytes.into_py(py))
+        Ok(DataValue::Py(either_bytes.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
@@ -33,9 +34,9 @@ impl Validator for CallableValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match input.callable() {
-            true => Ok(input.to_object(py)),
+            true => Ok(DataValue::Py(input.to_object(py))),
             false => Err(ValError::new(ErrorType::CallableType, input)),
         }
     }

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -86,6 +86,7 @@ impl Validator for ChainValidator {
         for step in steps_iter {
             value = step
                 .validate(py, &value, extra, definitions, recursion_guard)
+                // FIXME this avoids a lifetime issue but costs cloning the erroneous input
                 .map_err(|e| e.duplicate(py))?;
         }
 

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::py_schema_err;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, PydanticCustomError, PydanticKnownError, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -95,7 +96,7 @@ impl Validator for CustomErrorValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         self.validator
             .validate(py, input, extra, definitions, recursion_guard)
             .map_err(|_| self.custom_error.as_val_error(input))

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -7,6 +7,7 @@ use ahash::AHashSet;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValLineError, ValResult};
 use crate::input::{GenericArguments, Input};
 use crate::lookup_key::LookupKey;
@@ -135,7 +136,7 @@ impl Validator for DataclassArgsValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let args = input.validate_dataclass_args(&self.dataclass_name)?;
 
         let output_dict = PyDict::new(py);
@@ -233,7 +234,7 @@ impl Validator for DataclassArgsValidator {
                                 definitions,
                                 recursion_guard,
                             )? {
-                                set_item!(field, value);
+                                set_item!(field, DataValue::Py(value));
                             } else {
                                 errors.push(field.lookup_key.error(
                                     ErrorType::Missing,
@@ -302,9 +303,11 @@ impl Validator for DataclassArgsValidator {
         }
         if errors.is_empty() {
             if let Some(init_only_args) = init_only_args {
-                Ok((output_dict, PyTuple::new(py, init_only_args)).to_object(py))
+                Ok(DataValue::Py(
+                    (output_dict, PyTuple::new(py, init_only_args)).to_object(py),
+                ))
             } else {
-                Ok((output_dict, py.None()).to_object(py))
+                Ok(DataValue::Py((output_dict, py.None()).to_object(py)))
             }
         } else {
             Err(ValError::LineErrors(errors))
@@ -320,7 +323,7 @@ impl Validator for DataclassArgsValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let dict: &PyDict = obj.downcast()?;
 
         let ok = |output: PyObject| {
@@ -329,7 +332,9 @@ impl Validator for DataclassArgsValidator {
             // which doesn't make much sense in this context but we need to put something there
             // so that function validators that sit between DataclassValidator and DataclassArgsValidator
             // always get called the same shape of data.
-            Ok(PyTuple::new(py, vec![dict.to_object(py), py.None()]).into_py(py))
+            Ok(DataValue::Py(
+                PyTuple::new(py, vec![dict.to_object(py), py.None()]).into_py(py),
+            ))
         };
 
         if let Some(field) = self.fields.iter().find(|f| f.name == field_name) {
@@ -356,7 +361,7 @@ impl Validator for DataclassArgsValidator {
                 .validator
                 .validate(py, field_value, &next_extra, definitions, recursion_guard)
             {
-                Ok(output) => ok(output),
+                Ok(output) => ok(output.to_object(py)),
                 Err(ValError::LineErrors(line_errors)) => {
                     let errors = line_errors
                         .into_iter()
@@ -481,7 +486,7 @@ impl Validator for DataclassValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if let Some(self_instance) = extra.self_instance {
             // in the case that self_instance is Some, we're calling validation from within `BaseModel.__init__`
             return self.validate_init(py, self_instance, input, extra, definitions, recursion_guard);
@@ -496,10 +501,10 @@ impl Validator for DataclassValidator {
                     .validator
                     .validate(py, input_dict, extra, definitions, recursion_guard)?;
                 let dc = create_class(self.class.as_ref(py))?;
-                self.set_dict_call(py, dc.as_ref(py), val_output, input)?;
-                Ok(dc)
+                self.set_dict_call(py, dc.as_ref(py), val_output.to_object(py), input)?;
+                Ok(DataValue::Py(dc))
             } else {
-                Ok(input.to_object(py))
+                Ok(DataValue::Py(input.to_object(py)))
             }
         } else if extra.strict.unwrap_or(self.strict) && input.is_python() {
             Err(ValError::new(
@@ -513,8 +518,8 @@ impl Validator for DataclassValidator {
                 .validator
                 .validate(py, input, extra, definitions, recursion_guard)?;
             let dc = create_class(self.class.as_ref(py))?;
-            self.set_dict_call(py, dc.as_ref(py), val_output, input)?;
-            Ok(dc)
+            self.set_dict_call(py, dc.as_ref(py), val_output.to_object(py), input)?;
+            Ok(DataValue::Py(dc))
         }
     }
 
@@ -527,7 +532,7 @@ impl Validator for DataclassValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if self.frozen {
             return Err(ValError::new(ErrorType::FrozenInstance, field_value));
         }
@@ -536,15 +541,18 @@ impl Validator for DataclassValidator {
 
         new_dict.set_item(field_name, field_value)?;
 
-        let val_assignment_result = self.validator.validate_assignment(
-            py,
-            new_dict,
-            field_name,
-            field_value,
-            extra,
-            definitions,
-            recursion_guard,
-        )?;
+        let val_assignment_result = self
+            .validator
+            .validate_assignment(
+                py,
+                new_dict,
+                field_name,
+                field_value,
+                extra,
+                definitions,
+                recursion_guard,
+            )?
+            .to_object(py);
 
         let (dc_dict, _): (&PyDict, PyObject) = val_assignment_result.extract(py)?;
 
@@ -557,7 +565,7 @@ impl Validator for DataclassValidator {
             force_setattr(py, obj, intern!(py, "__dict__"), dc_dict)?;
         }
 
-        Ok(obj.to_object(py))
+        Ok(DataValue::Py(obj.to_object(py)))
     }
 
     fn different_strict_behavior(
@@ -591,7 +599,7 @@ impl DataclassValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on the self_instance
         // instance anymore
         let new_extra = Extra {
@@ -602,9 +610,9 @@ impl DataclassValidator {
             .validator
             .validate(py, input, &new_extra, definitions, recursion_guard)?;
 
-        self.set_dict_call(py, self_instance, val_output, input)?;
+        self.set_dict_call(py, self_instance, val_output.to_object(py), input)?;
 
-        Ok(self_instance.into_py(py))
+        Ok(DataValue::Py(self_instance.into_py(py)))
     }
 
     fn dataclass_to_dict<'py>(&self, py: Python<'py>, dc: &'py PyAny) -> PyResult<&'py PyDict> {

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -234,7 +234,7 @@ impl Validator for DataclassArgsValidator {
                                 definitions,
                                 recursion_guard,
                             )? {
-                                set_item!(field, DataValue::Py(value));
+                                set_item!(field, value);
                             } else {
                                 errors.push(field.lookup_key.error(
                                     ErrorType::Missing,

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -5,6 +5,7 @@ use speedate::{Date, Time};
 use strum::EnumMessage;
 
 use crate::build_tools::{is_strict, py_schema_error_type};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{EitherDate, Input};
 
@@ -46,7 +47,7 @@ impl Validator for DateValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let date = match input.validate_date(extra.strict.unwrap_or(self.strict)) {
             Ok(date) => date,
             // if the date error was an internal error, return that immediately
@@ -99,7 +100,7 @@ impl Validator for DateValidator {
                 }
             }
         }
-        Ok(date.try_into_py(py)?)
+        Ok(DataValue::Py(date.try_into_py(py)?))
     }
 
     fn different_strict_behavior(

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -8,6 +8,7 @@ use strum::EnumMessage;
 
 use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::build_tools::{py_schema_err, schema_or_config_same};
+use crate::data_value::DataValue;
 use crate::errors::{py_err_string, ErrorType, ValError, ValResult};
 use crate::input::{EitherDateTime, Input};
 
@@ -66,7 +67,7 @@ impl Validator for DateTimeValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let datetime = input.validate_datetime(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         if let Some(constraints) = &self.constraints {
             // if we get an error from as_speedate, it's probably because the input datetime was invalid
@@ -120,7 +121,7 @@ impl Validator for DateTimeValidator {
                 tz_constraint.tz_check(speedate_dt.time.tz_offset, input)?;
             }
         }
-        Ok(datetime.try_into_py(py)?)
+        Ok(DataValue::Py(datetime.try_into_py(py)?))
     }
 
     fn different_strict_behavior(

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
@@ -81,7 +82,7 @@ impl Validator for DefinitionRefValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if let Some(id) = input.identity() {
             if recursion_guard.contains_or_insert(id, self.validator_id) {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
@@ -109,7 +110,7 @@ impl Validator for DefinitionRefValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if let Some(id) = obj.identity() {
             if recursion_guard.contains_or_insert(id, self.validator_id) {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
@@ -179,7 +180,7 @@ fn validate<'s, 'data>(
     extra: &Extra,
     definitions: &'data Definitions<CombinedValidator>,
     recursion_guard: &'s mut RecursionGuard,
-) -> ValResult<'data, PyObject> {
+) -> ValResult<'data, DataValue> {
     let validator = definitions.get(validator_id).unwrap();
     validator.validate(py, input, extra, definitions, recursion_guard)
 }
@@ -194,7 +195,7 @@ fn validate_assignment<'data>(
     extra: &Extra,
     definitions: &'data Definitions<CombinedValidator>,
     recursion_guard: &mut RecursionGuard,
-) -> ValResult<'data, PyObject> {
+) -> ValResult<'data, DataValue> {
     let validator = definitions.get(validator_id).unwrap();
     validator.validate_assignment(py, obj, field_name, field_value, extra, definitions, recursion_guard)
 }

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyMapping};
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::{ValError, ValLineError, ValResult};
 use crate::input::{
     DictGenericIterator, GenericMapping, Input, JsonObject, JsonObjectGenericIterator, MappingGenericIterator,
@@ -73,7 +74,7 @@ impl Validator for DictValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let dict = input.validate_dict(extra.strict.unwrap_or(self.strict))?;
         match dict {
             GenericMapping::PyDict(py_dict) => {
@@ -122,7 +123,7 @@ macro_rules! build_validate {
             extra: &Extra,
             definitions: &'data Definitions<CombinedValidator>,
             recursion_guard: &'s mut RecursionGuard,
-        ) -> ValResult<'data, PyObject> {
+        ) -> ValResult<'data, DataValue> {
             let output = PyDict::new(py);
             let mut errors: Vec<ValLineError> = Vec::new();
 
@@ -163,7 +164,7 @@ macro_rules! build_validate {
 
             if errors.is_empty() {
                 length_check!(input, "Dictionary", self.min_length, self.max_length, output);
-                Ok(output.into())
+                Ok(DataValue::Py(output.into()))
             } else {
                 Err(ValError::LineErrors(errors))
             }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::{is_strict, schema_or_config_same};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -70,13 +71,13 @@ impl Validator for FloatValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
         let float: f64 = either_float.try_into()?;
         if !self.allow_inf_nan && !float.is_finite() {
             return Err(ValError::new(ErrorType::FiniteNumber, input));
         }
-        Ok(float.into_py(py))
+        Ok(DataValue::Py(float.into_py(py)))
     }
 
     fn different_strict_behavior(
@@ -117,7 +118,7 @@ impl Validator for ConstrainedFloatValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_float = input.validate_float(extra.strict.unwrap_or(self.strict), extra.ultra_strict)?;
         let float: f64 = either_float.try_into()?;
         if !self.allow_inf_nan && !float.is_finite() {
@@ -155,7 +156,7 @@ impl Validator for ConstrainedFloatValidator {
                 return Err(ValError::new(ErrorType::GreaterThan { gt: gt.into() }, input));
             }
         }
-        Ok(float.into_py(py))
+        Ok(DataValue::Py(float.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyFrozenSet};
 
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -34,7 +35,7 @@ impl Validator for FrozenSetValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let collection = input.validate_frozenset(extra.strict.unwrap_or(self.strict))?;
         let f_set = PyFrozenSet::empty(py)?;
         collection.validate_to_set(
@@ -49,7 +50,7 @@ impl Validator for FrozenSetValidator {
             recursion_guard,
         )?;
         min_length_check!(input, "Frozenset", self.min_length, f_set);
-        Ok(f_set.into_py(py))
+        Ok(DataValue::Py(f_set.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::{ErrorMode, ErrorType, LocItem, ValError, ValResult};
 use crate::input::{GenericIterator, Input};
 use crate::recursion_guard::RecursionGuard;
@@ -58,7 +59,7 @@ impl Validator for GeneratorValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let iterator = input.validate_iter()?;
         let validator = self.item_validator.as_ref().map(|v| {
             InternalValidator::new(
@@ -79,7 +80,7 @@ impl Validator for GeneratorValidator {
             max_length: self.max_length,
             hide_input_in_errors: self.hide_input_in_errors,
         };
-        Ok(v_iterator.into_py(py))
+        Ok(DataValue::Py(v_iterator.into_py(py)))
     }
 
     fn different_strict_behavior(
@@ -294,6 +295,7 @@ impl InternalValidator {
                     self.hide_input_in_errors,
                 )
             })
+            .map(|v| v.to_object(py))
     }
 
     pub fn validate<'s, 'data>(
@@ -326,6 +328,7 @@ impl InternalValidator {
                     self.hide_input_in_errors,
                 )
             })
+            .map(|v| v.to_object(py))
     }
 }
 

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -53,9 +53,12 @@ impl Validator for IntValidator {
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, DataValue> {
-        Ok(DataValue::Py(
-            input.validate_int(extra.strict.unwrap_or(self.strict))?.into_py(py),
-        ))
+        Ok(match input.validate_int(extra.strict.unwrap_or(self.strict))? {
+            crate::input::EitherInt::I64(int) => DataValue::Int(int),
+            crate::input::EitherInt::U64(int) => DataValue::BigInt(BigInt::from(int)),
+            crate::input::EitherInt::BigInt(int) => DataValue::BigInt(int),
+            crate::input::EitherInt::Py(int) => DataValue::Py(int.into_py(py)),
+        })
     }
 
     fn different_strict_behavior(

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, Int};
 use crate::recursion_guard::RecursionGuard;
@@ -51,8 +52,10 @@ impl Validator for IntValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
-        Ok(input.validate_int(extra.strict.unwrap_or(self.strict))?.into_py(py))
+    ) -> ValResult<'data, DataValue> {
+        Ok(DataValue::Py(
+            input.validate_int(extra.strict.unwrap_or(self.strict))?.into_py(py),
+        ))
     }
 
     fn different_strict_behavior(
@@ -92,7 +95,7 @@ impl Validator for ConstrainedIntValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_int = input.validate_int(extra.strict.unwrap_or(self.strict))?;
         let int_value = either_int.as_int()?;
 
@@ -129,7 +132,7 @@ impl Validator for ConstrainedIntValidator {
                 return Err(ValError::new(ErrorType::GreaterThan { gt: gt.clone().into() }, input));
             }
         }
-        Ok(either_int.into_py(py))
+        Ok(DataValue::Py(either_int.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
 
 use crate::build_tools::py_schema_err;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -64,7 +65,7 @@ impl Validator for IsInstanceValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if !input.is_python() {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(
                 "Cannot check isinstance when validating from json, \
@@ -74,7 +75,7 @@ impl Validator for IsInstanceValidator {
 
         let ob = input.to_object(py);
         match ob.as_ref(py).is_instance(self.class.as_ref(py))? {
-            true => Ok(ob),
+            true => Ok(DataValue::Py(ob)),
             false => Err(ValError::new(
                 ErrorType::IsInstanceOf {
                     class: self.class_repr.clone(),

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
 
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -51,9 +52,9 @@ impl Validator for IsSubclassValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match input.input_is_subclass(self.class.as_ref(py))? {
-            true => Ok(input.to_object(py)),
+            true => Ok(DataValue::Py(input.to_object(py))),
             false => Err(ValError::new(
                 ErrorType::IsSubclassOf {
                     class: self.class_repr.clone(),

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -52,14 +53,14 @@ impl Validator for JsonValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let json_value = input.parse_json()?;
         match self.validator {
             Some(ref validator) => match validator.validate(py, &json_value, extra, definitions, recursion_guard) {
                 Ok(v) => Ok(v),
                 Err(err) => Err(err.duplicate(py)),
             },
-            None => Ok(json_value.to_object(py)),
+            None => Ok(DataValue::Py(json_value.to_object(py))),
         }
     }
 

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::definitions::DefinitionsBuilder;
 use crate::errors::ValResult;
 use crate::input::Input;
@@ -58,7 +59,7 @@ impl Validator for JsonOrPython {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match extra.mode {
             InputType::Python => self.python.validate(py, input, extra, definitions, recursion_guard),
             InputType::Json => self.json.validate(py, input, extra, definitions, recursion_guard),

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -62,7 +63,7 @@ impl Validator for LaxOrStrictValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if extra.strict.unwrap_or(self.strict) {
             self.strict_validator
                 .validate(py, input, extra, definitions, recursion_guard)

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::{GenericIterable, Input};
 use crate::recursion_guard::RecursionGuard;
@@ -120,7 +121,7 @@ impl Validator for ListValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let seq = input.validate_list(extra.strict.unwrap_or(self.strict))?;
 
         let output = match self.item_validator {
@@ -138,13 +139,13 @@ impl Validator for ListValidator {
                 GenericIterable::List(list) => {
                     length_check!(input, "List", self.min_length, self.max_length, list);
                     let list_copy = list.get_slice(0, usize::MAX);
-                    return Ok(list_copy.into_py(py));
+                    return Ok(DataValue::Py(list_copy.into_py(py)));
                 }
                 _ => seq.to_vec(py, input, "List", self.max_length)?,
             },
         };
         min_length_check!(input, "List", self.min_length, output);
-        Ok(output.into_py(py))
+        Ok(DataValue::Py(output.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -8,6 +8,7 @@ use pyo3::types::{PyDict, PyList};
 use pyo3::{intern, PyTraverseError, PyVisit};
 
 use crate::build_tools::{py_schema_err, py_schema_error_type};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
@@ -188,9 +189,9 @@ impl Validator for LiteralValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match self.lookup.validate(py, input)? {
-            Some((_, v)) => Ok(v.clone()),
+            Some((_, v)) => Ok(DataValue::Py(v.clone_ref(py))),
             None => Err(ValError::new(
                 ErrorType::LiteralError {
                     expected: self.expected_repr.clone(),

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -264,7 +264,7 @@ impl SchemaValidator {
             .default_value(py, None::<i64>, &extra, &self.definitions, recursion_guard);
         match r {
             Ok(maybe_default) => match maybe_default {
-                Some(v) => Ok(PySome::new(v).into_py(py)),
+                Some(v) => Ok(PySome::new(v.to_object(py)).into_py(py)),
                 None => Ok(py.None().into_py(py)),
             },
             Err(e) => Err(self.prepare_validation_err(py, e, ErrorMode::Python)),
@@ -690,7 +690,7 @@ pub trait Validator: Send + Sync + Clone + Debug {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, Option<PyObject>> {
+    ) -> ValResult<'data, Option<DataValue>> {
         Ok(None)
     }
 

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -32,9 +33,9 @@ impl Validator for NoneValidator {
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match input.is_none() {
-            true => Ok(py.None()),
+            true => Ok(DataValue::Py(py.None())),
             false => Err(ValError::new(ErrorType::NoneRequired, input)),
         }
     }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -28,14 +28,14 @@ impl_py_gc_traverse!(NoneValidator {});
 impl Validator for NoneValidator {
     fn validate<'s, 'data>(
         &'s self,
-        py: Python<'data>,
+        _py: Python<'data>,
         input: &'data impl Input<'data>,
         _extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, DataValue> {
         match input.is_none() {
-            true => Ok(DataValue::Py(py.None())),
+            true => Ok(DataValue::Null),
             false => Err(ValError::new(ErrorType::NoneRequired, input)),
         }
     }

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -40,9 +41,9 @@ impl Validator for NullableValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match input.is_none() {
-            true => Ok(py.None()),
+            true => Ok(DataValue::Py(py.None())),
             false => self.validator.validate(py, input, extra, definitions, recursion_guard),
         }
     }

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -43,7 +43,7 @@ impl Validator for NullableValidator {
         recursion_guard: &'s mut RecursionGuard,
     ) -> ValResult<'data, DataValue> {
         match input.is_none() {
-            true => Ok(DataValue::Py(py.None())),
+            true => Ok(DataValue::Null),
             false => self.validator.validate(py, input, extra, definitions, recursion_guard),
         }
     }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet};
 
+use crate::data_value::DataValue;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -65,7 +66,7 @@ impl Validator for SetValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let collection = input.validate_set(extra.strict.unwrap_or(self.strict))?;
         let set = PySet::empty(py)?;
         collection.validate_to_set(
@@ -80,7 +81,7 @@ impl Validator for SetValidator {
             recursion_guard,
         )?;
         min_length_check!(input, "Set", self.min_length, set);
-        Ok(set.into_py(py))
+        Ok(DataValue::Py(set.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -4,6 +4,7 @@ use pyo3::types::{PyDict, PyString};
 use regex::Regex;
 
 use crate::build_tools::{is_strict, py_schema_error_type, schema_or_config};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -47,8 +48,10 @@ impl Validator for StrValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
-        Ok(input.validate_str(extra.strict.unwrap_or(self.strict))?.into_py(py))
+    ) -> ValResult<'data, DataValue> {
+        Ok(DataValue::Py(
+            input.validate_str(extra.strict.unwrap_or(self.strict))?.into_py(py),
+        ))
     }
 
     fn different_strict_behavior(
@@ -90,7 +93,7 @@ impl Validator for StrConstrainedValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let either_str = input.validate_str(extra.strict.unwrap_or(self.strict))?;
         let cow = either_str.as_cow()?;
         let mut str = cow.as_ref();
@@ -135,7 +138,7 @@ impl Validator for StrConstrainedValidator {
             // we haven't modified the string, return the original as it might be a PyString
             either_str.as_py_string(py)
         };
-        Ok(py_string.into_py(py))
+        Ok(DataValue::Py(py_string.into_py(py)))
     }
 
     fn different_strict_behavior(

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -5,6 +5,7 @@ use pyo3::types::{PyDict, PyString, PyTime};
 use speedate::Time;
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{EitherTime, Input};
 use crate::recursion_guard::RecursionGuard;
@@ -48,7 +49,7 @@ impl Validator for TimeValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let time = input.validate_time(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         if let Some(constraints) = &self.constraints {
             let raw_time = time.as_raw()?;
@@ -77,7 +78,7 @@ impl Validator for TimeValidator {
                 tz_constraint.tz_check(raw_time.tz_offset, input)?;
             }
         }
-        Ok(time.try_into_py(py)?)
+        Ok(DataValue::Py(time.try_into_py(py)?))
     }
 
     fn different_strict_behavior(

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -4,6 +4,7 @@ use pyo3::types::{PyDelta, PyDict};
 use speedate::Duration;
 
 use crate::build_tools::is_strict;
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{duration_as_pytimedelta, pytimedelta_as_duration, Input};
 use crate::recursion_guard::RecursionGuard;
@@ -74,7 +75,7 @@ impl Validator for TimeDeltaValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
         if let Some(constraints) = &self.constraints {
@@ -103,7 +104,7 @@ impl Validator for TimeDeltaValidator {
             check_constraint!(ge, GreaterThanEqual);
             check_constraint!(gt, GreaterThan);
         }
-        Ok(py_timedelta.into())
+        Ok(DataValue::Py(py_timedelta.into()))
     }
 
     fn different_strict_behavior(

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -166,7 +166,7 @@ fn validate_tuple_positional<'s, 'data, T: Iterator<Item = PyResult<&'data I>>, 
             },
             None => {
                 if let Some(value) = validator.default_value(py, Some(index), extra, definitions, recursion_guard)? {
-                    output.push(value);
+                    output.push(value.to_object(py));
                 } else {
                     errors.push(ValLineError::new_with_loc(ErrorType::Missing, input, index));
                 }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -6,6 +6,7 @@ use ahash::AHashSet;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config, schema_or_config_same, ExtraBehavior};
+use crate::data_value::DataValue;
 use crate::errors::{py_err_string, ErrorType, ValError, ValLineError, ValResult};
 use crate::input::{
     AttributesGenericIterator, DictGenericIterator, GenericMapping, Input, JsonObjectGenericIterator,
@@ -147,7 +148,7 @@ impl Validator for TypedDictValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let strict = extra.strict.unwrap_or(self.strict);
         let dict = input.validate_dict(strict)?;
 
@@ -279,7 +280,7 @@ impl Validator for TypedDictValidator {
         if !errors.is_empty() {
             Err(ValError::LineErrors(errors))
         } else {
-            Ok(output_dict.to_object(py))
+            Ok(DataValue::Py(output_dict.to_object(py)))
         }
     }
 

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -6,6 +6,7 @@ use pyo3::{intern, PyTraverseError, PyVisit};
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, LocItem, ValError, ValLineError, ValResult};
 use crate::input::{GenericMapping, Input};
 use crate::lookup_key::LookupKey;
@@ -87,7 +88,7 @@ impl Validator for UnionValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if self.ultra_strict_required {
             // do an ultra strict check first
             let ultra_strict_extra = extra.as_strict(true);
@@ -310,7 +311,7 @@ impl Validator for TaggedUnionValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         match self.discriminator {
             Discriminator::LookupKey(ref lookup_key) => {
                 macro_rules! find_validator {
@@ -431,7 +432,7 @@ impl TaggedUnionValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if let Ok(Some((tag, validator))) = self.lookup.validate(py, tag) {
             return match validator.validate(py, input, extra, definitions, recursion_guard) {
                 Ok(res) => Ok(res),

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -10,6 +10,7 @@ use ahash::AHashSet;
 use url::{ParseError, SyntaxViolation, Url};
 
 use crate::build_tools::{is_strict, py_schema_err};
+use crate::data_value::DataValue;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
@@ -67,7 +68,7 @@ impl Validator for UrlValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let mut lib_url = self.get_url(input, extra.strict.unwrap_or(self.strict))?;
 
         if let Some((ref allowed_schemes, ref expected_schemes_repr)) = self.allowed_schemes {
@@ -84,7 +85,7 @@ impl Validator for UrlValidator {
             self.default_port,
             &self.default_path,
         ) {
-            Ok(()) => Ok(PyUrl::new(lib_url).into_py(py)),
+            Ok(()) => Ok(DataValue::Py(PyUrl::new(lib_url).into_py(py))),
             Err(error_type) => return Err(ValError::new(error_type, input)),
         }
     }
@@ -198,7 +199,7 @@ impl Validator for MultiHostUrlValidator {
         extra: &Extra,
         _definitions: &'data Definitions<CombinedValidator>,
         _recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         let mut multi_url = self.get_url(input, extra.strict.unwrap_or(self.strict))?;
 
         if let Some((ref allowed_schemes, ref expected_schemes_repr)) = self.allowed_schemes {
@@ -214,7 +215,7 @@ impl Validator for MultiHostUrlValidator {
             self.default_port,
             &self.default_path,
         ) {
-            Ok(()) => Ok(multi_url.into_py(py)),
+            Ok(()) => Ok(DataValue::Py(multi_url.into_py(py))),
             Err(error_type) => return Err(ValError::new(error_type, input)),
         }
     }

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -8,6 +8,7 @@ use pyo3::PyVisit;
 use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
+use crate::data_value::DataValue;
 use crate::errors::{LocItem, ValError, ValResult};
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
@@ -134,23 +135,26 @@ impl Validator for WithDefaultValidator {
         extra: &Extra,
         definitions: &'data Definitions<CombinedValidator>,
         recursion_guard: &'s mut RecursionGuard,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<'data, DataValue> {
         if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {
-            Ok(self
-                .default_value(py, None::<usize>, extra, definitions, recursion_guard)?
-                .unwrap())
+            Ok(DataValue::Py(
+                self.default_value(py, None::<usize>, extra, definitions, recursion_guard)?
+                    .unwrap(),
+            ))
         } else {
             match self.validator.validate(py, input, extra, definitions, recursion_guard) {
                 Ok(v) => Ok(v),
                 Err(e) => match e {
-                    ValError::UseDefault => Ok(self
-                        .default_value(py, None::<usize>, extra, definitions, recursion_guard)?
-                        .ok_or(e)?),
+                    ValError::UseDefault => Ok(DataValue::Py(
+                        self.default_value(py, None::<usize>, extra, definitions, recursion_guard)?
+                            .ok_or(e)?,
+                    )),
                     e => match self.on_error {
                         OnError::Raise => Err(e),
-                        OnError::Default => Ok(self
-                            .default_value(py, None::<usize>, extra, definitions, recursion_guard)?
-                            .ok_or(e)?),
+                        OnError::Default => Ok(DataValue::Py(
+                            self.default_value(py, None::<usize>, extra, definitions, recursion_guard)?
+                                .ok_or(e)?,
+                        )),
                         OnError::Omit => Err(ValError::Omit),
                     },
                 },
@@ -176,7 +180,7 @@ impl Validator for WithDefaultValidator {
                 };
                 if self.validate_default {
                     match self.validate(py, dft.into_ref(py), extra, definitions, recursion_guard) {
-                        Ok(v) => Ok(Some(v)),
+                        Ok(v) => Ok(Some(v.to_object(py))),
                         Err(e) => {
                             if let Some(outer_loc) = outer_loc {
                                 Err(e.with_outer_location(outer_loc.into()))


### PR DESCRIPTION
## Change Summary

Try to allow validators to return an enum to propagate rust types.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin