### PR TITLE
don't install pytest-codspeed on non x86_64 machines

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,8 @@ hypothesis==6.79.4
 # pandas doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
 pandas==2.0.3; python_version >= "3.9" and python_version < "3.12" and implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest==7.4.0
-pytest-codspeed~=2.1.0; implementation_name == "cpython"
+# we run codspeed benchmarks on x86_64 CPython (i.e. native github actions architecture)
+pytest-codspeed~=2.1.0; implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest-examples==0.0.10
 pytest-speed==0.3.5
 pytest-mock==3.11.1


### PR DESCRIPTION
## Change Summary

Should fix failures like https://github.com/pydantic/pydantic-core/actions/runs/5879887441/job/15946120306

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb