### PR TITLE
fix serialization of subclasses

### DIFF
--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -29,7 +29,7 @@ pub(crate) fn infer_to_python(
     exclude: Option<&PyAny>,
     extra: &Extra,
 ) -> PyResult<PyObject> {
-    infer_to_python_known(&extra.ob_type_lookup.get_type(value), value, include, exclude, extra)
+    infer_to_python_known(extra.ob_type_lookup.get_type(value), value, include, exclude, extra)
 }
 
 // arbitrary ids to identify that we recursed through infer_to_{python,json}_known
@@ -37,7 +37,7 @@ pub(crate) fn infer_to_python(
 const INFER_DEF_REF_ID: usize = usize::MAX;
 
 pub(crate) fn infer_to_python_known(
-    ob_type: &ObType,
+    ob_type: ObType,
     value: &PyAny,
     include: Option<&PyAny>,
     exclude: Option<&PyAny>,
@@ -315,7 +315,7 @@ impl<'py> SerializeInfer<'py> {
 impl<'py> Serialize for SerializeInfer<'py> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let ob_type = self.extra.ob_type_lookup.get_type(self.value);
-        infer_serialize_known(&ob_type, self.value, serializer, self.include, self.exclude, self.extra)
+        infer_serialize_known(ob_type, self.value, serializer, self.include, self.exclude, self.extra)
     }
 }
 
@@ -327,7 +327,7 @@ pub(crate) fn infer_serialize<S: Serializer>(
     extra: &Extra,
 ) -> Result<S::Ok, S::Error> {
     infer_serialize_known(
-        &extra.ob_type_lookup.get_type(value),
+        extra.ob_type_lookup.get_type(value),
         value,
         serializer,
         include,
@@ -337,7 +337,7 @@ pub(crate) fn infer_serialize<S: Serializer>(
 }
 
 pub(crate) fn infer_serialize_known<S: Serializer>(
-    ob_type: &ObType,
+    ob_type: ObType,
     value: &PyAny,
     serializer: S,
     include: Option<&PyAny>,
@@ -560,10 +560,10 @@ fn serialize_unknown(value: &PyAny) -> Cow<str> {
 
 pub(crate) fn infer_json_key<'py>(key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
     let ob_type = extra.ob_type_lookup.get_type(key);
-    infer_json_key_known(&ob_type, key, extra)
+    infer_json_key_known(ob_type, key, extra)
 }
 
-pub(crate) fn infer_json_key_known<'py>(ob_type: &ObType, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
+pub(crate) fn infer_json_key_known<'py>(ob_type: ObType, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
     match ob_type {
         ObType::None => super::type_serializers::simple::none_json_key(),
         ObType::Int | ObType::IntSubclass | ObType::Float | ObType::FloatSubclass => {

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -531,7 +531,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
                 let msg = format!(
                     "{}Unable to serialize unknown type: {}",
                     SERIALIZATION_ERR_MARKER,
-                    safe_repr(value)
+                    safe_repr(value.get_type()),
                 );
                 return Err(S::Error::custom(msg));
             }
@@ -542,7 +542,10 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
 }
 
 fn unknown_type_error(value: &PyAny) -> PyErr {
-    PydanticSerializationError::new_err(format!("Unable to serialize unknown type: {}", safe_repr(value)))
+    PydanticSerializationError::new_err(format!(
+        "Unable to serialize unknown type: {}",
+        safe_repr(value.get_type())
+    ))
 }
 
 fn serialize_unknown(value: &PyAny) -> Cow<str> {

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -110,9 +110,8 @@ impl ObTypeLookup {
     }
 
     pub fn is_type(&self, value: &PyAny, expected_ob_type: ObType) -> IsType {
-        match self.ob_type_is_expected(Some(value), value.get_type_ptr(), expected_ob_type) {
+        match self.ob_type_is_expected(Some(value), value.get_type_ptr(), &expected_ob_type) {
             IsType::False => {
-                dbg!(expected_ob_type, self.fallback_isinstance(value));
                 if expected_ob_type == self.fallback_isinstance(value) {
                     IsType::Subclass
                 } else {
@@ -127,7 +126,7 @@ impl ObTypeLookup {
         &self,
         op_value: Option<&PyAny>,
         type_ptr: *mut PyTypeObject,
-        expected_ob_type: ObType,
+        expected_ob_type: &ObType,
     ) -> IsType {
         let ob_type = type_ptr as usize;
         let ans = match expected_ob_type {
@@ -376,7 +375,7 @@ fn is_generator(op_value: Option<&PyAny>) -> bool {
     }
 }
 
-#[derive(Debug, Clone, Copy, EnumString, Display)]
+#[derive(Debug, Clone, EnumString, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum ObType {
     None,

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -2,10 +2,10 @@ use pyo3::ffi::PyTypeObject;
 use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFrozenSet, PyIterator, PyList, PySet, PyString,
-    PyTime, PyTuple,
+    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFloat, PyFrozenSet, PyInt, PyIterator, PyList,
+    PySet, PyString, PyTime, PyTuple,
 };
-use pyo3::{intern, AsPyPointer};
+use pyo3::{intern, AsPyPointer, PyTypeInfo};
 
 use strum::Display;
 use strum_macros::EnumString;
@@ -23,6 +23,7 @@ pub struct ObTypeLookup {
     list: usize,
     dict: usize,
     // other numeric types
+    decimal_object: PyObject,
     decimal: usize,
     // other string types
     bytes: usize,
@@ -39,18 +40,23 @@ pub struct ObTypeLookup {
     // types from this package
     url: usize,
     multi_host_url: usize,
-    // uuid type
-    uuid: usize,
     // enum type
-    enum_type: usize,
+    enum_object: PyObject,
+    enum_: usize,
     // generator
+    generator_object: PyObject,
     generator: usize,
     // path
+    path_object: PyObject,
     path: usize,
+    // uuid type
+    uuid_object: PyObject,
+    uuid: usize,
 }
 
 static TYPE_LOOKUP: GILOnceCell<ObTypeLookup> = GILOnceCell::new();
 
+#[derive(Debug)]
 pub enum IsType {
     Exact,
     Subclass,
@@ -60,6 +66,11 @@ pub enum IsType {
 impl ObTypeLookup {
     fn new(py: Python) -> Self {
         let lib_url = url::Url::parse("https://example.com").unwrap();
+        let decimal_type = py.import("decimal").unwrap().getattr("Decimal").unwrap();
+        let enum_object = py.import("enum").unwrap().getattr("Enum").unwrap();
+        let generator_object = py.import("types").unwrap().getattr("GeneratorType").unwrap();
+        let path_object = py.import("pathlib").unwrap().getattr("Path").unwrap();
+        let uuid_object = py.import("uuid").unwrap().getattr("UUID").unwrap();
         Self {
             none: py.None().as_ref(py).get_type_ptr() as usize,
             int: 0i32.into_py(py).as_ref(py).get_type_ptr() as usize,
@@ -67,7 +78,8 @@ impl ObTypeLookup {
             float: 0f32.into_py(py).as_ref(py).get_type_ptr() as usize,
             list: PyList::empty(py).get_type_ptr() as usize,
             dict: PyDict::new(py).get_type_ptr() as usize,
-            decimal: py.import("decimal").unwrap().getattr("Decimal").unwrap().as_ptr() as usize,
+            decimal_object: decimal_type.to_object(py),
+            decimal: decimal_type.as_ptr() as usize,
             string: PyString::new(py, "s").get_type_ptr() as usize,
             bytes: PyBytes::new(py, b"s").get_type_ptr() as usize,
             bytearray: PyByteArray::new(py, b"s").get_type_ptr() as usize,
@@ -82,10 +94,14 @@ impl ObTypeLookup {
             timedelta: PyDelta::new(py, 0, 0, 0, false).unwrap().get_type_ptr() as usize,
             url: PyUrl::new(lib_url.clone()).into_py(py).as_ref(py).get_type_ptr() as usize,
             multi_host_url: PyMultiHostUrl::new(lib_url, None).into_py(py).as_ref(py).get_type_ptr() as usize,
-            enum_type: py.import("enum").unwrap().getattr("Enum").unwrap().get_type_ptr() as usize,
-            generator: py.import("types").unwrap().getattr("GeneratorType").unwrap().as_ptr() as usize,
-            path: py.import("pathlib").unwrap().getattr("Path").unwrap().as_ptr() as usize,
-            uuid: py.import("uuid").unwrap().getattr("UUID").unwrap().as_ptr() as usize,
+            enum_object: enum_object.to_object(py),
+            enum_: enum_object.get_type_ptr() as usize,
+            generator_object: generator_object.to_object(py),
+            generator: generator_object.as_ptr() as usize,
+            path_object: path_object.to_object(py),
+            path: path_object.as_ptr() as usize,
+            uuid_object: uuid_object.to_object(py),
+            uuid: uuid_object.as_ptr() as usize,
         }
     }
 
@@ -94,7 +110,17 @@ impl ObTypeLookup {
     }
 
     pub fn is_type(&self, value: &PyAny, expected_ob_type: ObType) -> IsType {
-        self.ob_type_is_expected(Some(value), value.get_type_ptr(), expected_ob_type)
+        match self.ob_type_is_expected(Some(value), value.get_type_ptr(), expected_ob_type) {
+            IsType::False => {
+                dbg!(expected_ob_type, self.fallback_isinstance(value));
+                if expected_ob_type == self.fallback_isinstance(value) {
+                    IsType::Subclass
+                } else {
+                    IsType::False
+                }
+            }
+            is_type => is_type,
+        }
     }
 
     fn ob_type_is_expected(
@@ -140,10 +166,10 @@ impl ObTypeLookup {
             ObType::MultiHostUrl => self.multi_host_url == ob_type,
             ObType::Dataclass => is_dataclass(op_value),
             ObType::PydanticSerializable => is_pydantic_serializable(op_value),
-            ObType::Enum => self.enum_type == ob_type,
+            ObType::Enum => self.enum_ == ob_type,
             ObType::Generator => self.generator == ob_type,
             ObType::Path => self.path == ob_type,
-            ObType::Uuid => is_uuid(op_value),
+            ObType::Uuid => self.uuid == ob_type,
             ObType::Unknown => false,
         };
 
@@ -167,7 +193,10 @@ impl ObTypeLookup {
     }
 
     pub fn get_type(&self, value: &PyAny) -> ObType {
-        self.lookup_by_ob_type(Some(value), value.get_type_ptr())
+        match self.lookup_by_ob_type(Some(value), value.get_type_ptr()) {
+            ObType::Unknown => self.fallback_isinstance(value),
+            ob_type => ob_type,
+        }
     }
 
     fn lookup_by_ob_type(&self, op_value: Option<&PyAny>, type_ptr: *mut PyTypeObject) -> ObType {
@@ -222,6 +251,8 @@ impl ObTypeLookup {
             ObType::Url
         } else if ob_type == self.multi_host_url {
             ObType::MultiHostUrl
+        } else if ob_type == self.uuid {
+            ObType::Uuid
         } else if is_pydantic_serializable(op_value) {
             ObType::PydanticSerializable
         } else if is_dataclass(op_value) {
@@ -232,8 +263,6 @@ impl ObTypeLookup {
             ObType::Generator
         } else if ob_type == self.path {
             ObType::Path
-        } else if ob_type == self.uuid || is_uuid(op_value) {
-            ObType::Uuid
         } else {
             // this allows for subtypes of the supported class types,
             // if `ob_type` didn't match any member of self, we try again with the next base type pointer
@@ -255,9 +284,66 @@ impl ObTypeLookup {
             let meta_type = unsafe { (*type_ptr).ob_type };
             #[cfg(any(not(PyPy), Py_3_9))]
             let meta_type = unsafe { (*type_ptr).ob_base.ob_base.ob_type };
-            meta_type as usize == self.enum_type
+            meta_type as usize == self.enum_
         } else {
             false
+        }
+    }
+
+    /// If our logic for finding types by recursively checking `tp_base` fails, we fallback to this which
+    /// uses `isinstance` thus supporting both mixins and classes that implement `__instancecheck__`.
+    /// We care about order here since:
+    /// 1. we pay a price for each `isinstance` call
+    /// 2. some types are subclasses of others, e.g. `bool` is a subclass of `int`
+    /// hence we put common types first
+    fn fallback_isinstance(&self, value: &PyAny) -> ObType {
+        let py = value.py();
+        if PyBool::is_type_of(value) {
+            ObType::Bool
+        } else if PyInt::is_type_of(value) {
+            ObType::IntSubclass
+        } else if PyFloat::is_type_of(value) {
+            ObType::FloatSubclass
+        } else if PyString::is_type_of(value) {
+            ObType::StrSubclass
+        } else if PyBytes::is_type_of(value) {
+            ObType::Bytes
+        } else if PyByteArray::is_type_of(value) {
+            ObType::Bytearray
+        } else if PyList::is_type_of(value) {
+            ObType::List
+        } else if PyTuple::is_type_of(value) {
+            ObType::Tuple
+        } else if PyDict::is_type_of(value) {
+            ObType::Dict
+        } else if PySet::is_type_of(value) {
+            ObType::Set
+        } else if PyFrozenSet::is_type_of(value) {
+            ObType::Frozenset
+        } else if PyDateTime::is_type_of(value) {
+            ObType::Datetime
+        } else if PyDate::is_type_of(value) {
+            ObType::Date
+        } else if PyTime::is_type_of(value) {
+            ObType::Time
+        } else if PyDelta::is_type_of(value) {
+            ObType::Timedelta
+        } else if PyUrl::is_type_of(value) {
+            ObType::Url
+        } else if PyMultiHostUrl::is_type_of(value) {
+            ObType::MultiHostUrl
+        } else if value.is_instance(self.decimal_object.as_ref(py)).unwrap_or(false) {
+            ObType::Decimal
+        } else if value.is_instance(self.uuid_object.as_ref(py)).unwrap_or(false) {
+            ObType::Uuid
+        } else if value.is_instance(self.enum_object.as_ref(py)).unwrap_or(false) {
+            ObType::Enum
+        } else if value.is_instance(self.generator_object.as_ref(py)).unwrap_or(false) {
+            ObType::Generator
+        } else if value.is_instance(self.path_object.as_ref(py)).unwrap_or(false) {
+            ObType::Path
+        } else {
+            ObType::Unknown
         }
     }
 }
@@ -272,13 +358,6 @@ fn is_dataclass(op_value: Option<&PyAny>) -> bool {
     }
 }
 
-fn is_uuid(op_value: Option<&PyAny>) -> bool {
-    if let Some(value) = op_value {
-        value.hasattr(intern!(value.py(), "int")).unwrap_or(false)
-    } else {
-        false
-    }
-}
 fn is_pydantic_serializable(op_value: Option<&PyAny>) -> bool {
     if let Some(value) = op_value {
         value
@@ -297,7 +376,7 @@ fn is_generator(op_value: Option<&PyAny>) -> bool {
     }
 }
 
-#[derive(Debug, Clone, EnumString, Display)]
+#[derive(Debug, Clone, Copy, EnumString, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum ObType {
     None,
@@ -342,4 +421,48 @@ pub enum ObType {
     Uuid,
     // unknown type
     Unknown,
+}
+
+impl PartialEq for ObType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::None, Self::None) => true,
+            (Self::Int, Self::Int) => true,
+            (Self::IntSubclass, Self::IntSubclass) => true,
+            (Self::Bool, Self::Bool) => true,
+            (Self::Float, Self::Float) => true,
+            (Self::FloatSubclass, Self::FloatSubclass) => true,
+            (Self::Decimal, Self::Decimal) => true,
+            (Self::Str, Self::Str) => true,
+            (Self::StrSubclass, Self::StrSubclass) => true,
+            (Self::Bytes, Self::Bytes) => true,
+            (Self::Bytearray, Self::Bytearray) => true,
+            (Self::List, Self::List) => true,
+            (Self::Tuple, Self::Tuple) => true,
+            (Self::Set, Self::Set) => true,
+            (Self::Frozenset, Self::Frozenset) => true,
+            (Self::Dict, Self::Dict) => true,
+            (Self::Datetime, Self::Datetime) => true,
+            (Self::Date, Self::Date) => true,
+            (Self::Time, Self::Time) => true,
+            (Self::Timedelta, Self::Timedelta) => true,
+            (Self::Url, Self::Url) => true,
+            (Self::MultiHostUrl, Self::MultiHostUrl) => true,
+            (Self::PydanticSerializable, Self::PydanticSerializable) => true,
+            (Self::Dataclass, Self::Dataclass) => true,
+            (Self::Enum, Self::Enum) => true,
+            (Self::Generator, Self::Generator) => true,
+            (Self::Path, Self::Path) => true,
+            (Self::Uuid, Self::Uuid) => true,
+            // not Unknown here - unknowns are never equal
+            // special cases for subclasses
+            (Self::IntSubclass, Self::Int) => true,
+            (Self::Int, Self::IntSubclass) => true,
+            (Self::FloatSubclass, Self::Float) => true,
+            (Self::Float, Self::FloatSubclass) => true,
+            (Self::StrSubclass, Self::Str) => true,
+            (Self::Str, Self::StrSubclass) => true,
+            _ => false,
+        }
+    }
 }

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -368,7 +368,7 @@ fn is_generator(op_value: Option<&PyAny>) -> bool {
     }
 }
 
-#[derive(Debug, Clone, EnumString, Display)]
+#[derive(Debug, Clone, Copy, EnumString, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum ObType {
     None,
@@ -417,44 +417,20 @@ pub enum ObType {
 
 impl PartialEq for ObType {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::None, Self::None) => true,
-            (Self::Int, Self::Int) => true,
-            (Self::IntSubclass, Self::IntSubclass) => true,
-            (Self::Bool, Self::Bool) => true,
-            (Self::Float, Self::Float) => true,
-            (Self::FloatSubclass, Self::FloatSubclass) => true,
-            (Self::Decimal, Self::Decimal) => true,
-            (Self::Str, Self::Str) => true,
-            (Self::StrSubclass, Self::StrSubclass) => true,
-            (Self::Bytes, Self::Bytes) => true,
-            (Self::Bytearray, Self::Bytearray) => true,
-            (Self::List, Self::List) => true,
-            (Self::Tuple, Self::Tuple) => true,
-            (Self::Set, Self::Set) => true,
-            (Self::Frozenset, Self::Frozenset) => true,
-            (Self::Dict, Self::Dict) => true,
-            (Self::Datetime, Self::Datetime) => true,
-            (Self::Date, Self::Date) => true,
-            (Self::Time, Self::Time) => true,
-            (Self::Timedelta, Self::Timedelta) => true,
-            (Self::Url, Self::Url) => true,
-            (Self::MultiHostUrl, Self::MultiHostUrl) => true,
-            (Self::PydanticSerializable, Self::PydanticSerializable) => true,
-            (Self::Dataclass, Self::Dataclass) => true,
-            (Self::Enum, Self::Enum) => true,
-            (Self::Generator, Self::Generator) => true,
-            (Self::Path, Self::Path) => true,
-            (Self::Uuid, Self::Uuid) => true,
-            // not Unknown here - unknowns are never equal
-            // special cases for subclasses
-            (Self::IntSubclass, Self::Int) => true,
-            (Self::Int, Self::IntSubclass) => true,
-            (Self::FloatSubclass, Self::Float) => true,
-            (Self::Float, Self::FloatSubclass) => true,
-            (Self::StrSubclass, Self::Str) => true,
-            (Self::Str, Self::StrSubclass) => true,
-            _ => false,
+        if ((*self) as u8) == ((*other) as u8) {
+            // everything is equal to itself except for Unknown, which is never equal to anything
+            !matches!(self, Self::Unknown)
+        } else {
+            match (self, other) {
+                // special cases for subclasses
+                (Self::IntSubclass, Self::Int) => true,
+                (Self::Int, Self::IntSubclass) => true,
+                (Self::FloatSubclass, Self::Float) => true,
+                (Self::Float, Self::FloatSubclass) => true,
+                (Self::StrSubclass, Self::Str) => true,
+                (Self::Str, Self::StrSubclass) => true,
+                _ => false,
+            }
         }
     }
 }

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -146,7 +146,7 @@ impl TypeSerializer for DataclassSerializer {
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
         if self.allow_value(key, extra)? {
-            infer_json_key_known(&ObType::Dataclass, key, extra)
+            infer_json_key_known(ObType::Dataclass, key, extra)
         } else {
             extra.warnings.on_fallback_py(&self.name, key, extra)?;
             infer_json_key(key, extra)

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -38,7 +38,7 @@ impl TypeSerializer for DecimalSerializer {
     ) -> PyResult<PyObject> {
         let _py = value.py();
         match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
-            IsType::Exact | IsType::Subclass => infer_to_python_known(&ObType::Decimal, value, include, exclude, extra),
+            IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Decimal, value, include, exclude, extra),
             IsType::False => {
                 extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
                 infer_to_python(value, include, exclude, extra)
@@ -48,7 +48,7 @@ impl TypeSerializer for DecimalSerializer {
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
         match extra.ob_type_lookup.is_type(key, ObType::Decimal) {
-            IsType::Exact | IsType::Subclass => infer_json_key_known(&ObType::Decimal, key, extra),
+            IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Decimal, key, extra),
             IsType::False => {
                 extra.warnings.on_fallback_py(self.get_name(), key, extra)?;
                 infer_json_key(key, extra)
@@ -66,7 +66,7 @@ impl TypeSerializer for DecimalSerializer {
     ) -> Result<S::Ok, S::Error> {
         match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => {
-                infer_serialize_known(&ObType::Decimal, value, serializer, include, exclude, extra)
+                infer_serialize_known(ObType::Decimal, value, serializer, include, exclude, extra)
             }
             IsType::False => {
                 extra.warnings.on_fallback_ser::<S>(self.get_name(), value, extra)?;

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -181,7 +181,7 @@ impl TypeSerializer for ModelSerializer {
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
         if self.allow_value(key, extra)? {
-            infer_json_key_known(&ObType::PydanticSerializable, key, extra)
+            infer_json_key_known(ObType::PydanticSerializable, key, extra)
         } else {
             extra.warnings.on_fallback_py(&self.name, key, extra)?;
             infer_json_key(key, extra)

--- a/src/serializers/type_serializers/nullable.rs
+++ b/src/serializers/type_serializers/nullable.rs
@@ -50,7 +50,7 @@ impl TypeSerializer for NullableSerializer {
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
         match extra.ob_type_lookup.is_type(key, ObType::None) {
-            IsType::Exact => infer_json_key_known(&ObType::None, key, extra),
+            IsType::Exact => infer_json_key_known(ObType::None, key, extra),
             _ => self.serializer.json_key(key, extra),
         }
     }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,5 +10,4 @@ pytest-mock==3.11.1
 pytest-pretty==1.2.0
 pytest-timeout==2.1.0
 pytz==2023.3
-# later version of numpy do not support 3.7 or even 3.8
-numpy==1.21.6
+numpy==1.25.2; python_version >= "3.9" and python_version < "3.12"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,5 @@ pytest-mock==3.11.1
 pytest-pretty==1.2.0
 pytest-timeout==2.1.0
 pytz==2023.3
-numpy==1.25.2
+# later version of numpy do not support 3.7 or even 3.8
+numpy==1.21.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ pytest-mock==3.11.1
 pytest-pretty==1.2.0
 pytest-timeout==2.1.0
 pytz==2023.3
+numpy==1.25.2

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -9,7 +9,6 @@ from enum import Enum
 from pathlib import Path
 from typing import ClassVar
 
-import numpy
 import pytest
 from dirty_equals import HasRepr, IsList
 
@@ -19,6 +18,11 @@ from pydantic_core import PydanticSerializationError, SchemaSerializer, SchemaVa
 from ..conftest import plain_repr
 from .test_dataclasses import IsStrictDict, on_pypy
 from .test_list_tuple import as_list, as_tuple
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 
 @pytest.fixture(scope='module')
@@ -577,6 +581,7 @@ def test_slots_mixed(any_serializer):
     assert any_serializer.to_json(dc) == b'{"x":1,"x2":2}'
 
 
+@pytest.mark.skipif(numpy is None, reason='numpy is not installed')
 def test_numpy_float(any_serializer):
     assert any_serializer.to_python(numpy.float64(1.0)) == 1.0
     assert any_serializer.to_python(numpy.float64(1.0), mode='json') == 1.0

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -1,6 +1,7 @@
 import json
 from enum import IntEnum
 
+import numpy
 import pytest
 
 from pydantic_core import SchemaSerializer, core_schema
@@ -37,6 +38,7 @@ _BIG_NUMBER_BYTES = b'1' + (b'0' * 40)
         ('int', IntSubClass(42), IntSubClass(42), b'42'),
         ('int', MyIntEnum.one, MyIntEnum.one, b'1'),
         ('float', FloatSubClass(42), FloatSubClass(42), b'42.0'),
+        ('float', numpy.float64(1.0), numpy.float64(1.0), b'1.0'),
     ],
 )
 def test_simple_serializers(schema_type, value, expected_python, expected_json, custom_type_schema):

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -1,10 +1,14 @@
 import json
 from enum import IntEnum
 
-import numpy
 import pytest
 
 from pydantic_core import SchemaSerializer, core_schema
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 
 class IntSubClass(int):
@@ -38,7 +42,6 @@ _BIG_NUMBER_BYTES = b'1' + (b'0' * 40)
         ('int', IntSubClass(42), IntSubClass(42), b'42'),
         ('int', MyIntEnum.one, MyIntEnum.one, b'1'),
         ('float', FloatSubClass(42), FloatSubClass(42), b'42.0'),
-        ('float', numpy.float64(1.0), numpy.float64(1.0), b'1.0'),
     ],
 )
 def test_simple_serializers(schema_type, value, expected_python, expected_json, custom_type_schema):
@@ -119,3 +122,17 @@ def test_simple_serializers_fallback(schema_type):
         UserWarning, match=f'Expected `{schema_type}` but got `list` - serialized value may not be as expected'
     ):
         assert s.to_json([1, 2, 3]) == b'[1,2,3]'
+
+
+@pytest.mark.skipif(numpy is None, reason='numpy is not installed')
+def test_numpy():
+    s = SchemaSerializer(core_schema.float_schema())
+    v = s.to_python(numpy.float64(1.0))
+    assert v == 1.0
+    assert type(v) == numpy.float64
+
+    v = s.to_python(numpy.float64(1.0), mode='json')
+    assert v == 1.0
+    assert type(v) == float
+
+    assert s.to_json(numpy.float64(1.0)) == b'1.0'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -327,7 +327,12 @@ def test_json_key_fallback():
     assert to_json(x, fallback=fallback_func) == b'{"fallback:FoobarHash":1}'
 
 
-class BadRepr:
+class BedReprMeta(type):
+    def __repr__(self):
+        raise ValueError('bad repr')
+
+
+class BadRepr(metaclass=BedReprMeta):
     def __repr__(self):
         raise ValueError('bad repr')
 
@@ -338,7 +343,7 @@ class BadRepr:
 def test_bad_repr():
     b = BadRepr()
 
-    error_msg = '^Unable to serialize unknown type: <unprintable BadRepr object>$'
+    error_msg = '^Unable to serialize unknown type: <unprintable BedReprMeta object>$'
     with pytest.raises(PydanticSerializationError, match=error_msg):
         to_jsonable_python(b)
 

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -97,7 +97,7 @@ async function main() {
     setupStreams(FS, pyodide._module.TTY);
     FS.mkdir('/test_dir');
     FS.chdir('/test_dir');
-    await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
+    await pyodide.loadPackage(['micropip', 'pytest', 'pytz', 'numpy']);
     if (pydantic_core_version < '2.0.0') await pyodide.loadPackage(['typing-extensions']);
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});
     post();


### PR DESCRIPTION
## Change Summary

added a fallback method to look for subclasses of types we know how to serialize.

This should work for both custom `__isinstancecheck__` logic, and cases where types are used as mixins, e.g. `numpy.float64`.

## Related issue number

fix https://github.com/pydantic/pydantic/issues/6963

Selected Reviewer: @davidhewitt