### PR TITLE
fix json-or-python serializer as JSON object key

### DIFF
--- a/src/serializers/type_serializers/json_or_python.rs
+++ b/src/serializers/type_serializers/json_or_python.rs
@@ -59,7 +59,7 @@ impl TypeSerializer for JsonOrPythonSerializer {
     }
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
-        self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+        self.json.json_key(key, extra)
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/tests/serializers/test_json_or_python.py
+++ b/tests/serializers/test_json_or_python.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from pydantic_core import SchemaSerializer, core_schema
 
 
@@ -17,3 +19,24 @@ def test_json_or_python():
 
     assert s.to_json(0) == b'1'
     assert s.to_python(0) == 2
+
+
+def test_json_or_python_enum_dict_key():
+    # See https://github.com/pydantic/pydantic/issues/6795
+    class MyEnum(str, Enum):
+        A = 'A'
+        B = 'B'
+
+    print(MyEnum('A'))
+
+    s = SchemaSerializer(
+        core_schema.dict_schema(
+            core_schema.json_or_python_schema(
+                core_schema.str_schema(), core_schema.no_info_after_validator_function(MyEnum, core_schema.str_schema())
+            ),
+            core_schema.int_schema(),
+        )
+    )
+
+    assert s.to_json({MyEnum.A: 1, MyEnum.B: 2}) == b'{"A":1,"B":2}'
+    assert s.to_python({MyEnum.A: 1, MyEnum.B: 2}) == {MyEnum.A: 1, MyEnum.B: 2}


### PR DESCRIPTION
## Change Summary

Change `json-or-python` serializer to delegate to the `json` serializer to decide what to do as a JSON key.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/6795

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
