### PR TITLE
custom behaviour for timedelta subclasses

### DIFF
--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -1,6 +1,7 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 use speedate::{Date, DateTime, Duration, ParseError, Time, TimeConfig};
@@ -10,6 +11,7 @@ use strum::EnumMessage;
 
 use super::Input;
 use crate::errors::{ErrorType, ValError, ValResult};
+use crate::tools::py_err;
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum EitherDate<'a> {
@@ -76,7 +78,8 @@ impl<'a> From<&'a PyTime> for EitherTime<'a> {
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum EitherTimedelta<'a> {
     Raw(Duration),
-    Py(&'a PyDelta),
+    PyExact(&'a PyDelta),
+    PySubclass(&'a PyDelta),
 }
 
 impl<'a> From<Duration> for EitherTimedelta<'a> {
@@ -85,13 +88,38 @@ impl<'a> From<Duration> for EitherTimedelta<'a> {
     }
 }
 
-impl<'a> From<&'a PyDelta> for EitherTimedelta<'a> {
-    fn from(timedelta: &'a PyDelta) -> Self {
-        Self::Py(timedelta)
+impl<'a> EitherTimedelta<'a> {
+    pub fn as_raw(&self) -> PyResult<Duration> {
+        match self {
+            Self::Raw(timedelta) => Ok(timedelta.clone()),
+            Self::PyExact(py_timedelta) => Ok(pytimedelta_exact_as_duration(py_timedelta)),
+            Self::PySubclass(py_timedelta) => pytimedelta_subclass_as_duration(py_timedelta),
+        }
+    }
+
+    pub fn try_into_py(&self, py: Python<'a>) -> PyResult<&'a PyDelta> {
+        match self {
+            Self::PyExact(timedelta) => Ok(*timedelta),
+            Self::PySubclass(timedelta) => Ok(*timedelta),
+            Self::Raw(duration) => duration_as_pytimedelta(py, duration),
+        }
     }
 }
 
-pub fn pytimedelta_as_duration(py_timedelta: &PyDelta) -> Duration {
+impl<'a> TryFrom<&'a PyAny> for EitherTimedelta<'a> {
+    type Error = PyErr;
+
+    fn try_from(value: &'a PyAny) -> PyResult<Self> {
+        if let Ok(dt) = <PyDelta as PyTryFrom>::try_from_exact(value) {
+            Ok(EitherTimedelta::PyExact(dt))
+        } else {
+            let dt = value.downcast::<PyDelta>()?;
+            Ok(EitherTimedelta::PySubclass(dt))
+        }
+    }
+}
+
+pub fn pytimedelta_exact_as_duration(py_timedelta: &PyDelta) -> Duration {
     // see https://docs.python.org/3/c-api/datetime.html#c.PyDateTime_DELTA_GET_DAYS
     // days can be negative, but seconds and microseconds are always positive.
     let mut days = py_timedelta.get_days(); // -999999999 to 999999999
@@ -114,20 +142,20 @@ pub fn pytimedelta_as_duration(py_timedelta: &PyDelta) -> Duration {
     Duration::new(positive, days as u32, seconds as u32, microseconds as u32).unwrap()
 }
 
-impl<'a> EitherTimedelta<'a> {
-    pub fn as_raw(&self) -> Duration {
-        match self {
-            Self::Raw(timedelta) => timedelta.clone(),
-            Self::Py(py_timedelta) => pytimedelta_as_duration(py_timedelta),
-        }
+pub fn pytimedelta_subclass_as_duration(py_timedelta: &PyDelta) -> PyResult<Duration> {
+    let total_seconds: f64 = py_timedelta
+        .call_method0(intern!(py_timedelta.py(), "total_seconds"))?
+        .extract()?;
+    if total_seconds.is_nan() {
+        return py_err!(PyValueError; "NaN values not permitted");
     }
-
-    pub fn try_into_py(&self, py: Python<'a>) -> PyResult<&'a PyDelta> {
-        match self {
-            Self::Py(timedelta) => Ok(*timedelta),
-            Self::Raw(duration) => duration_as_pytimedelta(py, duration),
-        }
-    }
+    let positive = total_seconds >= 0_f64;
+    let total_seconds = total_seconds.abs();
+    let microsecond = total_seconds.fract() * 1_000_000.0;
+    let days = (total_seconds / 86400f64) as u32;
+    let seconds = total_seconds as u64 % 86400;
+    Duration::new(positive, days, seconds as u32, microsecond.round() as u32)
+        .map_err(|err| PyValueError::new_err(err.to_string()))
 }
 
 pub fn duration_as_pytimedelta<'py>(py: Python<'py>, duration: &Duration) -> PyResult<&'py PyDelta> {

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -89,7 +89,7 @@ impl<'a> From<Duration> for EitherTimedelta<'a> {
 }
 
 impl<'a> EitherTimedelta<'a> {
-    pub fn as_raw(&self) -> PyResult<Duration> {
+    pub fn as_duration(&self) -> PyResult<Duration> {
         match self {
             Self::Raw(timedelta) => Ok(timedelta.clone()),
             Self::PyExact(py_timedelta) => Ok(pytimedelta_exact_as_duration(py_timedelta)),

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -89,7 +89,7 @@ impl<'a> From<Duration> for EitherTimedelta<'a> {
 }
 
 impl<'a> EitherTimedelta<'a> {
-    pub fn as_duration(&self) -> PyResult<Duration> {
+    pub fn to_duration(&self) -> PyResult<Duration> {
         match self {
             Self::Raw(timedelta) => Ok(timedelta.clone()),
             Self::PyExact(py_timedelta) => Ok(pytimedelta_exact_as_duration(py_timedelta)),

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -3,7 +3,7 @@ use std::str::from_utf8;
 
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFloat, PyFrozenSet, PyInt, PyIterator, PyList,
+    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDict, PyFloat, PyFrozenSet, PyInt, PyIterator, PyList,
     PyMapping, PySequence, PySet, PyString, PyTime, PyTuple, PyType,
 };
 #[cfg(not(PyPy))]
@@ -667,8 +667,8 @@ impl<'a> Input<'a> for PyAny {
         &self,
         _microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
     ) -> ValResult<EitherTimedelta> {
-        if let Ok(dt) = self.downcast::<PyDelta>() {
-            Ok(dt.into())
+        if let Ok(either_dt) = EitherTimedelta::try_from(self) {
+            Ok(either_dt)
         } else {
             Err(ValError::new(ErrorTypeDefaults::TimeDeltaType, self))
         }
@@ -678,8 +678,8 @@ impl<'a> Input<'a> for PyAny {
         &self,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
     ) -> ValResult<EitherTimedelta> {
-        if let Ok(dt) = self.downcast::<PyDelta>() {
-            Ok(dt.into())
+        if let Ok(either_dt) = EitherTimedelta::try_from(self) {
+            Ok(either_dt)
         } else if let Ok(py_str) = self.downcast::<PyString>() {
             let str = py_string_str(py_str)?;
             bytes_as_timedelta(self, str.as_bytes(), microseconds_overflow_behavior)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -12,8 +12,8 @@ mod shared;
 
 pub use datetime::TzInfo;
 pub(crate) use datetime::{
-    duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, pytimedelta_as_duration,
-    EitherDate, EitherDateTime, EitherTime, EitherTimedelta,
+    duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, EitherDate, EitherDateTime,
+    EitherTime, EitherTimedelta,
 };
 pub(crate) use input_abstract::{Input, InputType};
 pub(crate) use parse_json::{JsonInput, JsonObject};

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -9,7 +9,7 @@ use pyo3::{intern, PyNativeType};
 use serde::ser::Error;
 
 use crate::build_tools::py_schema_err;
-use crate::input::pytimedelta_as_duration;
+use crate::input::EitherTimedelta;
 use crate::tools::SchemaDict;
 
 use super::errors::py_err_se_err;
@@ -73,27 +73,30 @@ impl TimedeltaMode {
         py_timedelta.call_method0(intern!(py_timedelta.py(), "total_seconds"))
     }
 
-    pub fn timedelta_to_json(&self, py_timedelta: &PyDelta) -> PyResult<PyObject> {
-        let py = py_timedelta.py();
+    pub fn either_delta_to_json(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<PyObject> {
         match self {
             Self::Iso8601 => {
-                let d = pytimedelta_as_duration(py_timedelta);
+                let d = either_delta.as_raw()?;
                 Ok(d.to_string().into_py(py))
             }
             Self::Float => {
+                // convert to int via a py timedelta not duration since we know this this case the input would have
+                // been a py timedelta
+                let py_timedelta = either_delta.try_into_py(py)?;
                 let seconds = Self::total_seconds(py_timedelta)?;
                 Ok(seconds.into_py(py))
             }
         }
     }
 
-    pub fn json_key<'py>(&self, py_timedelta: &PyDelta) -> PyResult<Cow<'py, str>> {
+    pub fn json_key<'py>(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<Cow<'py, str>> {
         match self {
             Self::Iso8601 => {
-                let d = pytimedelta_as_duration(py_timedelta);
+                let d = either_delta.as_raw()?;
                 Ok(d.to_string().into())
             }
             Self::Float => {
+                let py_timedelta = either_delta.try_into_py(py)?;
                 let seconds: f64 = Self::total_seconds(py_timedelta)?.extract()?;
                 Ok(seconds.to_string().into())
             }
@@ -102,15 +105,17 @@ impl TimedeltaMode {
 
     pub fn timedelta_serialize<S: serde::ser::Serializer>(
         &self,
-        py_timedelta: &PyDelta,
+        py: Python,
+        either_delta: &EitherTimedelta,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         match self {
             Self::Iso8601 => {
-                let d = pytimedelta_as_duration(py_timedelta);
+                let d = either_delta.as_raw().map_err(py_err_se_err)?;
                 serializer.serialize_str(&d.to_string())
             }
             Self::Float => {
+                let py_timedelta = either_delta.try_into_py(py).map_err(py_err_se_err)?;
                 let seconds = Self::total_seconds(py_timedelta).map_err(py_err_se_err)?;
                 let seconds: f64 = seconds.extract().map_err(py_err_se_err)?;
                 serializer.serialize_f64(seconds)

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -76,7 +76,7 @@ impl TimedeltaMode {
     pub fn either_delta_to_json(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<PyObject> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_raw()?;
+                let d = either_delta.as_duration()?;
                 Ok(d.to_string().into_py(py))
             }
             Self::Float => {
@@ -92,7 +92,7 @@ impl TimedeltaMode {
     pub fn json_key<'py>(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<Cow<'py, str>> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_raw()?;
+                let d = either_delta.as_duration()?;
                 Ok(d.to_string().into())
             }
             Self::Float => {
@@ -111,7 +111,7 @@ impl TimedeltaMode {
     ) -> Result<S::Ok, S::Error> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_raw().map_err(py_err_se_err)?;
+                let d = either_delta.as_duration().map_err(py_err_se_err)?;
                 serializer.serialize_str(&d.to_string())
             }
             Self::Float => {

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -76,7 +76,7 @@ impl TimedeltaMode {
     pub fn either_delta_to_json(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<PyObject> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_duration()?;
+                let d = either_delta.to_duration()?;
                 Ok(d.to_string().into_py(py))
             }
             Self::Float => {
@@ -92,7 +92,7 @@ impl TimedeltaMode {
     pub fn json_key<'py>(&self, py: Python, either_delta: &EitherTimedelta) -> PyResult<Cow<'py, str>> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_duration()?;
+                let d = either_delta.to_duration()?;
                 Ok(d.to_string().into())
             }
             Self::Float => {
@@ -111,7 +111,7 @@ impl TimedeltaMode {
     ) -> Result<S::Ok, S::Error> {
         match self {
             Self::Iso8601 => {
-                let d = either_delta.as_duration().map_err(py_err_se_err)?;
+                let d = either_delta.to_duration().map_err(py_err_se_err)?;
                 serializer.serialize_str(&d.to_string())
             }
             Self::Float => {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -29,7 +29,7 @@ fn get_constraint(schema: &PyDict, key: &str) -> PyResult<Option<Duration>> {
     match schema.get_item(key) {
         Some(value) => {
             let either_timedelta = EitherTimedelta::try_from(value)?;
-            Ok(Some(either_timedelta.as_duration()?))
+            Ok(Some(either_timedelta.to_duration()?))
         }
         None => Ok(None),
     }
@@ -77,7 +77,7 @@ impl Validator for TimeDeltaValidator {
         let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
         if let Some(constraints) = &self.constraints {
-            let raw_timedelta = timedelta.as_duration()?;
+            let raw_timedelta = timedelta.to_duration()?;
 
             macro_rules! check_constraint {
                 ($constraint:ident, $error:ident) => {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -1,13 +1,11 @@
-use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDelta, PyDict};
+use pyo3::types::PyDict;
 use speedate::Duration;
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::{duration_as_pytimedelta, pytimedelta_as_duration, Input};
+use crate::input::{duration_as_pytimedelta, EitherTimedelta, Input};
 use crate::recursion_guard::RecursionGuard;
-use crate::tools::SchemaDict;
 
 use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
@@ -27,6 +25,16 @@ struct TimedeltaConstraints {
     gt: Option<Duration>,
 }
 
+fn get_constraint(schema: &PyDict, key: &str) -> PyResult<Option<Duration>> {
+    match schema.get_item(key) {
+        Some(value) => {
+            let either_timedelta = EitherTimedelta::try_from(value)?;
+            Ok(Some(either_timedelta.as_raw()?))
+        }
+        None => Ok(None),
+    }
+}
+
 impl BuildValidator for TimeDeltaValidator {
     const EXPECTED_TYPE: &'static str = "timedelta";
 
@@ -35,20 +43,11 @@ impl BuildValidator for TimeDeltaValidator {
         config: Option<&PyDict>,
         _definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let py: Python<'_> = schema.py();
         let constraints = TimedeltaConstraints {
-            le: schema
-                .get_as::<&PyDelta>(intern!(py, "le"))?
-                .map(pytimedelta_as_duration),
-            lt: schema
-                .get_as::<&PyDelta>(intern!(py, "lt"))?
-                .map(pytimedelta_as_duration),
-            ge: schema
-                .get_as::<&PyDelta>(intern!(py, "ge"))?
-                .map(pytimedelta_as_duration),
-            gt: schema
-                .get_as::<&PyDelta>(intern!(py, "gt"))?
-                .map(pytimedelta_as_duration),
+            le: get_constraint(schema, "le")?,
+            lt: get_constraint(schema, "lt")?,
+            ge: get_constraint(schema, "ge")?,
+            gt: get_constraint(schema, "gt")?,
         };
 
         Ok(Self {
@@ -78,7 +77,7 @@ impl Validator for TimeDeltaValidator {
         let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
         if let Some(constraints) = &self.constraints {
-            let raw_timedelta = timedelta.as_raw();
+            let raw_timedelta = timedelta.as_raw()?;
 
             macro_rules! check_constraint {
                 ($constraint:ident, $error:ident) => {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -29,7 +29,7 @@ fn get_constraint(schema: &PyDict, key: &str) -> PyResult<Option<Duration>> {
     match schema.get_item(key) {
         Some(value) => {
             let either_timedelta = EitherTimedelta::try_from(value)?;
-            Ok(Some(either_timedelta.as_raw()?))
+            Ok(Some(either_timedelta.as_duration()?))
         }
         None => Ok(None),
     }
@@ -77,7 +77,7 @@ impl Validator for TimeDeltaValidator {
         let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
         if let Some(constraints) = &self.constraints {
-            let raw_timedelta = timedelta.as_raw()?;
+            let raw_timedelta = timedelta.as_duration()?;
 
             macro_rules! check_constraint {
                 ($constraint:ident, $error:ident) => {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 coverage==7.2.7
 dirty-equals==0.6.0
 hypothesis==6.79.4
+pandas==2.0.3
 pytest==7.4.0
 pytest-codspeed~=2.1.0
 pytest-examples==0.0.10

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 coverage==7.2.7
 dirty-equals==0.6.0
 hypothesis==6.79.4
-pandas==2.0.3
+pandas==2.0.3; python_version >= "3.9" and python_version < "3.12"
 pytest==7.4.0
 pytest-codspeed~=2.1.0
 pytest-examples==0.0.10

--- a/tests/serializers/test_timedelta.py
+++ b/tests/serializers/test_timedelta.py
@@ -4,6 +4,11 @@ import pytest
 
 from pydantic_core import SchemaSerializer, core_schema
 
+try:
+    import pandas
+except ImportError:
+    pandas = None
+
 
 def test_timedelta():
     v = SchemaSerializer(core_schema.timedelta_schema())
@@ -36,3 +41,12 @@ def test_timedelta_key():
     assert v.to_python({timedelta(days=2, hours=3, minutes=4): 1}) == {timedelta(days=2, hours=3, minutes=4): 1}
     assert v.to_python({timedelta(days=2, hours=3, minutes=4): 1}, mode='json') == {'P2DT11040S': 1}
     assert v.to_json({timedelta(days=2, hours=3, minutes=4): 1}) == b'{"P2DT11040S":1}'
+
+
+@pytest.mark.skipif(not pandas, reason='pandas not installed')
+def test_pandas():
+    v = SchemaSerializer(core_schema.timedelta_schema())
+    d = pandas.Timestamp('2023-01-01T02:00:00Z') - pandas.Timestamp('2023-01-01T00:00:00Z')
+    assert v.to_python(d) == d
+    assert v.to_python(d, mode='json') == 'PT7200S'
+    assert v.to_json(d) == b'"PT7200S"'


### PR DESCRIPTION
## Change Summary

Support pandas `Timedelta` which don't supply support the Python timedelta C-API.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/7095

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @davidhewitt