### PR TITLE
fix: E721 Do not compare types, use `isinstance()`

### DIFF
--- a/tests/serializers/test_bytes.py
+++ b/tests/serializers/test_bytes.py
@@ -82,11 +82,11 @@ def test_subclass_bytes(schema_type, input_value, expected_json):
     s = SchemaSerializer({'type': schema_type})
     v = s.to_python(input_value)
     assert v == input_value
-    assert type(v) == type(input_value)
+    assert isinstance(v, type(input_value))
 
     v = s.to_python(input_value, mode='json')
     assert v == expected_json
-    assert type(v) == str
+    assert isinstance(v, str)
 
     assert s.to_json(input_value) == json.dumps(expected_json).encode('utf-8')
 

--- a/tests/serializers/test_set_frozenset.py
+++ b/tests/serializers/test_set_frozenset.py
@@ -18,7 +18,7 @@ def test_frozenset_any():
     fs = frozenset(['a', 'b', 'c'])
     output = v.to_python(fs)
     assert output == {'a', 'b', 'c'}
-    assert type(output) == frozenset
+    assert isinstance(output, frozenset)
     assert v.to_python(fs, mode='json') == IsList('a', 'b', 'c', check_order=False)
     assert json.loads(v.to_json(fs)) == IsList('a', 'b', 'c', check_order=False)
 

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -53,14 +53,14 @@ def test_simple_serializers(schema_type, value, expected_python, expected_json, 
     s = SchemaSerializer(schema)
     v = s.to_python(value)
     assert v == expected_python
-    assert type(v) == type(expected_python)
+    assert isinstance(v, type(expected_python))
 
     assert s.to_json(value) == expected_json
 
     v_json = s.to_python(value, mode='json')
     v_json_expected = json.loads(expected_json)
     assert v_json == v_json_expected
-    assert type(v_json) == type(v_json_expected)
+    assert isinstance(v_json, type(v_json_expected))
 
 
 def test_int_to_float():
@@ -70,19 +70,19 @@ def test_int_to_float():
     s = SchemaSerializer(core_schema.float_schema())
     v_plain = s.to_python(1)
     assert v_plain == 1
-    assert type(v_plain) == int
+    assert isinstance(v_plain, int)
 
     v_plain_subclass = s.to_python(IntSubClass(1))
     assert v_plain_subclass == IntSubClass(1)
-    assert type(v_plain_subclass) == IntSubClass
+    assert isinstance(v_plain_subclass, IntSubClass)
 
     v_json = s.to_python(1, mode='json')
     assert v_json == 1.0
-    assert type(v_json) == float
+    assert isinstance(v_json, float)
 
     v_json_subclass = s.to_python(IntSubClass(1), mode='json')
     assert v_json_subclass == 1
-    assert type(v_json_subclass) == float
+    assert isinstance(v_json_subclass, float)
 
     assert s.to_json(1) == b'1.0'
     assert s.to_json(IntSubClass(1)) == b'1.0'
@@ -95,12 +95,12 @@ def test_int_to_float_key():
     s = SchemaSerializer(core_schema.dict_schema(core_schema.float_schema(), core_schema.float_schema()))
     v_plain = s.to_python({1: 1})
     assert v_plain == {1: 1}
-    assert type(list(v_plain.keys())[0]) == int
-    assert type(v_plain[1]) == int
+    assert isinstance(list(v_plain.keys())[0], int)
+    assert isinstance(v_plain[1], int)
 
     v_json = s.to_python({1: 1}, mode='json')
     assert v_json == {'1': 1.0}
-    assert type(v_json['1']) == float
+    assert isinstance(v_json['1'], float)
 
     assert s.to_json({1: 1}) == b'{"1":1.0}'
 
@@ -129,10 +129,10 @@ def test_numpy():
     s = SchemaSerializer(core_schema.float_schema())
     v = s.to_python(numpy.float64(1.0))
     assert v == 1.0
-    assert type(v) == numpy.float64
+    assert isinstance(v, numpy.float64)
 
     v = s.to_python(numpy.float64(1.0), mode='json')
     assert v == 1.0
-    assert type(v) == float
+    assert isinstance(v, float)
 
     assert s.to_json(numpy.float64(1.0)) == b'1.0'

--- a/tests/serializers/test_string.py
+++ b/tests/serializers/test_string.py
@@ -68,10 +68,10 @@ def test_subclass_str(schema_type, input_value, expected):
     s = SchemaSerializer({'type': schema_type})
     v = s.to_python(input_value)
     assert v == input_value
-    assert type(v) == type(input_value)
+    assert isinstance(v, type(input_value))
 
     v = s.to_python(input_value, mode='json')
     assert v == expected
-    assert type(v) == str
+    assert isinstance(v, str)
 
     assert s.to_json(input_value) == json.dumps(expected).encode('utf-8')

--- a/tests/serializers/test_url.py
+++ b/tests/serializers/test_url.py
@@ -67,9 +67,9 @@ def test_any():
 
     s = SchemaSerializer(core_schema.any_schema())
     assert s.to_python(url) == url
-    assert type(s.to_python(url)) == Url
+    assert isinstance(s.to_python(url), Url)
     assert s.to_python(multi_host_url) == multi_host_url
-    assert type(s.to_python(multi_host_url)) == MultiHostUrl
+    assert isinstance(s.to_python(multi_host_url), MultiHostUrl)
     assert s.to_python(url, mode='json') == 'https://ex.com/'
     assert s.to_python(multi_host_url, mode='json') == 'https://ex.com,ex.org/path'
     assert s.to_json(url) == b'"https://ex.com/"'

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -354,7 +354,7 @@ def test_dataclass_subclass_subclass_revalidate():
     sub_foo = FooDataclassSame(a='hello', b='True')
     sub_foo2 = v.validate_python(sub_foo)
     assert sub_foo2 is not sub_foo
-    assert type(sub_foo2) is FooDataclass
+    assert isinstance(sub_foo2, FooDataclass)
     assert dataclasses.asdict(sub_foo2) == dict(a='hello', b=True)
 
 

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -51,7 +51,7 @@ def test_int_py_and_json(py_and_json: PyAndJson, input_value, expected):
     else:
         output = v.validate_test(input_value)
         assert output == expected
-        assert type(output) == int
+        assert isinstance(output, int)
 
 
 @pytest.mark.parametrize(
@@ -425,10 +425,10 @@ def test_int_subclass() -> None:
     v = SchemaValidator({'type': 'int'})
     v_lax = v.validate_python(IntSubclass(1))
     assert v_lax == 1
-    assert type(v_lax) == int
+    assert isinstance(v_lax, int)
     v_strict = v.validate_python(IntSubclass(1), strict=True)
     assert v_strict == 1
-    assert type(v_strict) == int
+    assert isinstance(v_strict, int)
 
     assert v.validate_python(IntSubclass(1136885225876639845)) == 1136885225876639845
     assert v.validate_python(IntSubclass(i64_max + 7)) == i64_max + 7
@@ -440,10 +440,10 @@ def test_int_subclass_constraint() -> None:
     v = SchemaValidator({'type': 'int', 'gt': 0})
     v_lax = v.validate_python(IntSubclass(1))
     assert v_lax == 1
-    assert type(v_lax) == int
+    assert isinstance(v_lax, int)
     v_strict = v.validate_python(IntSubclass(1), strict=True)
     assert v_strict == 1
-    assert type(v_strict) == int
+    assert isinstance(v_strict, int)
 
     with pytest.raises(ValidationError, match='Input should be greater than 0'):
         v.validate_python(IntSubclass(0))
@@ -457,4 +457,4 @@ def test_float_subclass() -> None:
     v = SchemaValidator({'type': 'int'})
     v_lax = v.validate_python(FloatSubclass(1))
     assert v_lax == 1
-    assert type(v_lax) == int
+    assert isinstance(v_lax, int)

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -708,7 +708,7 @@ def test_revalidate_subclass_instances():
     assert hasattr(m3, 'field_c')
     m4 = v.validate_python(m3)
     assert m4 is not m3
-    assert type(m4) is MyModel
+    assert isinstance(m4, MyModel)
     assert not hasattr(m4, 'field_c')
 
     m5 = MySubModel()

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -233,7 +233,7 @@ def test_lax_subclass(FruitEnum, kwargs):
     assert v.validate_python(b'foobar') == 'foobar'
     p = v.validate_python(FruitEnum.pear)
     assert p == 'pear'
-    assert type(p) is str
+    assert isinstance(p, str)
     assert repr(p) == "'pear'"
 
 


### PR DESCRIPTION
This PR use `isinstance` replace `type` in test cases.

Selected Reviewer: @adriangb