### PR TITLE
Add unified tuple validator that can handle "variadic" tuples via PEP-646

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -142,7 +142,7 @@ def type_dict_schema(  # noqa: C901
                             'type': 'union',
                             'choices': [
                                 schema_ref_validator,
-                                {'type': 'tuple-positional', 'items_schema': [schema_ref_validator, {'type': 'str'}]},
+                                {'type': 'tuple', 'items_schema': [schema_ref_validator, {'type': 'str'}]},
                             ],
                         },
                     }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -140,8 +140,7 @@ combined_serializer! {
         Union: super::type_serializers::union::UnionSerializer;
         Literal: super::type_serializers::literal::LiteralSerializer;
         Recursive: super::type_serializers::definitions::DefinitionRefSerializer;
-        TuplePositional: super::type_serializers::tuple::TuplePositionalSerializer;
-        TupleVariable: super::type_serializers::tuple::TupleVariableSerializer;
+        Tuple: super::type_serializers::tuple::TupleSerializer;
     }
 }
 
@@ -248,8 +247,7 @@ impl PyGcTraverse for CombinedSerializer {
             CombinedSerializer::Union(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Literal(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Recursive(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::TuplePositional(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::TupleVariable(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Tuple(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Uuid(inner) => inner.py_gc_traverse(visit),
         }
     }

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -2,154 +2,29 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 use std::borrow::Cow;
+use std::iter;
 
 use serde::ser::SerializeSeq;
 
 use crate::definitions::DefinitionsBuilder;
+use crate::serializers::type_serializers::any::AnySerializer;
 use crate::tools::SchemaDict;
 
-use super::any::AnySerializer;
 use super::{
     infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, Extra,
     PydanticSerializer, SchemaFilter, SerMode, TypeSerializer,
 };
 
 #[derive(Debug, Clone)]
-pub struct TupleVariableSerializer {
-    item_serializer: Box<CombinedSerializer>,
+pub struct TupleSerializer {
+    serializers: Vec<CombinedSerializer>,
+    variadic_item_index: Option<usize>,
     filter: SchemaFilter<usize>,
     name: String,
 }
 
-impl BuildSerializer for TupleVariableSerializer {
-    const EXPECTED_TYPE: &'static str = "tuple-variable";
-
-    fn build(
-        schema: &PyDict,
-        config: Option<&PyDict>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        let py = schema.py();
-        if let Some("positional") = schema.get_as::<&str>(intern!(py, "mode"))? {
-            return TuplePositionalSerializer::build(schema, config, definitions);
-        }
-        let item_serializer = match schema.get_as::<&PyDict>(intern!(py, "items_schema"))? {
-            Some(items_schema) => CombinedSerializer::build(items_schema, config, definitions)?,
-            None => AnySerializer::build(schema, config, definitions)?,
-        };
-        let name = format!("tuple[{}, ...]", item_serializer.get_name());
-        Ok(Self {
-            item_serializer: Box::new(item_serializer),
-            filter: SchemaFilter::from_schema(schema)?,
-            name,
-        }
-        .into())
-    }
-}
-
-impl_py_gc_traverse!(TupleVariableSerializer { item_serializer });
-
-impl TypeSerializer for TupleVariableSerializer {
-    fn to_python(
-        &self,
-        value: &PyAny,
-        include: Option<&PyAny>,
-        exclude: Option<&PyAny>,
-        extra: &Extra,
-    ) -> PyResult<PyObject> {
-        match value.downcast::<PyTuple>() {
-            Ok(py_tuple) => {
-                let py = value.py();
-                let item_serializer = self.item_serializer.as_ref();
-
-                let mut items = Vec::with_capacity(py_tuple.len());
-                for (index, element) in py_tuple.iter().enumerate() {
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        items.push(item_serializer.to_python(element, next_include, next_exclude, extra)?);
-                    }
-                }
-                match extra.mode {
-                    SerMode::Json => Ok(PyList::new(py, items).into_py(py)),
-                    _ => Ok(PyTuple::new(py, items).into_py(py)),
-                }
-            }
-            Err(_) => {
-                extra.warnings.on_fallback_py(&self.name, value, extra)?;
-                infer_to_python(value, include, exclude, extra)
-            }
-        }
-    }
-
-    fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
-        match key.downcast::<PyTuple>() {
-            Ok(py_tuple) => {
-                let item_serializer = self.item_serializer.as_ref();
-
-                let mut key_builder = KeyBuilder::new();
-                for element in py_tuple {
-                    key_builder.push(&item_serializer.json_key(element, extra)?);
-                }
-                Ok(Cow::Owned(key_builder.finish()))
-            }
-            Err(_) => {
-                extra.warnings.on_fallback_py(&self.name, key, extra)?;
-                infer_json_key(key, extra)
-            }
-        }
-    }
-
-    fn serde_serialize<S: serde::ser::Serializer>(
-        &self,
-        value: &PyAny,
-        serializer: S,
-        include: Option<&PyAny>,
-        exclude: Option<&PyAny>,
-        extra: &Extra,
-    ) -> Result<S::Ok, S::Error> {
-        match value.downcast::<PyTuple>() {
-            Ok(py_tuple) => {
-                let py_tuple: &PyTuple = py_tuple.downcast().map_err(py_err_se_err)?;
-                let item_serializer = self.item_serializer.as_ref();
-
-                let mut seq = serializer.serialize_seq(Some(py_tuple.len()))?;
-                for (index, element) in py_tuple.iter().enumerate() {
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))
-                        .map_err(py_err_se_err)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let item_serialize =
-                            PydanticSerializer::new(element, item_serializer, next_include, next_exclude, extra);
-                        seq.serialize_element(&item_serialize)?;
-                    }
-                }
-                seq.end()
-            }
-            Err(_) => {
-                extra.warnings.on_fallback_ser::<S>(&self.name, value, extra)?;
-                infer_serialize(value, serializer, include, exclude, extra)
-            }
-        }
-    }
-
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct TuplePositionalSerializer {
-    items_serializers: Vec<CombinedSerializer>,
-    extra_serializer: Box<CombinedSerializer>,
-    filter: SchemaFilter<usize>,
-    name: String,
-}
-
-impl BuildSerializer for TuplePositionalSerializer {
-    const EXPECTED_TYPE: &'static str = "tuple-positional";
+impl BuildSerializer for TupleSerializer {
+    const EXPECTED_TYPE: &'static str = "tuple";
 
     fn build(
         schema: &PyDict,
@@ -158,37 +33,31 @@ impl BuildSerializer for TuplePositionalSerializer {
     ) -> PyResult<CombinedSerializer> {
         let py = schema.py();
         let items: &PyList = schema.get_as_req(intern!(py, "items_schema"))?;
-
-        let extra_serializer = match schema.get_as::<&PyDict>(intern!(py, "extras_schema"))? {
-            Some(extras_schema) => CombinedSerializer::build(extras_schema, config, definitions)?,
-            None => AnySerializer::build(schema, config, definitions)?,
-        };
-        let items_serializers: Vec<CombinedSerializer> = items
+        let serializers: Vec<CombinedSerializer> = items
             .iter()
             .map(|item| CombinedSerializer::build(item.downcast()?, config, definitions))
             .collect::<PyResult<_>>()?;
 
-        let descr = items_serializers
-            .iter()
-            .map(TypeSerializer::get_name)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut serializer_names = serializers.iter().map(TypeSerializer::get_name).collect::<Vec<_>>();
+        let variadic_item_index: Option<usize> = schema.get_as(intern!(py, "variadic_item_index"))?;
+        if let Some(variadic_item_index) = variadic_item_index {
+            serializer_names.insert(variadic_item_index + 1, "...");
+        }
+        let name = format!("tuple[{}]", serializer_names.join(", "));
+
         Ok(Self {
-            items_serializers,
-            extra_serializer: Box::new(extra_serializer),
+            serializers,
+            variadic_item_index,
             filter: SchemaFilter::from_schema(schema)?,
-            name: format!("tuple[{descr}]"),
+            name,
         }
         .into())
     }
 }
 
-impl_py_gc_traverse!(TuplePositionalSerializer {
-    items_serializers,
-    extra_serializer
-});
+impl_py_gc_traverse!(TupleSerializer { serializers });
 
-impl TypeSerializer for TuplePositionalSerializer {
+impl TypeSerializer for TupleSerializer {
     fn to_python(
         &self,
         value: &PyAny,
@@ -200,31 +69,53 @@ impl TypeSerializer for TuplePositionalSerializer {
             Ok(py_tuple) => {
                 let py = value.py();
 
+                let n_items = py_tuple.len();
                 let mut py_tuple_iter = py_tuple.iter();
-                let mut items = Vec::with_capacity(py_tuple.len());
-                for (index, serializer) in self.items_serializers.iter().enumerate() {
-                    let element = match py_tuple_iter.next() {
-                        Some(value) => value,
-                        None => break,
+                let mut items = Vec::with_capacity(n_items);
+
+                macro_rules! use_serializers {
+                    ($serializers_iter:expr) => {
+                        for (index, serializer) in $serializers_iter.enumerate() {
+                            let element = match py_tuple_iter.next() {
+                                Some(value) => value,
+                                None => break,
+                            };
+                            let op_next = self
+                                .filter
+                                .index_filter(index, include, exclude, Some(n_items))?;
+                            if let Some((next_include, next_exclude)) = op_next {
+                                items.push(serializer.to_python(element, next_include, next_exclude, extra)?);
+                            }
+                        }
                     };
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        items.push(serializer.to_python(element, next_include, next_exclude, extra)?);
-                    }
                 }
-                let expected_length = self.items_serializers.len();
-                let extra_serializer = self.extra_serializer.as_ref();
-                for (index2, element) in py_tuple_iter.enumerate() {
-                    let index = index2 + expected_length;
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        items.push(extra_serializer.to_python(element, next_include, next_exclude, extra)?);
+
+                if let Some(variadic_item_index) = self.variadic_item_index {
+                    // Need `saturating_sub` to handle items with too few elements without panicking
+                    let n_variadic_items = (n_items + 1).saturating_sub(self.serializers.len());
+                    let serializers_iter = self.serializers[..variadic_item_index]
+                        .iter()
+                        .chain(iter::repeat(&self.serializers[variadic_item_index]).take(n_variadic_items))
+                        .chain(self.serializers[variadic_item_index + 1..].iter());
+                    use_serializers!(serializers_iter);
+                } else {
+                    use_serializers!(self.serializers.iter());
+                    let mut warned = false;
+                    for (i, element) in py_tuple_iter.enumerate() {
+                        if !warned {
+                            extra
+                                .warnings
+                                .custom_warning("Unexpected extra items present in tuple".to_string());
+                            warned = true;
+                        }
+                        let op_next =
+                            self.filter
+                                .index_filter(i + self.serializers.len(), include, exclude, Some(n_items))?;
+                        if let Some((next_include, next_exclude)) = op_next {
+                            items.push(AnySerializer.to_python(element, next_include, next_exclude, extra)?);
+                        }
                     }
-                }
+                };
 
                 match extra.mode {
                     SerMode::Json => Ok(PyList::new(py, items).into_py(py)),
@@ -244,17 +135,33 @@ impl TypeSerializer for TuplePositionalSerializer {
                 let mut py_tuple_iter = py_tuple.iter();
 
                 let mut key_builder = KeyBuilder::new();
-                for serializer in &self.items_serializers {
-                    let element = match py_tuple_iter.next() {
-                        Some(value) => value,
-                        None => break,
+
+                let n_items = py_tuple.len();
+
+                macro_rules! use_serializers {
+                    ($serializers_iter:expr) => {
+                        for serializer in $serializers_iter {
+                            let element = match py_tuple_iter.next() {
+                                Some(value) => value,
+                                None => break,
+                            };
+                            key_builder.push(&serializer.json_key(element, extra)?);
+                        }
                     };
-                    key_builder.push(&serializer.json_key(element, extra)?);
                 }
-                let extra_serializer = self.extra_serializer.as_ref();
-                for element in py_tuple_iter {
-                    key_builder.push(&extra_serializer.json_key(element, extra)?);
-                }
+
+                if let Some(variadic_item_index) = self.variadic_item_index {
+                    // Need `saturating_sub` to handle items with too few elements without panicking
+                    let n_variadic_items = (n_items + 1).saturating_sub(self.serializers.len());
+                    let serializers_iter = self.serializers[..variadic_item_index]
+                        .iter()
+                        .chain(iter::repeat(&self.serializers[variadic_item_index]).take(n_variadic_items))
+                        .chain(self.serializers[variadic_item_index + 1..].iter());
+                    use_serializers!(serializers_iter);
+                } else {
+                    use_serializers!(self.serializers.iter());
+                };
+
                 Ok(Cow::Owned(key_builder.finish()))
             }
             Err(_) => {
@@ -276,38 +183,64 @@ impl TypeSerializer for TuplePositionalSerializer {
             Ok(py_tuple) => {
                 let py_tuple: &PyTuple = py_tuple.downcast().map_err(py_err_se_err)?;
 
+                let n_items = py_tuple.len();
                 let mut py_tuple_iter = py_tuple.iter();
-                let mut seq = serializer.serialize_seq(Some(py_tuple.len()))?;
-                for (index, serializer) in self.items_serializers.iter().enumerate() {
-                    let element = match py_tuple_iter.next() {
-                        Some(value) => value,
-                        None => break,
+                let mut seq = serializer.serialize_seq(Some(n_items))?;
+
+                macro_rules! use_serializers {
+                    ($serializers_iter:expr) => {
+                        for (index, serializer) in $serializers_iter.enumerate() {
+                            let element = match py_tuple_iter.next() {
+                                Some(value) => value,
+                                None => break,
+                            };
+                            let op_next = self
+                                .filter
+                                .index_filter(index, include, exclude, Some(n_items))
+                                .map_err(py_err_se_err)?;
+                            if let Some((next_include, next_exclude)) = op_next {
+                                let item_serialize =
+                                    PydanticSerializer::new(element, serializer, next_include, next_exclude, extra);
+                                seq.serialize_element(&item_serialize)?;
+                            }
+                        }
                     };
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))
-                        .map_err(py_err_se_err)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let item_serialize =
-                            PydanticSerializer::new(element, serializer, next_include, next_exclude, extra);
-                        seq.serialize_element(&item_serialize)?;
-                    }
                 }
 
-                let expected_length = self.items_serializers.len();
-                let extra_serializer = self.extra_serializer.as_ref();
-                for (index2, element) in py_tuple_iter.enumerate() {
-                    let index = index2 + expected_length;
-                    let op_next = self
-                        .filter
-                        .index_filter(index, include, exclude, Some(py_tuple.len()))
-                        .map_err(py_err_se_err)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let item_serialize =
-                            PydanticSerializer::new(element, extra_serializer, next_include, next_exclude, extra);
-                        seq.serialize_element(&item_serialize)?;
+                if let Some(variadic_item_index) = self.variadic_item_index {
+                    // Need `saturating_sub` to handle items with too few elements without panicking
+                    let n_variadic_items = (n_items + 1).saturating_sub(self.serializers.len());
+                    let serializers_iter = self.serializers[..variadic_item_index]
+                        .iter()
+                        .chain(iter::repeat(&self.serializers[variadic_item_index]).take(n_variadic_items))
+                        .chain(self.serializers[variadic_item_index + 1..].iter());
+                    use_serializers!(serializers_iter);
+                } else {
+                    use_serializers!(self.serializers.iter());
+                    let mut warned = false;
+                    for (i, element) in py_tuple_iter.enumerate() {
+                        if !warned {
+                            extra
+                                .warnings
+                                .custom_warning("Unexpected extra items present in tuple".to_string());
+                            warned = true;
+                        }
+                        let op_next = self
+                            .filter
+                            .index_filter(i + self.serializers.len(), include, exclude, Some(n_items))
+                            .map_err(py_err_se_err)?;
+                        if let Some((next_include, next_exclude)) = op_next {
+                            let item_serialize = PydanticSerializer::new(
+                                element,
+                                &CombinedSerializer::Any(AnySerializer),
+                                next_include,
+                                next_exclude,
+                                extra,
+                            );
+                            seq.serialize_element(&item_serialize)?;
+                        }
                     }
-                }
+                };
 
                 seq.end()
             }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -491,8 +491,7 @@ pub fn build_validator<'a>(
         // decimals
         decimal::DecimalValidator,
         // tuples
-        tuple::TuplePositionalValidator,
-        tuple::TupleVariableValidator,
+        tuple::TupleValidator,
         // list/arrays
         list::ListValidator,
         // sets - unique lists
@@ -639,8 +638,7 @@ pub enum CombinedValidator {
     // sets - unique lists
     Set(set::SetValidator),
     // tuples
-    TuplePositional(tuple::TuplePositionalValidator),
-    TupleVariable(tuple::TupleVariableValidator),
+    Tuple(tuple::TupleValidator),
     // dicts/objects (recursive)
     Dict(dict::DictValidator),
     // None/null

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -1,87 +1,28 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
+use std::collections::VecDeque;
 
 use crate::build_tools::is_strict;
-use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
+use crate::errors::{py_err_string, ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{GenericIterable, Input};
 use crate::tools::SchemaDict;
 use crate::validators::Exactness;
 
-use super::list::{get_items_schema, min_length_check};
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug)]
-pub struct TupleVariableValidator {
+pub struct TupleValidator {
     strict: bool,
-    item_validator: Option<Box<CombinedValidator>>,
+    validators: Vec<CombinedValidator>,
+    variadic_item_index: Option<usize>,
     min_length: Option<usize>,
     max_length: Option<usize>,
     name: String,
 }
 
-impl BuildValidator for TupleVariableValidator {
-    const EXPECTED_TYPE: &'static str = "tuple-variable";
-    fn build(
-        schema: &PyDict,
-        config: Option<&PyDict>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        let py = schema.py();
-        let item_validator = get_items_schema(schema, config, definitions)?.map(Box::new);
-        let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
-        let name = format!("tuple[{inner_name}, ...]");
-        Ok(Self {
-            strict: is_strict(schema, config)?,
-            item_validator,
-            min_length: schema.get_as(intern!(py, "min_length"))?,
-            max_length: schema.get_as(intern!(py, "max_length"))?,
-            name,
-        }
-        .into())
-    }
-}
-
-impl_py_gc_traverse!(TupleVariableValidator { item_validator });
-
-impl Validator for TupleVariableValidator {
-    fn validate<'data>(
-        &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
-        state: &mut ValidationState,
-    ) -> ValResult<PyObject> {
-        let seq = input.validate_tuple(state.strict_or(self.strict))?;
-        let exactness = match &seq {
-            GenericIterable::Tuple(_) | GenericIterable::JsonArray(_) => Exactness::Exact,
-            GenericIterable::List(_) => Exactness::Strict,
-            _ => Exactness::Lax,
-        };
-        state.floor_exactness(exactness);
-
-        let output = match self.item_validator {
-            Some(ref v) => seq.validate_to_vec(py, input, self.max_length, "Tuple", v, state)?,
-            None => seq.to_vec(py, input, "Tuple", self.max_length)?,
-        };
-        min_length_check!(input, "Tuple", self.min_length, output);
-        Ok(PyTuple::new(py, &output).into_py(py))
-    }
-
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-#[derive(Debug)]
-pub struct TuplePositionalValidator {
-    strict: bool,
-    items_validators: Vec<CombinedValidator>,
-    extras_validator: Option<Box<CombinedValidator>>,
-    name: String,
-}
-
-impl BuildValidator for TuplePositionalValidator {
-    const EXPECTED_TYPE: &'static str = "tuple-positional";
+impl BuildValidator for TupleValidator {
+    const EXPECTED_TYPE: &'static str = "tuple";
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
@@ -94,139 +35,296 @@ impl BuildValidator for TuplePositionalValidator {
             .map(|item| build_validator(item, config, definitions))
             .collect::<PyResult<_>>()?;
 
-        let descr = validators
-            .iter()
-            .map(Validator::get_name)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut validator_names = validators.iter().map(Validator::get_name).collect::<Vec<_>>();
+        let variadic_item_index: Option<usize> = schema.get_as(intern!(py, "variadic_item_index"))?;
+        // FIXME add friendly schema error if item out of bounds
+        if let Some(variadic_item_index) = variadic_item_index {
+            validator_names.insert(variadic_item_index + 1, "...");
+        }
+        let name = format!("tuple[{}]", validator_names.join(", "));
+
         Ok(Self {
             strict: is_strict(schema, config)?,
-            items_validators: validators,
-            extras_validator: match schema.get_item(intern!(py, "extras_schema"))? {
-                Some(v) => Some(Box::new(build_validator(v, config, definitions)?)),
-                None => None,
-            },
-            name: format!("tuple[{descr}]"),
+            validators,
+            variadic_item_index,
+            min_length: schema.get_as(intern!(py, "min_length"))?,
+            max_length: schema.get_as(intern!(py, "max_length"))?,
+            name,
         }
         .into())
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn validate_tuple_positional<'s, 'data, T: Iterator<Item = PyResult<&'data I>>, I: Input<'data> + 'data>(
-    py: Python<'data>,
-    input: &'data impl Input<'data>,
-    state: &mut ValidationState,
-    output: &mut Vec<PyObject>,
-    errors: &mut Vec<ValLineError>,
-    extras_validator: &Option<Box<CombinedValidator>>,
-    items_validators: &[CombinedValidator],
-    collection_iter: &mut T,
-    actual_length: Option<usize>,
-) -> ValResult<()> {
-    for (index, validator) in items_validators.iter().enumerate() {
-        match collection_iter.next() {
-            Some(result) => match validator.validate(py, result?, state) {
-                Ok(item) => output.push(item),
-                Err(ValError::LineErrors(line_errors)) => {
-                    errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index.into())));
-                }
-                Err(err) => return Err(err),
-            },
-            None => {
-                if let Some(value) = validator.default_value(py, Some(index), state)? {
-                    output.push(value);
-                } else {
-                    errors.push(ValLineError::new_with_loc(ErrorTypeDefaults::Missing, input, index));
+impl_py_gc_traverse!(TupleValidator { validators });
+
+impl TupleValidator {
+    #[allow(clippy::too_many_arguments)]
+    fn validate_tuple_items<'s, 'data, I: Input<'data> + 'data>(
+        &self,
+        py: Python<'data>,
+        input: &'data impl Input<'data>,
+        state: &mut ValidationState,
+        output: &mut Vec<PyObject>,
+        errors: &mut Vec<ValLineError>,
+        item_validators: &[CombinedValidator],
+        collection_iter: &mut NextCountingIterator<impl Iterator<Item = &'data I>>,
+        actual_length: Option<usize>,
+    ) -> ValResult<()> {
+        // Validate the head:
+        for validator in item_validators {
+            match collection_iter.next() {
+                Some((index, input_item)) => match validator.validate(py, input_item, state) {
+                    Ok(item) => self.push_output_item(input, output, item, actual_length)?,
+                    Err(ValError::LineErrors(line_errors)) => {
+                        errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index.into())));
+                    }
+                    Err(ValError::Omit) => (),
+                    Err(err) => return Err(err),
+                },
+                None => {
+                    let index = collection_iter.next_calls() - 1;
+                    if let Some(value) = validator.default_value(py, Some(index), state)? {
+                        output.push(value);
+                    } else {
+                        errors.push(ValLineError::new_with_loc(ErrorTypeDefaults::Missing, input, index));
+                    }
                 }
             }
         }
+
+        Ok(())
     }
-    for (index, result) in collection_iter.enumerate() {
-        let item = result?;
-        match extras_validator {
-            Some(ref extras_validator) => match extras_validator.validate(py, item, state) {
-                Ok(item) => output.push(item),
-                Err(ValError::LineErrors(line_errors)) => {
-                    errors.extend(
-                        line_errors
-                            .into_iter()
-                            .map(|err| err.with_outer_location((index + items_validators.len()).into())),
-                    );
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_tuple_variable<'data, I: Input<'data> + 'data, InputT: Input<'data> + 'data>(
+        &self,
+        py: Python<'data>,
+        input: &'data InputT,
+        state: &mut ValidationState,
+        errors: &mut Vec<ValLineError>,
+        collection_iter: &mut NextCountingIterator<impl Iterator<Item = &'data I>>,
+        actual_length: Option<usize>,
+    ) -> ValResult<Vec<PyObject>> {
+        let expected_length = if self.variadic_item_index.is_some() {
+            actual_length.unwrap_or(self.validators.len())
+        } else {
+            self.validators.len()
+        };
+        let mut output = Vec::with_capacity(expected_length);
+        if let Some(variable_validator_index) = self.variadic_item_index {
+            let (head_validators, [variable_validator, tail_validators @ ..]) =
+                self.validators.split_at(variable_validator_index)
+            else {
+                unreachable!("validators will always contain variable validator")
+            };
+
+            // Validate the "head" items
+            self.validate_tuple_items(
+                py,
+                input,
+                state,
+                &mut output,
+                errors,
+                head_validators,
+                collection_iter,
+                actual_length,
+            )?;
+
+            let n_tail_validators = tail_validators.len();
+            if n_tail_validators == 0 {
+                for (index, input_item) in collection_iter {
+                    match variable_validator.validate(py, input_item, state) {
+                        Ok(item) => self.push_output_item(input, &mut output, item, actual_length)?,
+                        Err(ValError::LineErrors(line_errors)) => {
+                            errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index.into())));
+                        }
+                        Err(ValError::Omit) => (),
+                        Err(err) => return Err(err),
+                    }
                 }
-                Err(ValError::Omit) => (),
-                Err(err) => return Err(err),
-            },
-            None => {
-                errors.push(ValLineError::new(
+            } else {
+                // Populate a buffer with the first n_tail_validators items
+                // NB: We take from collection_iter.inner to avoid increasing the next calls count
+                // while populating the buffer. This means the index in the following loop is the
+                // right one for user errors.
+                let mut tail_buffer: VecDeque<&'data I> =
+                    collection_iter.inner.by_ref().take(n_tail_validators).collect();
+
+                // Save the current index for the tail validation below when we recreate a new NextCountingIterator
+                let mut index = collection_iter.next_calls();
+
+                // Iterate over all remaining collection items, validating as items "leave" the buffer
+                for (buffer_item_index, input_item) in collection_iter {
+                    index = buffer_item_index;
+                    // This `unwrap` is safe because you can only get here
+                    // if there were at least `n_tail_validators` (> 0) items in the iterator
+                    let buffered_item = tail_buffer.pop_front().unwrap();
+                    tail_buffer.push_back(input_item);
+
+                    match variable_validator.validate(py, buffered_item, state) {
+                        Ok(item) => self.push_output_item(input, &mut output, item, actual_length)?,
+                        Err(ValError::LineErrors(line_errors)) => {
+                            errors.extend(
+                                line_errors
+                                    .into_iter()
+                                    .map(|err| err.with_outer_location(buffer_item_index.into())),
+                            );
+                        }
+                        Err(ValError::Omit) => (),
+                        Err(err) => return Err(err),
+                    }
+                }
+
+                // Validate the buffered items using the tail validators
+                self.validate_tuple_items(
+                    py,
+                    input,
+                    state,
+                    &mut output,
+                    errors,
+                    tail_validators,
+                    &mut NextCountingIterator::new(tail_buffer.into_iter(), index),
+                    actual_length,
+                )?;
+            }
+        } else {
+            // Validate all items as positional
+            self.validate_tuple_items(
+                py,
+                input,
+                state,
+                &mut output,
+                errors,
+                &self.validators,
+                collection_iter,
+                actual_length,
+            )?;
+
+            // Generate an error if there are any extra items:
+            if collection_iter.next().is_some() {
+                return Err(ValError::new(
                     ErrorType::TooLong {
                         field_type: "Tuple".to_string(),
-                        max_length: items_validators.len(),
+                        max_length: self.validators.len(),
                         actual_length,
                         context: None,
                     },
                     input,
                 ));
-                // no need to continue through further items
-                break;
             }
         }
+        Ok(output)
     }
-    Ok(())
+
+    fn push_output_item<'data>(
+        &self,
+        input: &'data impl Input<'data>,
+        output: &mut Vec<PyObject>,
+        item: PyObject,
+        actual_length: Option<usize>,
+    ) -> ValResult<()> {
+        output.push(item);
+        if let Some(max_length) = self.max_length {
+            if output.len() > max_length {
+                return Err(ValError::new(
+                    ErrorType::TooLong {
+                        field_type: "Tuple".to_string(),
+                        max_length,
+                        actual_length,
+                        context: None,
+                    },
+                    input,
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
-impl_py_gc_traverse!(TuplePositionalValidator {
-    items_validators,
-    extras_validator
-});
-
-impl Validator for TuplePositionalValidator {
+impl Validator for TupleValidator {
     fn validate<'data>(
         &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
-        let collection = input.validate_tuple(state.strict_or(self.strict))?;
-        let exactness: crate::validators::Exactness = match &collection {
+        let collection: GenericIterable<'_> = input.validate_tuple(state.strict_or(self.strict))?;
+        let exactness = match &collection {
             GenericIterable::Tuple(_) | GenericIterable::JsonArray(_) => Exactness::Exact,
             GenericIterable::List(_) => Exactness::Strict,
             _ => Exactness::Lax,
         };
         state.floor_exactness(exactness);
-
         let actual_length = collection.generic_len();
-        let expected_length = if self.extras_validator.is_some() {
-            actual_length.unwrap_or(self.items_validators.len())
-        } else {
-            self.items_validators.len()
-        };
 
-        let mut output: Vec<PyObject> = Vec::with_capacity(expected_length);
         let mut errors: Vec<ValLineError> = Vec::new();
 
+        let mut iteration_error = None;
+
         macro_rules! iter {
-            ($collection_iter:expr) => {{
-                validate_tuple_positional(
+            ($collection_iter:expr) => {
+                self.validate_tuple_variable(
                     py,
                     input,
                     state,
-                    &mut output,
                     &mut errors,
-                    &self.extras_validator,
-                    &self.items_validators,
-                    &mut $collection_iter,
+                    &mut NextCountingIterator::new($collection_iter, 0),
                     actual_length,
-                )?
-            }};
+                )
+            };
         }
 
-        match collection {
-            GenericIterable::List(collection_iter) => iter!(collection_iter.iter().map(Ok)),
-            GenericIterable::Tuple(collection_iter) => iter!(collection_iter.iter().map(Ok)),
-            GenericIterable::JsonArray(collection_iter) => iter!(collection_iter.iter().map(Ok)),
-            other => iter!(other.as_sequence_iterator(py)?),
+        let output = match collection {
+            GenericIterable::List(collection_iter) => iter!(collection_iter.iter())?,
+            GenericIterable::Tuple(collection_iter) => iter!(collection_iter.iter())?,
+            GenericIterable::JsonArray(collection_iter) => iter!(collection_iter.iter())?,
+            other => iter!({
+                let mut sequence_iterator = other.as_sequence_iterator(py)?;
+                let iteration_error = &mut iteration_error;
+                let mut index: usize = 0;
+                std::iter::from_fn(move || {
+                    if iteration_error.is_some() {
+                        return None;
+                    }
+                    index += 1;
+                    match sequence_iterator.next() {
+                        Some(Ok(item)) => Some(item),
+                        Some(Err(e)) => {
+                            *iteration_error = Some(ValError::new_with_loc(
+                                ErrorType::IterationError {
+                                    error: py_err_string(py, e),
+                                    context: None,
+                                },
+                                input,
+                                index,
+                            ));
+                            None
+                        }
+                        None => None,
+                    }
+                })
+            })?,
+        };
+
+        if let Some(err) = iteration_error {
+            return Err(err);
         }
+
+        if let Some(min_length) = self.min_length {
+            let actual_length = output.len();
+            if actual_length < min_length {
+                errors.push(ValLineError::new(
+                    ErrorType::TooShort {
+                        field_type: "Tuple".to_string(),
+                        min_length,
+                        actual_length,
+                        context: None,
+                    },
+                    input,
+                ));
+            }
+        }
+
         if errors.is_empty() {
             Ok(PyTuple::new(py, &output).into_py(py))
         } else {
@@ -236,5 +334,30 @@ impl Validator for TuplePositionalValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+}
+
+struct NextCountingIterator<I: Iterator> {
+    inner: I,
+    count: usize,
+}
+
+impl<I: Iterator> NextCountingIterator<I> {
+    fn new(inner: I, count: usize) -> Self {
+        Self { inner, count }
+    }
+
+    fn next_calls(&self) -> usize {
+        self.count
+    }
+}
+
+impl<I: Iterator> Iterator for NextCountingIterator<I> {
+    type Item = (usize, I::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let count = self.count;
+        self.count += 1;
+        self.inner.next().map(|item| (count, item))
     }
 }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -457,7 +457,7 @@ impl TaggedUnionValidator {
         let tag_cow = either_tag.as_cow()?;
         let tag = tag_cow.as_ref();
         // custom logic to distinguish between different function and tuple schemas
-        if tag == "function" || tag == "tuple" {
+        if tag == "function" {
             let mode = match dict {
                 GenericMapping::PyDict(dict) => match dict.get_item(intern!(py, "mode"))? {
                     Some(m) => Some(m.validate_str(true, false)?.into_inner()),
@@ -465,21 +465,11 @@ impl TaggedUnionValidator {
                 },
                 _ => unreachable!(),
             };
-            if tag == "function" {
-                let mode = mode.ok_or_else(|| self.tag_not_found(input))?;
-                match mode.as_cow()?.as_ref() {
-                    "plain" => Ok(intern!(py, "function-plain")),
-                    "wrap" => Ok(intern!(py, "function-wrap")),
-                    _ => Ok(intern!(py, "function")),
-                }
-            } else {
-                // tag == "tuple"
-                if let Some(mode) = mode {
-                    if mode.as_cow()?.as_ref() == "positional" {
-                        return Ok(intern!(py, "tuple-positional"));
-                    }
-                }
-                Ok(intern!(py, "tuple-variable"))
+            let mode = mode.ok_or_else(|| self.tag_not_found(input))?;
+            match mode.as_cow()?.as_ref() {
+                "plain" => Ok(intern!(py, "function-plain")),
+                "wrap" => Ok(intern!(py, "function-wrap")),
+                _ => Ok(intern!(py, "function")),
             }
         } else {
             Ok(PyString::new(py, tag))

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -83,16 +83,20 @@ def schema(*, strict: bool = False) -> dict:
                         'max_length': 42,
                     },
                 },
-                'field_tuple_var_len_any': {'type': 'model-field', 'schema': {'type': 'tuple-variable'}},
+                'field_tuple_var_len_any': {
+                    'type': 'model-field',
+                    'schema': {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
+                },
                 'field_tuple_var_len_float': {
                     'type': 'model-field',
-                    'schema': {'type': 'tuple-variable', 'items_schema': {'type': 'float'}},
+                    'schema': {'type': 'tuple', 'items_schema': [{'type': 'float'}], 'variadic_item_index': 0},
                 },
                 'field_tuple_var_len_float_con': {
                     'type': 'model-field',
                     'schema': {
-                        'type': 'tuple-variable',
-                        'items_schema': {'type': 'float'},
+                        'type': 'tuple',
+                        'items_schema': [{'type': 'float'}],
+                        'variadic_item_index': 0,
                         'min_length': 3,
                         'max_length': 42,
                     },
@@ -100,7 +104,7 @@ def schema(*, strict: bool = False) -> dict:
                 'field_tuple_fix_len': {
                     'type': 'model-field',
                     'schema': {
-                        'type': 'tuple-positional',
+                        'type': 'tuple',
                         'items_schema': [{'type': 'str'}, {'type': 'int'}, {'type': 'float'}, {'type': 'bool'}],
                     },
                 },

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -848,7 +848,7 @@ def test_raise_error_custom(benchmark):
 def test_positional_tuple(benchmark):
     v = SchemaValidator(
         {
-            'type': 'tuple-positional',
+            'type': 'tuple',
             'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}, {'type': 'int'}, {'type': 'int'}],
         }
     )
@@ -859,7 +859,7 @@ def test_positional_tuple(benchmark):
 
 @pytest.mark.benchmark(group='tuple')
 def test_variable_tuple(benchmark):
-    v = SchemaValidator({'type': 'tuple-variable', 'items_schema': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     assert v.validate_python((1, 2, 3, '4', 5)) == (1, 2, 3, 4, 5)
 
     benchmark(v.validate_python, (1, 2, 3, '4', 5))
@@ -867,7 +867,7 @@ def test_variable_tuple(benchmark):
 
 @pytest.mark.benchmark(group='tuple-many')
 def test_tuple_many_variable(benchmark):
-    v = SchemaValidator({'type': 'tuple-variable', 'items_schema': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     assert v.validate_python(list(range(10))) == tuple(range(10))
 
     benchmark(v.validate_python, list(range(10)))
@@ -875,7 +875,7 @@ def test_tuple_many_variable(benchmark):
 
 @pytest.mark.benchmark(group='tuple-many')
 def test_tuple_many_positional(benchmark):
-    v = SchemaValidator({'type': 'tuple-positional', 'items_schema': [], 'extras_schema': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     assert v.validate_python(list(range(10))) == tuple(range(10))
 
     benchmark(v.validate_python, list(range(10)))

--- a/tests/serializers/test_none.py
+++ b/tests/serializers/test_none.py
@@ -16,7 +16,7 @@ all_scalars = (
     'url',
     'multi-host-url',
 )
-all_types = all_scalars + ('list', 'tuple-variable', 'dict', 'set', 'frozenset')
+all_types = all_scalars + ('list', 'dict', 'set', 'frozenset')
 
 
 @pytest.mark.parametrize('schema_type', all_types)

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -79,17 +79,7 @@ all_schema_functions = [
     (core_schema.callable_schema, args(), {'type': 'callable'}),
     (core_schema.list_schema, args(), {'type': 'list'}),
     (core_schema.list_schema, args({'type': 'int'}), {'type': 'list', 'items_schema': {'type': 'int'}}),
-    (
-        core_schema.tuple_positional_schema,
-        args([{'type': 'int'}]),
-        {'type': 'tuple-positional', 'items_schema': [{'type': 'int'}]},
-    ),
-    (core_schema.tuple_positional_schema, args([]), {'type': 'tuple-positional', 'items_schema': []}),
-    (
-        core_schema.tuple_variable_schema,
-        args({'type': 'int'}),
-        {'type': 'tuple-variable', 'items_schema': {'type': 'int'}},
-    ),
+    (core_schema.tuple_schema, args([]), {'type': 'tuple', 'items_schema': []}),
     (
         core_schema.set_schema,
         args({'type': 'int'}, min_length=4),

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -77,9 +77,9 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: CoreSchema = {'type': 'set', 'items_schema': {'type': 'str'}, 'max_length': 3}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'tuple-variable', 'items_schema': {'type': 'str'}, 'max_length': 3}
+    schema: CoreSchema = {'type': 'tuple', 'items_schema': [{'type': 'str'}], 'variadic_item_index': 0, 'max_length': 3}
     SchemaValidator(schema)
-    schema: CoreSchema = {'type': 'tuple-positional', 'items_schema': [{'type': 'str'}, {'type': 'int'}]}
+    schema: CoreSchema = {'type': 'tuple', 'items_schema': [{'type': 'str'}, {'type': 'int'}]}
     SchemaValidator(schema)
     schema: CoreSchema = {'type': 'frozenset', 'items_schema': {'type': 'str'}, 'max_length': 3}
     SchemaValidator(schema)

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -279,7 +279,7 @@ def test_outside_parent():
                 }
             ),
             [
-                core_schema.tuple_positional_schema(
+                core_schema.tuple_schema(
                     [core_schema.int_schema(), core_schema.int_schema(), core_schema.str_schema()], ref='tuple-iis'
                 )
             ],
@@ -426,7 +426,7 @@ def multiple_tuple_schema() -> SchemaValidator:
                 }
             ),
             [
-                core_schema.tuple_positional_schema(
+                core_schema.tuple_schema(
                     [
                         core_schema.int_schema(),
                         core_schema.nullable_schema(core_schema.definition_reference_schema('t')),
@@ -522,7 +522,7 @@ def test_definition_wrap():
             [
                 core_schema.with_info_wrap_validator_function(
                     wrap_func,
-                    core_schema.tuple_positional_schema(
+                    core_schema.tuple_schema(
                         [
                             core_schema.int_schema(),
                             core_schema.nullable_schema(core_schema.definition_reference_schema('wrapper')),

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -276,13 +276,13 @@ def test_generator_error():
     [
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'any'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
             frozenset(((1, 10), (2, 20), ('3', '30'))),
             id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'int'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0},
             frozenset(((1, 10), (2, 20), (3, 30))),
             id='Tuple[int, int]',
         ),

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -305,13 +305,13 @@ def test_generator_error():
     [
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'any'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
             [(1, 10), (2, 20), ('3', '30')],
             id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'int'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0},
             [(1, 10), (2, 20), (3, 30)],
             id='Tuple[int, int]',
         ),

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -242,13 +242,13 @@ def test_generator_error():
     [
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'any'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
             {(1, 10), (2, 20), ('3', '30')},
             id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'int'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0},
             {(1, 10), (2, 20), (3, 30)},
             id='Tuple[int, int]',
         ),

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -5,19 +5,19 @@ from typing import Any, Dict, Type
 import pytest
 from dirty_equals import IsNonNegative, IsTuple
 
-from pydantic_core import SchemaValidator, ValidationError
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson, infinite_generator
 
 
 @pytest.mark.parametrize(
-    'mode,items,input_value,expected',
+    'variadic_item_index,items,input_value,expected',
     [
-        ('variable', {'type': 'int'}, [1, 2, 3], (1, 2, 3)),
-        ('variable', {'type': 'int'}, 1, Err('[type=tuple_type, input_value=1, input_type=int]')),
-        ('positional', [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}], [1, 2, '3'], (1, 2, 3)),
+        (0, [{'type': 'int'}], [1, 2, 3], (1, 2, 3)),
+        (0, [{'type': 'int'}], 1, Err('[type=tuple_type, input_value=1, input_type=int]')),
+        (None, [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}], [1, 2, '3'], (1, 2, 3)),
         (
-            'positional',
+            None,
             [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}],
             5,
             Err('[type=tuple_type, input_value=5, input_type=int]'),
@@ -25,8 +25,8 @@ from ..conftest import Err, PyAndJson, infinite_generator
     ],
     ids=repr,
 )
-def test_tuple_json(py_and_json: PyAndJson, mode, items, input_value, expected):
-    v = py_and_json({'type': f'tuple-{mode}', 'items_schema': items})
+def test_tuple_json(py_and_json: PyAndJson, variadic_item_index, items, input_value, expected):
+    v = py_and_json(core_schema.tuple_schema(items_schema=items, variadic_item_index=variadic_item_index))
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)
@@ -35,7 +35,7 @@ def test_tuple_json(py_and_json: PyAndJson, mode, items, input_value, expected):
 
 
 def test_any_no_copy():
-    v = SchemaValidator({'type': 'tuple-variable'})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0})
     input_value = (1, '2', b'3')
     output = v.validate_python(input_value)
     assert output == input_value
@@ -44,20 +44,22 @@ def test_any_no_copy():
 
 
 @pytest.mark.parametrize(
-    'mode,items,input_value,expected',
+    'variadic_item_index,items,input_value,expected',
     [
-        ('variable', {'type': 'int'}, (1, 2, '33'), (1, 2, 33)),
-        ('variable', {'type': 'str'}, (b'1', b'2', '33'), ('1', '2', '33')),
-        ('positional', [{'type': 'int'}, {'type': 'str'}, {'type': 'float'}], (1, b'a', 33), (1, 'a', 33.0)),
+        (0, [{'type': 'int'}], (1, 2, '33'), (1, 2, 33)),
+        (0, [{'type': 'str'}], (b'1', b'2', '33'), ('1', '2', '33')),
+        (None, [{'type': 'int'}, {'type': 'str'}, {'type': 'float'}], (1, b'a', 33), (1, 'a', 33.0)),
     ],
 )
-def test_tuple_strict_passes_with_tuple(mode, items, input_value, expected):
-    v = SchemaValidator({'type': f'tuple-{mode}', 'items_schema': items, 'strict': True})
+def test_tuple_strict_passes_with_tuple(variadic_item_index, items, input_value, expected):
+    v = SchemaValidator(
+        core_schema.tuple_schema(items_schema=items, variadic_item_index=variadic_item_index, strict=True)
+    )
     assert v.validate_python(input_value) == expected
 
 
 def test_empty_positional_tuple():
-    v = SchemaValidator({'type': 'tuple-positional', 'items_schema': []})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': []})
     assert v.validate_python(()) == ()
     assert v.validate_python([]) == ()
     with pytest.raises(ValidationError) as exc_info:
@@ -76,11 +78,13 @@ def test_empty_positional_tuple():
 
 
 @pytest.mark.parametrize(
-    'mode,items', [('variable', {'type': 'int'}), ('positional', [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
+    'variadic_item_index,items', [(0, [{'type': 'int'}]), (None, [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
 )
 @pytest.mark.parametrize('wrong_coll_type', [list, set, frozenset])
-def test_tuple_strict_fails_without_tuple(wrong_coll_type: Type[Any], mode, items):
-    v = SchemaValidator({'type': f'tuple-{mode}', 'items_schema': items, 'strict': True})
+def test_tuple_strict_fails_without_tuple(wrong_coll_type: Type[Any], variadic_item_index, items):
+    v = SchemaValidator(
+        core_schema.tuple_schema(variadic_item_index=variadic_item_index, items_schema=items, strict=True)
+    )
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(wrong_coll_type([1, 2, '33']))
     assert exc_info.value.errors(include_url=False) == [
@@ -119,7 +123,7 @@ def test_tuple_strict_fails_without_tuple(wrong_coll_type: Type[Any], mode, item
     ids=repr,
 )
 def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
-    v = SchemaValidator({'type': 'tuple-variable', **kwargs})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0, **kwargs})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -128,7 +132,7 @@ def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
 
 
 @pytest.mark.parametrize(
-    'mode,items', [('variable', {'type': 'int'}), ('positional', [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
+    'variadic_item_index,items', [(0, [{'type': 'int'}]), (None, [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
 )
 @pytest.mark.parametrize(
     'input_value,expected',
@@ -144,8 +148,8 @@ def test_tuple_var_len_kwargs(kwargs: Dict[str, Any], input_value, expected):
     ],
     ids=repr,
 )
-def test_tuple_validate(input_value, expected, mode, items):
-    v = SchemaValidator({'type': f'tuple-{mode}', 'items_schema': items})
+def test_tuple_validate(input_value, expected, variadic_item_index, items):
+    v = SchemaValidator(core_schema.tuple_schema(items_schema=items, variadic_item_index=variadic_item_index))
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -157,10 +161,10 @@ def test_tuple_validate(input_value, expected, mode, items):
 # on the first test run. This is a workaround to make sure the generator is
 # always recreated.
 @pytest.mark.parametrize(
-    'mode,items', [('variable', {'type': 'int'}), ('positional', [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
+    'variadic_item_index,items', [(0, [{'type': 'int'}]), (None, [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}])]
 )
-def test_tuple_validate_iterator(mode, items):
-    v = SchemaValidator({'type': f'tuple-{mode}', 'items_schema': items})
+def test_tuple_validate_iterator(variadic_item_index, items):
+    v = SchemaValidator(core_schema.tuple_schema(items_schema=items, variadic_item_index=variadic_item_index))
     assert v.validate_python((x for x in [1, 2, '3'])) == (1, 2, 3)
 
 
@@ -175,7 +179,7 @@ def test_tuple_validate_iterator(mode, items):
     ],
 )
 def test_tuple_var_len_errors(input_value, index):
-    v = SchemaValidator({'type': 'tuple-variable', 'items_schema': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python(input_value)
     assert exc_info.value.errors(include_url=False) == [
@@ -203,7 +207,7 @@ def test_tuple_var_len_errors(input_value, index):
     ],
 )
 def test_tuple_fix_len_errors(input_value, items, index):
-    v = SchemaValidator({'type': 'tuple-positional', 'items_schema': items})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': items})
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python(input_value)
     assert exc_info.value.errors(include_url=False) == [
@@ -218,10 +222,7 @@ def test_tuple_fix_len_errors(input_value, items, index):
 
 def test_multiple_missing(py_and_json: PyAndJson):
     v = py_and_json(
-        {
-            'type': 'tuple-positional',
-            'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}, {'type': 'int'}],
-        }
+        {'type': 'tuple', 'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}, {'type': 'int'}]}
     )
     assert v.validate_test([1, 2, 3, 4]) == (1, 2, 3, 4)
     with pytest.raises(ValidationError) as exc_info:
@@ -239,7 +240,7 @@ def test_multiple_missing(py_and_json: PyAndJson):
 
 
 def test_extra_arguments(py_and_json: PyAndJson):
-    v = py_and_json({'type': 'tuple-positional', 'items_schema': [{'type': 'int'}, {'type': 'int'}]})
+    v = py_and_json({'type': 'tuple', 'items_schema': [{'type': 'int'}, {'type': 'int'}]})
     assert v.validate_test([1, 2]) == (1, 2)
     with pytest.raises(ValidationError) as exc_info:
         v.validate_test([1, 2, 3, 4])
@@ -256,7 +257,7 @@ def test_extra_arguments(py_and_json: PyAndJson):
 
 
 def test_positional_empty(py_and_json: PyAndJson):
-    v = py_and_json({'type': 'tuple-positional', 'items_schema': []})
+    v = py_and_json({'type': 'tuple', 'items_schema': []})
     assert v.validate_test([]) == ()
     assert v.validate_python(()) == ()
     with pytest.raises(ValidationError, match='type=too_long,'):
@@ -264,7 +265,7 @@ def test_positional_empty(py_and_json: PyAndJson):
 
 
 def test_positional_empty_extra(py_and_json: PyAndJson):
-    v = py_and_json({'type': 'tuple-positional', 'items_schema': [], 'extras_schema': {'type': 'int'}})
+    v = py_and_json({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     assert v.validate_test([]) == ()
     assert v.validate_python(()) == ()
     assert v.validate_test([1]) == (1,)
@@ -273,7 +274,15 @@ def test_positional_empty_extra(py_and_json: PyAndJson):
 
 @pytest.mark.parametrize('input_value,expected', [((1, 2, 3), (1, 2, 3)), ([1, 2, 3], [1, 2, 3])])
 def test_union_tuple_list(input_value, expected):
-    v = SchemaValidator({'type': 'union', 'choices': [{'type': 'tuple-variable'}, {'type': 'list'}]})
+    v = SchemaValidator(
+        {
+            'type': 'union',
+            'choices': [
+                {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
+                {'type': 'list'},
+            ],
+        }
+    )
     assert v.validate_python(input_value) == expected
 
 
@@ -313,8 +322,8 @@ def test_union_tuple_var_len(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {'type': 'tuple-variable', 'items_schema': {'type': 'int'}, 'strict': True},
-                {'type': 'tuple-variable', 'items_schema': {'type': 'str'}, 'strict': True},
+                {'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0, 'strict': True},
+                {'type': 'tuple', 'items_schema': [{'type': 'str'}], 'variadic_item_index': 0, 'strict': True},
             ],
         }
     )
@@ -360,16 +369,8 @@ def test_union_tuple_fix_len(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {
-                    'type': 'tuple-positional',
-                    'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}],
-                    'strict': True,
-                },
-                {
-                    'type': 'tuple-positional',
-                    'items_schema': [{'type': 'str'}, {'type': 'str'}, {'type': 'str'}],
-                    'strict': True,
-                },
+                {'type': 'tuple', 'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}], 'strict': True},
+                {'type': 'tuple', 'items_schema': [{'type': 'str'}, {'type': 'str'}, {'type': 'str'}], 'strict': True},
             ],
         }
     )
@@ -383,7 +384,7 @@ def test_union_tuple_fix_len(input_value, expected):
 
 
 def test_tuple_fix_error():
-    v = SchemaValidator({'type': 'tuple-positional', 'items_schema': [{'type': 'int'}, {'type': 'str'}]})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}, {'type': 'str'}]})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python([1])
 
@@ -403,13 +404,9 @@ def test_tuple_fix_error():
         ([1], Err('type=missing', errors=[{'type': 'missing', 'loc': (1,), 'msg': 'Field required', 'input': [1]}])),
     ],
 )
-def test_tuple_fix_extra(input_value, expected, cache):
+def test_tuple_fix_extra(input_value, expected):
     v = SchemaValidator(
-        {
-            'type': 'tuple-positional',
-            'items_schema': [{'type': 'int'}, {'type': 'str'}],
-            'extras_schema': {'type': 'str'},
-        }
+        {'type': 'tuple', 'items_schema': [{'type': 'int'}, {'type': 'str'}, {'type': 'str'}], 'variadic_item_index': 2}
     )
 
     if isinstance(expected, Err):
@@ -421,9 +418,7 @@ def test_tuple_fix_extra(input_value, expected, cache):
 
 
 def test_tuple_fix_extra_any():
-    v = SchemaValidator(
-        {'type': 'tuple-positional', 'items_schema': [{'type': 'str'}], 'extras_schema': {'type': 'any'}}
-    )
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'str'}, {'type': 'any'}], 'variadic_item_index': 1})
     assert v.validate_python([b'1']) == ('1',)
     assert v.validate_python([b'1', 2]) == ('1', 2)
     assert v.validate_python((b'1', 2)) == ('1', 2)
@@ -443,7 +438,7 @@ def test_generator_error():
             raise RuntimeError('error')
         yield 3
 
-    v = SchemaValidator({'type': 'tuple-variable', 'items_schema': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0})
     assert v.validate_python(gen(False)) == (1, 2, 3)
 
     msg = r'Error iterating over object, error: RuntimeError: error \[type=iteration_error,'
@@ -456,13 +451,13 @@ def test_generator_error():
     [
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'any'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'any'}], 'variadic_item_index': 0},
             ((1, 10), (2, 20), ('3', '30')),
             id='Tuple[Any, Any]',
         ),
         pytest.param(
             {1: 10, 2: 20, '3': '30'}.items(),
-            {'type': 'tuple-variable', 'items_schema': {'type': 'int'}},
+            {'type': 'tuple', 'items_schema': [{'type': 'int'}], 'variadic_item_index': 0},
             ((1, 10), (2, 20), (3, 30)),
             id='Tuple[int, int]',
         ),
@@ -470,7 +465,7 @@ def test_generator_error():
     ],
 )
 def test_frozenset_from_dict_items(input_value, items_schema, expected):
-    v = SchemaValidator({'type': 'tuple-variable', 'items_schema': items_schema})
+    v = SchemaValidator({'type': 'tuple', 'items_schema': [items_schema], 'variadic_item_index': 0})
     output = v.validate_python(input_value)
     assert isinstance(output, tuple)
     assert output == expected
@@ -487,8 +482,9 @@ def test_frozenset_from_dict_items(input_value, items_schema, expected):
 def test_length_constraints_omit(input_value, expected):
     v = SchemaValidator(
         {
-            'type': 'tuple-variable',
-            'items_schema': {'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'},
+            'type': 'tuple',
+            'items_schema': [{'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'}],
+            'variadic_item_index': 0,
             'max_length': 4,
         }
     )

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -164,7 +164,11 @@ def test_dict_keys():
 
 def test_tuple_variable(py_and_json: PyAndJson):
     v = py_and_json(
-        {'type': 'tuple-variable', 'items_schema': {'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'}}
+        {
+            'type': 'tuple',
+            'items_schema': [{'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'}],
+            'variadic_item_index': 0,
+        }
     )
     assert v.validate_python((1, 2, 3)) == (1, 2, 3)
     assert v.validate_python([1, '2', 3]) == (1, 2, 3)
@@ -174,7 +178,7 @@ def test_tuple_variable(py_and_json: PyAndJson):
 def test_tuple_positional():
     v = SchemaValidator(
         {
-            'type': 'tuple-positional',
+            'type': 'tuple',
             'items_schema': [{'type': 'int'}, {'type': 'default', 'schema': {'type': 'int'}, 'default': 42}],
         }
     )
@@ -187,9 +191,13 @@ def test_tuple_positional():
 def test_tuple_positional_omit():
     v = SchemaValidator(
         {
-            'type': 'tuple-positional',
-            'items_schema': [{'type': 'int'}, {'type': 'int'}],
-            'extras_schema': {'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'},
+            'type': 'tuple',
+            'items_schema': [
+                {'type': 'int'},
+                {'type': 'int'},
+                {'type': 'default', 'schema': {'type': 'int'}, 'on_error': 'omit'},
+            ],
+            'variadic_item_index': 2,
         }
     )
     assert v.validate_python((1, '2')) == (1, 2)


### PR DESCRIPTION
This adds new capabilities for tuple validation that are necessary to accommodate variadic generic tuples in pydantic.

I don't think this will fully pave the way for validating _callables_ with a variadic signature, but I think the tuples case is more important anyway for typical pydantic usage. And if/when we do implement it for callables, it will probably look similar.

I believe we can replace the `'tuple-positional'` and `'tuple-variable'` schemas with the `'tuple'` schema introduced in this PR, but I'm not yet sure about any potential performance consequences that might have.

(I'm also not sure it even works properly yet — I need to add more tests, and check if all pydantic tests pass if I replace the use of `'tuple-positional'` and `'tuple-variable'` in pydantic.)

This is closely related to https://github.com/pydantic/pydantic/issues/5804 but does not close it quite yet — this needs additional work in pydantic, and possibly some implementation for other non-tuple types before that issue could/should be closed.