### PR TITLE
collapse arguments into ValidationState

### DIFF
--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -4,9 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
-use crate::recursion_guard::RecursionGuard;
-
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{validation_state::ValidationState, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 /// This might seem useless, but it's useful in DictValidator to avoid Option<Validator> a lot
 #[derive(Debug, Clone)]
@@ -31,11 +29,8 @@ impl Validator for AnyValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        // Ok(input.clone().into_py(py))
         Ok(input.to_object(py))
     }
 

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -10,10 +10,10 @@ use crate::errors::{ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{GenericArguments, Input};
 use crate::lookup_key::LookupKey;
 
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::validation_state::ValidationState;
+use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 struct Parameter {
@@ -165,9 +165,7 @@ impl Validator for ArgumentsValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        definitions: &'data Definitions<CombinedValidator>,
-        recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         let args = input.validate_args()?;
 
@@ -205,9 +203,7 @@ impl Validator for ArgumentsValidator {
                             ));
                         }
                         (Some(pos_value), None) => {
-                            match parameter
-                                .validator
-                                .validate(py, pos_value, extra, definitions, recursion_guard)
+                            match parameter.validator.validate(py, pos_value, state)
                             {
                                 Ok(value) => output_args.push(value),
                                 Err(ValError::LineErrors(line_errors)) => {
@@ -217,9 +213,7 @@ impl Validator for ArgumentsValidator {
                             }
                         }
                         (None, Some((lookup_path, kw_value))) => {
-                            match parameter
-                                .validator
-                                .validate(py, kw_value, extra, definitions, recursion_guard)
+                            match parameter.validator.validate(py, kw_value, state)
                             {
                                 Ok(value) => output_kwargs.set_item(parameter.kwarg_key.as_ref().unwrap(), value)?,
                                 Err(ValError::LineErrors(line_errors)) => {
@@ -231,7 +225,7 @@ impl Validator for ArgumentsValidator {
                             }
                         }
                         (None, None) => {
-                            if let Some(value) = parameter.validator.default_value(py, Some(parameter.name.as_str()), extra, definitions, recursion_guard)? {
+                            if let Some(value) = parameter.validator.default_value(py, Some(parameter.name.as_str()), state)? {
                                 if let Some(ref kwarg_key) = parameter.kwarg_key {
                                     output_kwargs.set_item(kwarg_key, value)?;
                                 } else {
@@ -261,7 +255,7 @@ impl Validator for ArgumentsValidator {
                     if len > self.positional_params_count {
                         if let Some(ref validator) = self.var_args_validator {
                             for (index, item) in $slice_macro!(args, self.positional_params_count, len).iter().enumerate() {
-                                match validator.validate(py, item, extra, definitions, recursion_guard) {
+                                match validator.validate(py, item, state) {
                                     Ok(value) => output_args.push(value),
                                     Err(ValError::LineErrors(line_errors)) => {
                                         errors.extend(
@@ -303,7 +297,7 @@ impl Validator for ArgumentsValidator {
                             };
                             if !used_kwargs.contains(either_str.as_cow()?.as_ref()) {
                                 match self.var_kwargs_validator {
-                                    Some(ref validator) => match validator.validate(py, value, extra, definitions, recursion_guard) {
+                                    Some(ref validator) => match validator.validate(py, value, state) {
                                         Ok(value) => output_kwargs.set_item(either_str.as_py_string(py), value)?,
                                         Err(ValError::LineErrors(line_errors)) => {
                                             for err in line_errors {

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -6,10 +6,9 @@ use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct BytesValidator {
@@ -45,11 +44,9 @@ impl Validator for BytesValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let either_bytes = input.validate_bytes(extra.strict.unwrap_or(self.strict))?;
+        let either_bytes = input.validate_bytes(state.strict_or(self.strict))?;
         Ok(either_bytes.into_py(py))
     }
 
@@ -84,11 +81,9 @@ impl Validator for BytesConstrainedValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let either_bytes = input.validate_bytes(extra.strict.unwrap_or(self.strict))?;
+        let either_bytes = input.validate_bytes(state.strict_or(self.strict))?;
         let len = either_bytes.len()?;
 
         if let Some(min_length) = self.min_length {

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -4,9 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
-use crate::recursion_guard::RecursionGuard;
-
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct CallableValidator;
@@ -30,9 +28,7 @@ impl Validator for CallableValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         match input.callable() {
             true => Ok(input.to_object(py)),

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -5,10 +5,10 @@ use pyo3::types::PyDict;
 use crate::build_tools::py_schema_err;
 use crate::errors::{ErrorType, PydanticCustomError, PydanticKnownError, ValError, ValResult};
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::validation_state::ValidationState;
+use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 pub enum CustomError {
@@ -92,12 +92,10 @@ impl Validator for CustomErrorValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        definitions: &'data Definitions<CombinedValidator>,
-        recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         self.validator
-            .validate(py, input, extra, definitions, recursion_guard)
+            .validate(py, input, state)
             .map_err(|_| self.custom_error.as_val_error(input))
     }
 

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -8,11 +8,10 @@ use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::{EitherDate, Input};
 
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 use crate::validators::datetime::{NowConstraint, NowOp};
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct DateValidator {
@@ -43,11 +42,9 @@ impl Validator for DateValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let strict = extra.strict.unwrap_or(self.strict);
+        let strict = state.strict_or(self.strict);
         let date = match input.validate_date(strict) {
             Ok(date) => date,
             // if the error was a parsing error, in lax mode we allow datetimes at midnight

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -9,10 +9,9 @@ use crate::errors::ValResult;
 use crate::errors::{ErrorType, InputValue};
 use crate::errors::{ErrorTypeDefaults, Number};
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct DecimalValidator {
@@ -79,12 +78,10 @@ impl Validator for DecimalValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         let decimal = input.validate_decimal(
-            extra.strict.unwrap_or(self.strict),
+            state.strict_or(self.strict),
             // Safety: self and py both outlive this call
             unsafe { py.from_borrowed_ptr(self.decimal_type.as_ptr()) },
         )?;

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -6,10 +6,10 @@ use pyo3::types::{PyDict, PyType};
 use crate::build_tools::py_schema_err;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::ValidationState;
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 pub struct IsInstanceValidator {
@@ -61,9 +61,7 @@ impl Validator for IsInstanceValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         if !input.is_python() {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -4,10 +4,10 @@ use pyo3::types::{PyDict, PyType};
 
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::ValidationState;
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 pub struct IsSubclassValidator {
@@ -48,9 +48,7 @@ impl Validator for IsSubclassValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         match input.input_is_subclass(self.class.as_ref(py))? {
             true => Ok(input.to_object(py)),

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -4,10 +4,10 @@ use pyo3::types::PyDict;
 
 use crate::errors::ValResult;
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::ValidationState;
+use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 pub struct JsonValidator {
@@ -49,13 +49,11 @@ impl Validator for JsonValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        definitions: &'data Definitions<CombinedValidator>,
-        recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         let json_value = input.parse_json()?;
         match self.validator {
-            Some(ref validator) => match validator.validate(py, &json_value, extra, definitions, recursion_guard) {
+            Some(ref validator) => match validator.validate(py, &json_value, state) {
                 Ok(v) => Ok(v),
                 Err(err) => Err(err.duplicate(py)),
             },

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -5,11 +5,11 @@ use pyo3::types::PyDict;
 use crate::definitions::DefinitionsBuilder;
 use crate::errors::ValResult;
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
 use super::InputType;
-use super::{build_validator, BuildValidator, CombinedValidator, Definitions, Extra, Validator};
+use super::ValidationState;
+use super::{build_validator, BuildValidator, CombinedValidator, Validator};
 
 #[derive(Debug, Clone)]
 pub struct JsonOrPython {
@@ -55,13 +55,11 @@ impl Validator for JsonOrPython {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        definitions: &'data Definitions<CombinedValidator>,
-        recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        match extra.mode {
-            InputType::Python => self.python.validate(py, input, extra, definitions, recursion_guard),
-            InputType::Json => self.json.validate(py, input, extra, definitions, recursion_guard),
+        match state.extra().mode {
+            InputType::Python => self.python.validate(py, input, state),
+            InputType::Json => self.json.validate(py, input, state),
         }
     }
 

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -11,10 +11,9 @@ use crate::build_tools::{py_schema_err, py_schema_error_type};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 struct BoolLiteral {
@@ -185,9 +184,7 @@ impl Validator for LiteralValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         match self.lookup.validate(py, input)? {
             Some((_, v)) => Ok(v.clone()),

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -3,9 +3,8 @@ use pyo3::types::PyDict;
 
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct NoneValidator;
@@ -29,9 +28,7 @@ impl Validator for NoneValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        _extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        _state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         match input.is_none() {
             true => Ok(py.None()),

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -4,10 +4,10 @@ use pyo3::types::PyDict;
 
 use crate::errors::ValResult;
 use crate::input::Input;
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::ValidationState;
+use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
 pub struct NullableValidator {
@@ -37,13 +37,11 @@ impl Validator for NullableValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        definitions: &'data Definitions<CombinedValidator>,
-        recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
         match input.is_none() {
             true => Ok(py.None()),
-            false => self.validator.validate(py, input, extra, definitions, recursion_guard),
+            false => self.validator.validate(py, input, state),
         }
     }
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -7,12 +7,11 @@ use speedate::Time;
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{EitherTime, Input};
-use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
 use super::datetime::extract_microseconds_precision;
 use super::datetime::TZConstraint;
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct TimeValidator {
@@ -45,11 +44,9 @@ impl Validator for TimeValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let time = input.validate_time(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
+        let time = input.validate_time(state.strict_or(self.strict), self.microseconds_precision)?;
         if let Some(constraints) = &self.constraints {
             let raw_time = time.as_raw()?;
 

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -5,10 +5,9 @@ use speedate::Duration;
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{duration_as_pytimedelta, EitherTimedelta, Input};
-use crate::recursion_guard::RecursionGuard;
 
 use super::datetime::extract_microseconds_precision;
-use super::{BuildValidator, CombinedValidator, Definitions, DefinitionsBuilder, Extra, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct TimeDeltaValidator {
@@ -70,11 +69,9 @@ impl Validator for TimeDeltaValidator {
         &'s self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
-        extra: &Extra,
-        _definitions: &'data Definitions<CombinedValidator>,
-        _recursion_guard: &'s mut RecursionGuard,
+        state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let timedelta = input.validate_timedelta(extra.strict.unwrap_or(self.strict), self.microseconds_precision)?;
+        let timedelta = input.validate_timedelta(state.strict_or(self.strict), self.microseconds_precision)?;
         let py_timedelta = timedelta.try_into_py(py)?;
         if let Some(constraints) = &self.constraints {
             let raw_timedelta = timedelta.to_duration()?;

--- a/src/validators/validation_state.rs
+++ b/src/validators/validation_state.rs
@@ -1,0 +1,47 @@
+use crate::{definitions::Definitions, recursion_guard::RecursionGuard};
+
+use super::{CombinedValidator, Extra};
+
+pub struct ValidationState<'a> {
+    pub recursion_guard: &'a mut RecursionGuard,
+    pub definitions: &'a Definitions<CombinedValidator>,
+    // deliberately make Extra readonly
+    extra: Extra<'a>,
+}
+
+impl<'a> ValidationState<'a> {
+    pub fn new(
+        extra: Extra<'a>,
+        definitions: &'a Definitions<CombinedValidator>,
+        recursion_guard: &'a mut RecursionGuard,
+    ) -> Self {
+        Self {
+            recursion_guard,
+            definitions,
+            extra,
+        }
+    }
+
+    pub fn with_new_extra<'r, R: 'r>(
+        &mut self,
+        extra: Extra<'_>,
+        f: impl for<'s> FnOnce(&'s mut ValidationState<'_>) -> R,
+    ) -> R {
+        // TODO: It would be nice to implement this function with a drop guard instead of a closure,
+        // but lifetimes get in a tangle. Maybe someone brave wants to have a go at unpicking lifetimes.
+        let mut new_state = ValidationState {
+            recursion_guard: self.recursion_guard,
+            definitions: self.definitions,
+            extra,
+        };
+        f(&mut new_state)
+    }
+
+    pub fn extra(&self) -> &'_ Extra<'a> {
+        &self.extra
+    }
+
+    pub fn strict_or(&self, default: bool) -> bool {
+        self.extra.strict.unwrap_or(default)
+    }
+}


### PR DESCRIPTION
## Change Summary

A refactoring to pack all of (extra, definitions, recursion_guard) into a single `ValidationState`. Split out of #867, both for easier review and also because the other PR is possibly not merging for a while and I think this is a useful refactoring.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
