### PR TITLE
Build wheels for arm64 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,10 @@ jobs:
             target: i686
             python-architecture: x86
             interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
+          - os: windows
+            ls: dir
+            target: aarch64
+            interpreter: 3.11 3.12
           - os: macos
             target: aarch64
             interpreter: 3.7 3.8 3.9 3.10 3.11 3.12


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Add CI configuration for cross compiling arm64 Windows wheels. Note that arm64 Windows only has official Python support since 3.11.

Example run: https://github.com/messense/pydantic-core/actions/runs/5776288091/job/15655238295

## Related issue number

fix #840 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
