### PR TITLE
make error "duplicate" cheaper

### DIFF
--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -31,7 +31,8 @@ impl<'a> Input<'a> for JsonInput {
     }
 
     fn as_error_value(&'a self) -> InputValue<'a> {
-        InputValue::JsonInput(self)
+        // cloning JsonInput is cheap due to use of Arc
+        InputValue::JsonInput(self.clone())
     }
 
     fn is_none(&self) -> bool {
@@ -262,7 +263,7 @@ impl<'a> Input<'a> for JsonInput {
             JsonInput::String(s) => Ok(string_to_vec(s).into()),
             JsonInput::Object(object) => {
                 // return keys iterator to match python's behavior
-                let keys: Vec<JsonInput> = object.keys().map(|k| JsonInput::String(k.clone())).collect();
+                let keys: JsonArray = JsonArray::new(object.keys().map(|k| JsonInput::String(k.clone())).collect());
                 Ok(keys.into())
             }
             _ => Err(ValError::new(ErrorTypeDefaults::IterableType, self)),
@@ -550,5 +551,5 @@ impl<'a> Input<'a> for String {
 }
 
 fn string_to_vec(s: &str) -> JsonArray {
-    s.chars().map(|c| JsonInput::String(c.to_string())).collect()
+    JsonArray::new(s.chars().map(|c| JsonInput::String(c.to_string())).collect())
 }

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -625,8 +625,8 @@ impl GenericPyIterator {
         }
     }
 
-    pub fn input<'a>(&'a self, py: Python<'a>) -> &'a PyAny {
-        self.obj.as_ref(py)
+    pub fn input_as_error_value<'py>(&self, py: Python<'py>) -> InputValue<'py> {
+        InputValue::PyAny(self.obj.clone_ref(py).into_ref(py))
     }
 
     pub fn index(&self) -> usize {
@@ -654,9 +654,8 @@ impl GenericJsonIterator {
         }
     }
 
-    pub fn input<'a>(&'a self, py: Python<'a>) -> &'a PyAny {
-        let input = JsonInput::Array(self.array.clone());
-        input.to_object(py).into_ref(py)
+    pub fn input_as_error_value<'py>(&self, _py: Python<'py>) -> InputValue<'py> {
+        InputValue::JsonInput(JsonInput::Array(self.array.clone()))
     }
 
     pub fn index(&self) -> usize {

--- a/src/lazy_index_map.rs
+++ b/src/lazy_index_map.rs
@@ -1,32 +1,36 @@
 use std::borrow::Borrow;
-use std::cell::RefCell;
 use std::cmp::{Eq, PartialEq};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::slice::Iter as SliceIter;
+use std::sync::OnceLock;
 
 use ahash::AHashMap;
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Default)]
 pub struct LazyIndexMap<K, V> {
-    vec: Vec<(K, V)>,
-    map: RefCell<Option<AHashMap<K, usize>>>,
+    vec: SmallVec<[(K, V); 8]>,
+    map: OnceLock<AHashMap<K, usize>>,
 }
 
 /// Like [IndexMap](https://docs.rs/indexmap/latest/indexmap/) but only builds the lookup map when it's needed.
 impl<K, V> LazyIndexMap<K, V>
 where
     K: Clone + Debug + Eq + Hash,
-    V: Clone + Debug,
+    V: Debug,
 {
     pub fn new() -> Self {
         Self {
-            vec: Vec::new(),
-            map: RefCell::new(None),
+            vec: SmallVec::new(),
+            map: OnceLock::new(),
         }
     }
 
     pub fn insert(&mut self, key: K, value: V) {
+        if let Some(map) = self.map.get_mut() {
+            map.insert(key.clone(), self.vec.len());
+        }
         self.vec.push((key, value));
     }
 
@@ -39,22 +43,14 @@ where
         K: Borrow<Q> + PartialEq<Q>,
         Q: Hash + Eq,
     {
-        let mut map = self.map.borrow_mut();
-        if let Some(map) = map.as_ref() {
-            map.get(key).map(|&i| &self.vec[i].1)
-        } else {
-            let mut new_map = AHashMap::with_capacity(self.vec.len());
-            let mut value = None;
-            // reverse here so the last value is the one that's returned
-            for (index, (k, v)) in self.vec.iter().enumerate().rev() {
-                if value.is_none() && k == key {
-                    value = Some(v);
-                }
-                new_map.insert(k.clone(), index);
-            }
-            *map = Some(new_map);
-            value
-        }
+        let map = self.map.get_or_init(|| {
+            self.vec
+                .iter()
+                .enumerate()
+                .map(|(index, (key, _))| (key.clone(), index))
+                .collect()
+        });
+        map.get(key).map(|&i| &self.vec[i].1)
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &K> {

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -504,7 +504,7 @@ pub fn convert_err<'a>(py: Python<'a>, err: PyErr, input: &'a impl Input<'a>) ->
         } else if let Ok(pydantic_error_type) = err.value(py).extract::<PydanticKnownError>() {
             pydantic_error_type.into_val_error(input)
         } else if let Ok(validation_error) = err.value(py).extract::<ValidationError>() {
-            validation_error.into_py(py)
+            validation_error.into_val_error(py)
         } else {
             py_err_string!(err.value(py), ValueError, input)
         }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -127,14 +127,14 @@ impl ValidatorIterator {
                         Some(validator) => {
                             if let Some(max_length) = max_length {
                                 if index >= max_length {
-                                    let val_error = ValError::new(
+                                    let val_error = ValError::new_custom_input(
                                         ErrorType::TooLong {
                                             field_type: "Generator".to_string(),
                                             max_length,
                                             actual_length: index + 1,
                                             context: None,
                                         },
-                                        $iter.input(py),
+                                        $iter.input_as_error_value(py),
                                     );
                                     return Err(ValidationError::from_val_error(
                                         py,
@@ -153,14 +153,14 @@ impl ValidatorIterator {
                     None => {
                         if let Some(min_length) = min_length {
                             if $iter.index() < min_length {
-                                let val_error = ValError::new(
+                                let val_error = ValError::new_custom_input(
                                     ErrorType::TooShort {
                                         field_type: "Generator".to_string(),
                                         min_length,
                                         actual_length: $iter.index(),
                                         context: None,
                                     },
-                                    $iter.input(py),
+                                    $iter.input_as_error_value(py),
                                 );
                                 return Err(ValidationError::from_val_error(
                                     py,

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -55,7 +55,7 @@ impl Validator for JsonValidator {
         match self.validator {
             Some(ref validator) => match validator.validate(py, &json_value, state) {
                 Ok(v) => Ok(v),
-                Err(err) => Err(err.duplicate(py)),
+                Err(err) => Err(err.into_owned(py)),
             },
             None => Ok(json_value.to_object(py)),
         }


### PR DESCRIPTION
## Change Summary

For #883 - replaces `ValLineError::duplicate` with `ValLineError::into_owned` which avoids the need to convert `JsonInput` to Python data when handling errors.

This is made possible by changing `JsonInput` to have `Arc` on the array and object variants. I used `SmallVec` inside those variants to avoid double-allocating for small lists & maps. Overall this shouldn't impact performance much, ideally will make it a bit tidier in #883.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin