### PR TITLE
limit test requirements so that all platforms can build

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,15 @@
 coverage==7.2.7
 dirty-equals==0.6.0
 hypothesis==6.79.4
-pandas==2.0.3; python_version >= "3.9" and python_version < "3.12"
+# pandas doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
+pandas==2.0.3; python_version >= "3.9" and python_version < "3.12" and implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest==7.4.0
-pytest-codspeed~=2.1.0
+pytest-codspeed~=2.1.0; implementation_name == "cpython"
 pytest-examples==0.0.10
 pytest-speed==0.3.5
 pytest-mock==3.11.1
 pytest-pretty==1.2.0
 pytest-timeout==2.1.0
 pytz==2023.3
-numpy==1.25.2; python_version >= "3.9" and python_version < "3.12"
+# numpy doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
+numpy==1.25.2; python_version >= "3.9" and python_version < "3.12" and implementation_name == "cpython" and platform_machine == 'x86_64'


### PR DESCRIPTION
## Change Summary

At the moment we have CI failures which seem to be caused by issues with `pandas`, `numpy` and `pytest-codspeed` pulling in either themselves or requirements on platforms which can't easily build them without a lot of faff.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
