### PR TITLE
fix inconsistency with strict mode of date validation

### DIFF
--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -336,7 +336,7 @@ error_types! {
         error: {ctx_type: Cow<'static, str>, ctx_fn: cow_field_from_context<String, _>},
     },
     DateFromDatetimeParsing {
-        error: {ctx_type: String, ctx_fn: field_from_context},
+        error: {ctx_type: Cow<'static, str>, ctx_fn: cow_field_from_context<String, _>},
     },
     DateFromDatetimeInexact {},
     DatePast {},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,25 @@ def py_and_json(request) -> PyAndJson:
     return ChosenPyAndJsonValidator
 
 
+class StrictModeType:
+    def __init__(self, schema: bool, extra: bool):
+        assert schema or extra
+        self.schema = schema
+        self.validator_args = {'strict': True} if extra else {}
+
+
+@pytest.fixture(
+    params=[
+        StrictModeType(schema=True, extra=False),
+        StrictModeType(schema=False, extra=True),
+        StrictModeType(schema=True, extra=True),
+    ],
+    ids=['strict-schema', 'strict-extra', 'strict-both'],
+)
+def strict_mode_type(request) -> StrictModeType:
+    return request.param
+
+
 @pytest.fixture
 def tmp_work_path(tmp_path: Path):
     """

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -127,13 +127,13 @@ def test_date_json(py_and_json: PyAndJson, input_value, expected):
     ],
     ids=repr,
 )
-def test_date_strict(input_value, expected):
-    v = SchemaValidator({'type': 'date', 'strict': True})
+def test_date_strict(input_value, expected, strict_mode_type):
+    v = SchemaValidator({'type': 'date', 'strict': strict_mode_type.schema})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
-            v.validate_python(input_value)
+            v.validate_python(input_value, **strict_mode_type.validator_args)
     else:
-        output = v.validate_python(input_value)
+        output = v.validate_python(input_value, **strict_mode_type.validator_args)
         assert output == expected
 
 
@@ -148,13 +148,13 @@ def test_date_strict(input_value, expected):
         ('1654646400', Err('Input should be a valid date [type=date_type')),
     ],
 )
-def test_date_strict_json(input_value, expected):
-    v = SchemaValidator({'type': 'date', 'strict': True})
+def test_date_strict_json(input_value, expected, strict_mode_type):
+    v = SchemaValidator({'type': 'date', 'strict': strict_mode_type.schema})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
-            v.validate_json(input_value)
+            v.validate_json(input_value, **strict_mode_type.validator_args)
     else:
-        output = v.validate_json(input_value)
+        output = v.validate_json(input_value, **strict_mode_type.validator_args)
         assert output == expected
 
 


### PR DESCRIPTION
## Change Summary

Stops strict dates from accepting timestamp strings, if `strict=True` at the extra level.

## Related issue number

Related to https://github.com/pydantic/pydantic/issues/7039

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
