### PR TITLE
Fix wasm preview

### DIFF
--- a/wasm-preview/README.md
+++ b/wasm-preview/README.md
@@ -2,10 +2,10 @@
 
 To run tests in your browser, go [here](https://githubproxy.samuelcolvin.workers.dev/pydantic/pydantic-core/blob/main/wasm-preview/index.html).
 
-To test with a specific version of pydantic-core, add a query parameter `?pydantic_core_version=...` to the URL, e.g. `?pydantic_core_version=v0.25.0`, defaults to latest release.
+To test with a specific version of pydantic-core, add a query parameter `?pydantic_core_version=...` to the URL, e.g. `?pydantic_core_version=v2.4.0`, defaults to latest release.
 
 This doesn't work for version of pydantic-core before v0.23.0 as before that we built 3.10 binaries, and pyodide now rust 3.11.
 
 If the output appears to stop prematurely, try looking in the developer console for more details.
 
-Tests are currently failing 10-15% of the wait through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information.
+For Pydantic version prior to `2.2.0`, tests will freeze at  at 10-15% of the way through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information. 

--- a/wasm-preview/README.md
+++ b/wasm-preview/README.md
@@ -8,4 +8,4 @@ This doesn't work for version of pydantic-core before v0.23.0 as before that we 
 
 If the output appears to stop prematurely, try looking in the developer console for more details.
 
-For Pydantic version prior to `2.2.0`, tests will freeze at  at 10-15% of the way through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information. 
+For pydantic-core versions prior to `2.2.0`, tests will freeze at  at 10-15% of the way through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information. 

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -97,7 +97,7 @@ async function main() {
     setupStreams(FS, pyodide._module.TTY);
     FS.mkdir('/test_dir');
     FS.chdir('/test_dir');
-    await pyodide.loadPackage(['micropip', 'pytest', 'pytz', 'typing-extensions']);
+    await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});
     post();
   } catch (err) {

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -98,6 +98,7 @@ async function main() {
     FS.mkdir('/test_dir');
     FS.chdir('/test_dir');
     await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
+    if (pydantic_core_version < "2.0.0") await pyodide.loadPackage(['typing-extensions'])
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});
     post();
   } catch (err) {

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -98,7 +98,7 @@ async function main() {
     FS.mkdir('/test_dir');
     FS.chdir('/test_dir');
     await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
-    if (pydantic_core_version < "2.0.0") await pyodide.loadPackage(['typing-extensions'])
+    if (pydantic_core_version < '2.0.0') await pyodide.loadPackage(['typing-extensions']);
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});
     post();
   } catch (err) {


### PR DESCRIPTION
## Change Summary

Fixes the [WASM Preview](https://github.com/pydantic/pydantic-core/tree/main/wasm-preview) by resolving a dependency mismatch in `typing-extensions`. Since pydantic-core version 2.0.0 it seems, the built wheel used in this demo already specifies typing-extensions as a dependency, and there's no need in install a (mismatched) version via `loadPackage` in advance.

## Related issue number

Fixes #834.

## Checklist

* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
<!-- please review -->
