### PR TITLE
add `left_to_right` union mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smallvec",
  "speedate",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 # disabled for benchmarks since it makes microbenchmark performance more flakey
 mimalloc = { version = "0.1.30", optional = true, default-features = false, features = ["local_dynamic_tls"] }
 speedate = "0.12.0"
+smallvec = "1.11.0"
 ahash = "0.8.0"
 url = "2.3.1"
 # idna is already required by url, added here to be explicit

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2499,7 +2499,7 @@ def union_schema(
         custom_error_message: The custom error message to use if the validation fails
         custom_error_context: The custom error context to use if the validation fails
         mode: How to select which choice to return
-            * `smart` (default) will try to return the choice which is the closest match the input value
+            * `smart` (default) will try to return the choice which is the closest match to the input value
             * `left_to_right` will return the first choice in `choices` which succeeds validation
         strict: Whether the underlying schemas should be validated with strict mode
         ref: optional unique identifier of the schema, used to reference the schema in other places

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -994,7 +994,7 @@ class DatetimeSchema(TypedDict, total=False):
     # defaults to current local utc offset from `time.localtime().tm_gmtoff`
     # value is restricted to -86_400 < offset < 86_400 by bounds in generate_self_schema.py
     now_utc_offset: int
-    microseconds_precision: Literal['truncate', 'error'] = ('truncate',)
+    microseconds_precision: Literal['truncate', 'error']  # default: 'truncate'
     ref: str
     metadata: Any
     serialization: SerSchema
@@ -2460,6 +2460,7 @@ class UnionSchema(TypedDict, total=False):
     custom_error_type: str
     custom_error_message: str
     custom_error_context: Dict[str, Union[str, int, float]]
+    mode: Literal['smart', 'left_to_right']  # default: 'smart'
     strict: bool
     ref: str
     metadata: Any
@@ -2473,6 +2474,7 @@ def union_schema(
     custom_error_type: str | None = None,
     custom_error_message: str | None = None,
     custom_error_context: dict[str, str | int] | None = None,
+    mode: Literal['smart', 'left_to_right'] | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -2496,6 +2498,9 @@ def union_schema(
         custom_error_type: The custom error type to use if the validation fails
         custom_error_message: The custom error message to use if the validation fails
         custom_error_context: The custom error context to use if the validation fails
+        mode: How to select which choice to return
+            * `smart` (default) will try to return the choice which is the closest match the input value
+            * `left_to_right` will return the first choice in `choices` which succeeds validation
         strict: Whether the underlying schemas should be validated with strict mode
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -2508,6 +2513,7 @@ def union_schema(
         custom_error_type=custom_error_type,
         custom_error_message=custom_error_message,
         custom_error_context=custom_error_context,
+        mode=mode,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -571,13 +571,8 @@ impl DataclassValidator {
     ) -> ValResult<'data, PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on the self_instance
         // instance anymore
-        let val_output = state.with_new_extra(
-            Extra {
-                self_instance: None,
-                ..*state.extra()
-            },
-            |state| self.validator.validate(py, input, state),
-        )?;
+        let state = &mut state.rebind_extra(|extra| extra.self_instance = None);
+        let val_output = self.validator.validate(py, input, state)?;
 
         self.set_dict_call(py, self_instance, val_output, input)?;
 

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -238,13 +238,8 @@ impl ModelValidator {
     ) -> ValResult<'data, PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on self_instance
         // anymore
-        let output = state.with_new_extra(
-            Extra {
-                self_instance: None,
-                ..*state.extra()
-            },
-            |state| self.validator.validate(py, input, state),
-        )?;
+        let state = &mut state.rebind_extra(|extra| extra.self_instance = None);
+        let output = self.validator.validate(py, input, state)?;
 
         if self.root_model {
             let fields_set = if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {


### PR DESCRIPTION
## Change Summary

Adds a `left_to_right` union mode which allows for V1-style union validation, for cases when V2 smart mode is problematic.

The related issue linked below suggested a `dumb_union` flag but I think it's better to take mode as a string to give us space to invent new strategies backwards-compatibly if we need to.

I assume that we'll expose this in pydantic as `Field(union_mode="left_to_right")`.

## Related issue number

https://github.com/pydantic/pydantic/issues/7097#issuecomment-1677134952

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin