### PR TITLE
avoid coercing int subclasses to floats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ features = ["pyo3/extension-module"]
 [tool.ruff]
 line-length = 120
 extend-select = ['Q', 'RUF100', 'C90', 'I']
-extend-ignore = ['E501']
+extend-ignore = [
+    'E501',  # ignore line too long and let black handle it
+    'E721',  # using type() instead of isinstance() - we use this in tests
+]
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 mccabe = { max-complexity = 13 }
 isort = { known-first-party = ['pydantic_core', 'tests'] }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -317,9 +317,8 @@ impl<'a> Input<'a> for PyAny {
             // Try strings before subclasses of int as that will be far more common
             str_as_int(self, &cow_str)
         } else if PyInt::is_type_of(self) {
-            // bools are a subclass of int, so check for bool type in this specific case
-            if PyBool::is_exact_type_of(self) {
-                Err(ValError::new(ErrorTypeDefaults::IntType, self))
+            if let Ok(bool) = self.downcast::<PyBool>() {
+                Ok(EitherInt::I64(i64::from(bool.is_true())))
             } else {
                 Ok(EitherInt::Py(self))
             }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -311,8 +311,8 @@ impl<'a> Input<'a> for PyAny {
     }
 
     fn lax_int(&'a self) -> ValResult<EitherInt<'a>> {
-        if PyInt::is_exact_type_of(self) {
-            Ok(EitherInt::Py(self))
+        if let Ok(either_int) = self.strict_int() {
+            Ok(either_int)
         } else if let Some(cow_str) = maybe_as_string(self, ErrorTypeDefaults::IntParsing)? {
             str_as_int(self, &cow_str)
         } else if let Ok(float) = self.extract::<f64>() {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -303,7 +303,9 @@ impl<'a> Input<'a> for PyAny {
             if PyBool::is_exact_type_of(self) {
                 Err(ValError::new(ErrorTypeDefaults::IntType, self))
             } else {
-                Ok(EitherInt::Py(self))
+                // force to an int to upcast to a pure python int
+                let int = self.extract::<i64>()?;
+                Ok(EitherInt::I64(int))
             }
         } else {
             Err(ValError::new(ErrorTypeDefaults::IntType, self))
@@ -317,11 +319,9 @@ impl<'a> Input<'a> for PyAny {
             // Try strings before subclasses of int as that will be far more common
             str_as_int(self, &cow_str)
         } else if PyInt::is_type_of(self) {
-            if let Ok(bool) = self.downcast::<PyBool>() {
-                Ok(EitherInt::I64(i64::from(bool.is_true())))
-            } else {
-                Ok(EitherInt::Py(self))
-            }
+            // force to an int to upcast to a pure python int to maintain current behaviour
+            let int = self.extract::<i64>()?;
+            Ok(EitherInt::I64(int))
         } else if let Ok(float) = self.extract::<f64>() {
             float_as_int(self, float)
         } else {

--- a/tests/serializers/test_bytes.py
+++ b/tests/serializers/test_bytes.py
@@ -86,7 +86,7 @@ def test_subclass_bytes(schema_type, input_value, expected_json):
 
     v = s.to_python(input_value, mode='json')
     assert v == expected_json
-    assert type(v) == str  # noqa: E721
+    assert type(v) == str
 
     assert s.to_json(input_value) == json.dumps(expected_json).encode('utf-8')
 

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -70,7 +70,7 @@ def test_int_to_float():
     s = SchemaSerializer(core_schema.float_schema())
     v_plain = s.to_python(1)
     assert v_plain == 1
-    assert type(v_plain) == int  # noqa: E721
+    assert type(v_plain) == int
 
     v_plain_subclass = s.to_python(IntSubClass(1))
     assert v_plain_subclass == IntSubClass(1)
@@ -78,11 +78,11 @@ def test_int_to_float():
 
     v_json = s.to_python(1, mode='json')
     assert v_json == 1.0
-    assert type(v_json) == float  # noqa: E721
+    assert type(v_json) == float
 
     v_json_subclass = s.to_python(IntSubClass(1), mode='json')
     assert v_json_subclass == 1
-    assert type(v_json_subclass) == float  # noqa: E721
+    assert type(v_json_subclass) == float
 
     assert s.to_json(1) == b'1.0'
     assert s.to_json(IntSubClass(1)) == b'1.0'
@@ -95,12 +95,12 @@ def test_int_to_float_key():
     s = SchemaSerializer(core_schema.dict_schema(core_schema.float_schema(), core_schema.float_schema()))
     v_plain = s.to_python({1: 1})
     assert v_plain == {1: 1}
-    assert type(list(v_plain.keys())[0]) == int  # noqa: E721
-    assert type(v_plain[1]) == int  # noqa: E721
+    assert type(list(v_plain.keys())[0]) == int
+    assert type(v_plain[1]) == int
 
     v_json = s.to_python({1: 1}, mode='json')
     assert v_json == {'1': 1.0}
-    assert type(v_json['1']) == float  # noqa: E721
+    assert type(v_json['1']) == float
 
     assert s.to_json({1: 1}) == b'{"1":1.0}'
 
@@ -133,6 +133,6 @@ def test_numpy():
 
     v = s.to_python(numpy.float64(1.0), mode='json')
     assert v == 1.0
-    assert type(v) == float  # noqa: E721
+    assert type(v) == float
 
     assert s.to_json(numpy.float64(1.0)) == b'1.0'

--- a/tests/serializers/test_string.py
+++ b/tests/serializers/test_string.py
@@ -72,6 +72,6 @@ def test_subclass_str(schema_type, input_value, expected):
 
     v = s.to_python(input_value, mode='json')
     assert v == expected
-    assert type(v) == str  # noqa: E721
+    assert type(v) == str
 
     assert s.to_json(input_value) == json.dumps(expected).encode('utf-8')

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -405,3 +405,16 @@ def test_string_as_int_with_underscores() -> None:
             v.validate_python(edge_case)
         with pytest.raises(ValidationError):
             v.validate_json(f'"{edge_case}"')
+
+
+class IntSubclass(int):
+    pass
+
+
+def test_int_subclass() -> None:
+    v = SchemaValidator({'type': 'int'})
+    assert v.validate_python(IntSubclass(1)) == 1
+    assert v.validate_python(IntSubclass(1), strict=True) == 1
+
+    assert v.validate_python(IntSubclass(1136885225876639845)) == 1136885225876639845
+    assert v.validate_python(IntSubclass(1136885225876639845), strict=True) == 1136885225876639845

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -51,7 +51,7 @@ def test_int_py_and_json(py_and_json: PyAndJson, input_value, expected):
     else:
         output = v.validate_test(input_value)
         assert output == expected
-        assert isinstance(output, int)
+        assert type(output) == int  # noqa: E721
 
 
 @pytest.mark.parametrize(
@@ -413,8 +413,25 @@ class IntSubclass(int):
 
 def test_int_subclass() -> None:
     v = SchemaValidator({'type': 'int'})
-    assert v.validate_python(IntSubclass(1)) == 1
-    assert v.validate_python(IntSubclass(1), strict=True) == 1
+    v_lax = v.validate_python(IntSubclass(1))
+    assert v_lax == 1
+    assert type(v_lax) == IntSubclass
+    v_strict = v.validate_python(IntSubclass(1), strict=True)
+    assert v_strict == 1
+    assert type(v_strict) == IntSubclass
 
     assert v.validate_python(IntSubclass(1136885225876639845)) == 1136885225876639845
     assert v.validate_python(IntSubclass(1136885225876639845), strict=True) == 1136885225876639845
+
+
+def test_int_subclass_constraint() -> None:
+    v = SchemaValidator({'type': 'int', 'gt': 0})
+    v_lax = v.validate_python(IntSubclass(1))
+    assert v_lax == 1
+    assert type(v_lax) == IntSubclass
+    v_strict = v.validate_python(IntSubclass(1), strict=True)
+    assert v_strict == 1
+    assert type(v_strict) == IntSubclass
+
+    with pytest.raises(ValidationError, match='Input should be greater than 0'):
+        v.validate_python(IntSubclass(0))

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -51,7 +51,7 @@ def test_int_py_and_json(py_and_json: PyAndJson, input_value, expected):
     else:
         output = v.validate_test(input_value)
         assert output == expected
-        assert type(output) == int  # noqa: E721
+        assert type(output) == int
 
 
 @pytest.mark.parametrize(
@@ -415,10 +415,10 @@ def test_int_subclass() -> None:
     v = SchemaValidator({'type': 'int'})
     v_lax = v.validate_python(IntSubclass(1))
     assert v_lax == 1
-    assert type(v_lax) == IntSubclass
+    assert type(v_lax) == int
     v_strict = v.validate_python(IntSubclass(1), strict=True)
     assert v_strict == 1
-    assert type(v_strict) == IntSubclass
+    assert type(v_strict) == int
 
     assert v.validate_python(IntSubclass(1136885225876639845)) == 1136885225876639845
     assert v.validate_python(IntSubclass(1136885225876639845), strict=True) == 1136885225876639845
@@ -428,10 +428,10 @@ def test_int_subclass_constraint() -> None:
     v = SchemaValidator({'type': 'int', 'gt': 0})
     v_lax = v.validate_python(IntSubclass(1))
     assert v_lax == 1
-    assert type(v_lax) == IntSubclass
+    assert type(v_lax) == int
     v_strict = v.validate_python(IntSubclass(1), strict=True)
     assert v_strict == 1
-    assert type(v_strict) == IntSubclass
+    assert type(v_strict) == int
 
     with pytest.raises(ValidationError, match='Input should be greater than 0'):
         v.validate_python(IntSubclass(0))

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -233,7 +233,7 @@ def test_lax_subclass(FruitEnum, kwargs):
     assert v.validate_python(b'foobar') == 'foobar'
     p = v.validate_python(FruitEnum.pear)
     assert p == 'pear'
-    assert type(p) is str  # noqa: E721
+    assert type(p) is str
     assert repr(p) == "'pear'"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fix validation if int subclasses.

With this we now upcast sub-types of `int` to `int` in both strict and lax mode, the rationale is as follows:
* the behaviour before was to upcast (via the `extract::<f64>()` logic which we're now avoiding)
* hence we're keeping the same behaviour in the very common case of lax ints - we even had tests for that in pydantic
* we now do the same in "strict" mode to match lax mode

## Related issue number

fix https://github.com/pydantic/pydantic/issues/7201

fix #913

## Checklist

* [x] Unit tests for the changes exist
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb