### PR TITLE
remove `'s` lifetime from `validate` and `validate_assignment`

### DIFF
--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -25,8 +25,8 @@ impl BuildValidator for AnyValidator {
 impl_py_gc_traverse!(AnyValidator {});
 
 impl Validator for AnyValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -161,8 +161,8 @@ impl_py_gc_traverse!(ArgumentsValidator {
 });
 
 impl Validator for ArgumentsValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -30,8 +30,8 @@ impl BuildValidator for BoolValidator {
 impl_py_gc_traverse!(BoolValidator {});
 
 impl Validator for BoolValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -40,8 +40,8 @@ impl BuildValidator for BytesValidator {
 impl_py_gc_traverse!(BytesValidator {});
 
 impl Validator for BytesValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -77,8 +77,8 @@ pub struct BytesConstrainedValidator {
 impl_py_gc_traverse!(BytesConstrainedValidator {});
 
 impl Validator for BytesConstrainedValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -72,8 +72,8 @@ impl_py_gc_traverse!(CallValidator {
 });
 
 impl Validator for CallValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -24,8 +24,8 @@ impl BuildValidator for CallableValidator {
 impl_py_gc_traverse!(CallableValidator {});
 
 impl Validator for CallableValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -70,8 +70,8 @@ fn build_validator_steps<'a>(
 impl_py_gc_traverse!(ChainValidator { steps });
 
 impl Validator for ChainValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -88,8 +88,8 @@ impl BuildValidator for CustomErrorValidator {
 impl_py_gc_traverse!(CustomErrorValidator { validator });
 
 impl Validator for CustomErrorValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -129,8 +129,8 @@ impl_py_gc_traverse!(Field { validator });
 impl_py_gc_traverse!(DataclassArgsValidator { fields });
 
 impl Validator for DataclassArgsValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -305,8 +305,8 @@ impl Validator for DataclassArgsValidator {
         }
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         obj: &'data PyAny,
         field_name: &'data str,
@@ -466,8 +466,8 @@ impl BuildValidator for DataclassValidator {
 impl_py_gc_traverse!(DataclassValidator { class, validator });
 
 impl Validator for DataclassValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -505,8 +505,8 @@ impl Validator for DataclassValidator {
         }
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         obj: &'data PyAny,
         field_name: &'data str,

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -38,8 +38,8 @@ impl BuildValidator for DateValidator {
 impl_py_gc_traverse!(DateValidator {});
 
 impl Validator for DateValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -58,8 +58,8 @@ impl BuildValidator for DateTimeValidator {
 impl_py_gc_traverse!(DateTimeValidator {});
 
 impl Validator for DateTimeValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -74,8 +74,8 @@ impl_py_gc_traverse!(DecimalValidator {
 });
 
 impl Validator for DecimalValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -73,8 +73,8 @@ impl BuildValidator for DefinitionRefValidator {
 impl_py_gc_traverse!(DefinitionRefValidator {});
 
 impl Validator for DefinitionRefValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -97,8 +97,8 @@ impl Validator for DefinitionRefValidator {
         }
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         obj: &'data PyAny,
         field_name: &'data str,
@@ -149,7 +149,7 @@ impl Validator for DefinitionRefValidator {
     }
 }
 
-fn validate<'s, 'data>(
+fn validate<'data>(
     validator_id: usize,
     py: Python<'data>,
     input: &'data impl Input<'data>,

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -65,8 +65,8 @@ impl_py_gc_traverse!(DictValidator {
 });
 
 impl Validator for DictValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -62,8 +62,8 @@ impl BuildValidator for FloatValidator {
 impl_py_gc_traverse!(FloatValidator {});
 
 impl Validator for FloatValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -107,8 +107,8 @@ pub struct ConstrainedFloatValidator {
 impl_py_gc_traverse!(ConstrainedFloatValidator {});
 
 impl Validator for ConstrainedFloatValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -27,8 +27,8 @@ impl BuildValidator for FrozenSetValidator {
 impl_py_gc_traverse!(FrozenSetValidator { item_validator });
 
 impl Validator for FrozenSetValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -93,8 +93,8 @@ macro_rules! impl_validator {
         });
 
         impl Validator for $name {
-            fn validate<'s, 'data>(
-                &'s self,
+            fn validate<'data>(
+                &self,
                 py: Python<'data>,
                 input: &'data impl Input<'data>,
                 state: &mut ValidationState<'_>,
@@ -102,8 +102,8 @@ macro_rules! impl_validator {
                 let validate = |v, s: &mut ValidationState<'_>| self.validator.validate(py, v, s);
                 self._validate(validate, py, input.to_object(py).into_ref(py), state)
             }
-            fn validate_assignment<'s, 'data: 's>(
-                &'s self,
+            fn validate_assignment<'data>(
+                &self,
                 py: Python<'data>,
                 obj: &'data PyAny,
                 field_name: &'data str,
@@ -246,8 +246,8 @@ impl BuildValidator for FunctionPlainValidator {
 impl_py_gc_traverse!(FunctionPlainValidator { func, config });
 
 impl Validator for FunctionPlainValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -343,8 +343,8 @@ impl_py_gc_traverse!(FunctionWrapValidator {
 });
 
 impl Validator for FunctionWrapValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -366,8 +366,8 @@ impl Validator for FunctionWrapValidator {
         )
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         obj: &'data PyAny,
         field_name: &'data str,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -51,8 +51,8 @@ impl BuildValidator for GeneratorValidator {
 impl_py_gc_traverse!(GeneratorValidator { item_validator });
 
 impl Validator for GeneratorValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -249,8 +249,8 @@ impl InternalValidator {
         }
     }
 
-    pub fn validate_assignment<'s, 'data: 's>(
-        &'s mut self,
+    pub fn validate_assignment<'data>(
+        &mut self,
         py: Python<'data>,
         model: &'data PyAny,
         field_name: &'data str,
@@ -281,15 +281,12 @@ impl InternalValidator {
             })
     }
 
-    pub fn validate<'s, 'data>(
-        &'s mut self,
+    pub fn validate<'data>(
+        &mut self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         outer_location: Option<LocItem>,
-    ) -> PyResult<PyObject>
-    where
-        's: 'data,
-    {
+    ) -> PyResult<PyObject> {
         let extra = Extra {
             mode: self.validation_mode,
             data: self.data.as_ref().map(|data| data.as_ref(py)),

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -44,8 +44,8 @@ impl BuildValidator for IntValidator {
 impl_py_gc_traverse!(IntValidator {});
 
 impl Validator for IntValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -84,8 +84,8 @@ pub struct ConstrainedIntValidator {
 impl_py_gc_traverse!(ConstrainedIntValidator {});
 
 impl Validator for ConstrainedIntValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -57,8 +57,8 @@ impl BuildValidator for IsInstanceValidator {
 impl_py_gc_traverse!(IsInstanceValidator { class });
 
 impl Validator for IsInstanceValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -44,8 +44,8 @@ impl BuildValidator for IsSubclassValidator {
 impl_py_gc_traverse!(IsSubclassValidator { class });
 
 impl Validator for IsSubclassValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -45,8 +45,8 @@ impl BuildValidator for JsonValidator {
 impl_py_gc_traverse!(JsonValidator { validator });
 
 impl Validator for JsonValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -51,8 +51,8 @@ impl BuildValidator for JsonOrPython {
 impl_py_gc_traverse!(JsonOrPython { json, python });
 
 impl Validator for JsonOrPython {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -55,8 +55,8 @@ impl_py_gc_traverse!(LaxOrStrictValidator {
 });
 
 impl Validator for LaxOrStrictValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -115,8 +115,8 @@ impl BuildValidator for ListValidator {
 impl_py_gc_traverse!(ListValidator { item_validator });
 
 impl Validator for ListValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -180,8 +180,8 @@ impl BuildValidator for LiteralValidator {
 impl_py_gc_traverse!(LiteralValidator { lookup });
 
 impl Validator for LiteralValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -683,8 +683,8 @@ pub enum CombinedValidator {
 #[enum_dispatch(CombinedValidator)]
 pub trait Validator: Send + Sync + Clone + Debug {
     /// Do the actual validation for this schema/type
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -702,8 +702,8 @@ pub trait Validator: Send + Sync + Clone + Debug {
 
     /// Validate assignment to a field of a model
     #[allow(clippy::too_many_arguments)]
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         _py: Python<'data>,
         _obj: &'data PyAny,
         _field_name: &'data str,

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -103,8 +103,8 @@ impl BuildValidator for ModelValidator {
 impl_py_gc_traverse!(ModelValidator { class, validator });
 
 impl Validator for ModelValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -147,8 +147,8 @@ impl Validator for ModelValidator {
         }
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         model: &'data PyAny,
         field_name: &'data str,

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -117,8 +117,8 @@ impl_py_gc_traverse!(ModelFieldsValidator {
 });
 
 impl Validator for ModelFieldsValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -313,8 +313,8 @@ impl Validator for ModelFieldsValidator {
         }
     }
 
-    fn validate_assignment<'s, 'data: 's>(
-        &'s self,
+    fn validate_assignment<'data>(
+        &self,
         py: Python<'data>,
         obj: &'data PyAny,
         field_name: &'data str,

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -24,8 +24,8 @@ impl BuildValidator for NoneValidator {
 impl_py_gc_traverse!(NoneValidator {});
 
 impl Validator for NoneValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -33,8 +33,8 @@ impl BuildValidator for NullableValidator {
 impl_py_gc_traverse!(NullableValidator { validator });
 
 impl Validator for NullableValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -57,8 +57,8 @@ impl BuildValidator for SetValidator {
 impl_py_gc_traverse!(SetValidator { item_validator });
 
 impl Validator for SetValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -39,8 +39,8 @@ impl BuildValidator for StrValidator {
 impl_py_gc_traverse!(StrValidator {});
 
 impl Validator for StrValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -81,8 +81,8 @@ pub struct StrConstrainedValidator {
 impl_py_gc_traverse!(StrConstrainedValidator {});
 
 impl Validator for StrConstrainedValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -40,8 +40,8 @@ impl BuildValidator for TimeValidator {
 impl_py_gc_traverse!(TimeValidator {});
 
 impl Validator for TimeValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -65,8 +65,8 @@ impl BuildValidator for TimeDeltaValidator {
 impl_py_gc_traverse!(TimeDeltaValidator {});
 
 impl Validator for TimeDeltaValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -44,8 +44,8 @@ impl BuildValidator for TupleVariableValidator {
 impl_py_gc_traverse!(TupleVariableValidator { item_validator });
 
 impl Validator for TupleVariableValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -197,8 +197,8 @@ impl_py_gc_traverse!(TuplePositionalValidator {
 });
 
 impl Validator for TuplePositionalValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -143,8 +143,8 @@ impl_py_gc_traverse!(TypedDictValidator {
 });
 
 impl Validator for TypedDictValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -99,8 +99,8 @@ impl PyGcTraverse for UnionValidator {
 }
 
 impl Validator for UnionValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -316,8 +316,8 @@ impl BuildValidator for TaggedUnionValidator {
 impl_py_gc_traverse!(TaggedUnionValidator { discriminator, lookup });
 
 impl Validator for TaggedUnionValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -59,8 +59,8 @@ impl BuildValidator for UrlValidator {
 impl_py_gc_traverse!(UrlValidator {});
 
 impl Validator for UrlValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
@@ -200,8 +200,8 @@ impl BuildValidator for MultiHostUrlValidator {
 impl_py_gc_traverse!(MultiHostUrlValidator {});
 
 impl Validator for MultiHostUrlValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -83,8 +83,8 @@ impl BuildValidator for UuidValidator {
 impl_py_gc_traverse!(UuidValidator {});
 
 impl Validator for UuidValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -126,8 +126,8 @@ impl BuildValidator for WithDefaultValidator {
 impl_py_gc_traverse!(WithDefaultValidator { default, validator });
 
 impl Validator for WithDefaultValidator {
-    fn validate<'s, 'data>(
-        &'s self,
+    fn validate<'data>(
+        &self,
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,


### PR DESCRIPTION
## Change Summary

As far as I can tell, not necessary and just increases cognitive load :)

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
