### PR TITLE
special case of datetime as not allowed in date serializer

### DIFF
--- a/tests/serializers/test_datetime.py
+++ b/tests/serializers/test_datetime.py
@@ -99,3 +99,11 @@ def test_any_datetime_key():
     # assert v.to_python(input_value) == v
     assert v.to_python(input_value, mode='json') == {'2022-12-02T12:13:14': 1, '2022-12-02': 2, '12:13:14': 3}
     assert v.to_json(input_value) == b'{"2022-12-02T12:13:14":1,"2022-12-02":2,"12:13:14":3}'
+
+
+def test_date_datetime_union():
+    # See https://github.com/pydantic/pydantic/issues/7039#issuecomment-1671986746
+    v = SchemaSerializer(core_schema.union_schema([core_schema.date_schema(), core_schema.datetime_schema()]))
+    assert v.to_python(datetime(2022, 12, 2, 1)) == datetime(2022, 12, 2, 1)
+    assert v.to_python(datetime(2022, 12, 2, 1), mode='json') == '2022-12-02T01:00:00'
+    assert v.to_json(datetime(2022, 12, 2, 1)) == b'"2022-12-02T01:00:00"'


### PR DESCRIPTION
## Change Summary

When serializing `date | datetime` unions we do not want the `date` serializer to allow `datetime` inputs, as they are a lossy serialization.

In general this seems undesirable, so I've gone for the approach of making `date` serializer disallow `datetime` always (and emit the usual unexpected type warning).

## Related issue number

Related to https://github.com/pydantic/pydantic/issues/7039#issuecomment-1671986746

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb