### PR TITLE
fix: cargo include

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
     "/rust-toolchain",
     "/src",
     "!/src/self_schema.py",
-    "/pydantic_core",
+    "/python/pydantic_core",
     "/tests",
     "/.cargo",
     "!__pycache__",


### PR DESCRIPTION
When referring to pydantic-core, I found that the include path in the cargo.toml file is wrong.

I run `cargo package --list` and it's not included. So it should include the python folder?



Selected Reviewer: @samuelcolvin