### PR TITLE
Fix typo in `MultiHostUrl.build` docstring

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -631,7 +631,7 @@ class MultiHostUrl(SupportsAllComparisons):
         fragment: Optional[str] = None,
     ) -> Self:
         """
-        Build a new `MultiHostUul` instance from its component parts.
+        Build a new `MultiHostUrl` instance from its component parts.
 
         This method takes either `hosts` - a list of `MultiHostHost` typed dicts, or the individual components
         `username`, `password`, `host` and `port`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu