### PR TITLE
special case serialization for int as input to float

### DIFF
--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -110,7 +110,17 @@ impl ObTypeLookup {
             // op_value is None on recursive calls
             ObType::IntSubclass => self.int == ob_type && op_value.is_none(),
             ObType::Bool => self.bool == ob_type,
-            ObType::Float => self.float == ob_type,
+            ObType::Float => {
+                if self.float == ob_type {
+                    true
+                } else if self.int == ob_type {
+                    // special case for int as the input to float serializer,
+                    // https://github.com/pydantic/pydantic/issues/7041
+                    return IsType::Subclass;
+                } else {
+                    false
+                }
+            }
             ObType::FloatSubclass => self.float == ob_type && op_value.is_none(),
             ObType::Str => self.string == ob_type,
             ObType::List => self.list == ob_type,

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -115,7 +115,7 @@ impl ObTypeLookup {
                     true
                 } else if self.int == ob_type {
                     // special case for int as the input to float serializer,
-                    // https://github.com/pydantic/pydantic/issues/7041
+                    // https://github.com/pydantic/pydantic-core/pull/866
                     return IsType::Subclass;
                 } else {
                     false

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 import pytest
 
-from pydantic_core import SchemaSerializer
+from pydantic_core import SchemaSerializer, core_schema
 
 
 class IntSubClass(int):
@@ -56,6 +56,48 @@ def test_simple_serializers(schema_type, value, expected_python, expected_json, 
     v_json_expected = json.loads(expected_json)
     assert v_json == v_json_expected
     assert type(v_json) == type(v_json_expected)
+
+
+def test_int_to_float():
+    """
+    See https://github.com/pydantic/pydantic/issues/7041
+    """
+    s = SchemaSerializer(core_schema.float_schema())
+    v_plain = s.to_python(1)
+    assert v_plain == 1
+    assert type(v_plain) == int
+
+    v_plain_subclass = s.to_python(IntSubClass(1))
+    assert v_plain_subclass == IntSubClass(1)
+    assert type(v_plain_subclass) == IntSubClass
+
+    v_json = s.to_python(1, mode='json')
+    assert v_json == 1.0
+    assert type(v_json) == float
+
+    v_json_subclass = s.to_python(IntSubClass(1), mode='json')
+    assert v_json_subclass == 1
+    assert type(v_json_subclass) == float
+
+    assert s.to_json(1) == b'1.0'
+    assert s.to_json(IntSubClass(1)) == b'1.0'
+
+
+def test_int_to_float_key():
+    """
+    See https://github.com/pydantic/pydantic/issues/7041
+    """
+    s = SchemaSerializer(core_schema.dict_schema(core_schema.float_schema(), core_schema.float_schema()))
+    v_plain = s.to_python({1: 1})
+    assert v_plain == {1: 1}
+    assert type(list(v_plain.keys())[0]) == int
+    assert type(v_plain[1]) == int
+
+    v_json = s.to_python({1: 1}, mode='json')
+    assert v_json == {'1': 1.0}
+    assert type(v_json['1']) == float
+
+    assert s.to_json({1: 1}) == b'{"1":1.0}'
 
 
 @pytest.mark.parametrize('schema_type', ['int', 'bool', 'float', 'none'])

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -60,7 +60,7 @@ def test_simple_serializers(schema_type, value, expected_python, expected_json, 
 
 def test_int_to_float():
     """
-    See https://github.com/pydantic/pydantic/issues/7041
+    See https://github.com/pydantic/pydantic-core/pull/866
     """
     s = SchemaSerializer(core_schema.float_schema())
     v_plain = s.to_python(1)
@@ -85,7 +85,7 @@ def test_int_to_float():
 
 def test_int_to_float_key():
     """
-    See https://github.com/pydantic/pydantic/issues/7041
+    See https://github.com/pydantic/pydantic-core/pull/866
     """
     s = SchemaSerializer(core_schema.dict_schema(core_schema.float_schema(), core_schema.float_schema()))
     v_plain = s.to_python({1: 1})


### PR DESCRIPTION
## Change Summary

There's very special logic for `float` and in, from [PEP 484](https://peps.python.org/pep-0484/#the-numeric-tower:~:text=when%20an%20argument%20is%20annotated%20as%20having%20type%20float%2C%20an%20argument%20of%20type%20int%20is%20acceptable):

> when an argument is annotated as having type `float`, an argument of type `int` is acceptable

With this change:
* in "python" mode (E.g. `model_dump()`) int as inputs to float serialization are unchanged - remain as ints
* in "json" mode and JSON serialization (E.g. `model_dump(mode='json')` and `model_dump_json()`) int as inputs to float serialization are converted to ints

This roughly matches how other types are serialized

## Related issue number

fix https://github.com/pydantic/pydantic/issues/7041

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt