### PR TITLE
check not type in serialization

### DIFF
--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -332,6 +332,7 @@ fn is_dataclass(op_value: Option<&PyAny>) -> bool {
         value
             .hasattr(intern!(value.py(), "__dataclass_fields__"))
             .unwrap_or(false)
+            && !value.is_instance_of::<PyType>()
     } else {
         false
     }
@@ -342,6 +343,7 @@ fn is_pydantic_serializable(op_value: Option<&PyAny>) -> bool {
         value
             .hasattr(intern!(value.py(), "__pydantic_serializer__"))
             .unwrap_or(false)
+            && !value.is_instance_of::<PyType>()
     } else {
         false
     }

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -505,6 +505,14 @@ def test_any_model():
     assert s.to_python(Foo(a='hello', b=b'more'), exclude={'a'}) == IsStrictDict()
     assert s.to_json(Foo(a='hello', b=b'more'), exclude={'a'}) == b'{}'
 
+    assert s.to_python(Foo) == Foo
+    with pytest.raises(PydanticSerializationError, match=r"Unable to serialize unknown type: <class 'type'>"):
+        s.to_python(Foo, mode='json')
+    with pytest.raises(PydanticSerializationError, match=r"Unable to serialize unknown type: <class 'type'>"):
+        s.to_json(Foo)
+    assert s.to_python(Foo, mode='json', fallback=lambda x: x.__name__) == 'Foo'
+    assert s.to_json(Foo, fallback=lambda x: x.__name__) == b'"Foo"'
+
 
 def test_dataclass_classvar(any_serializer):
     @dataclasses.dataclass


### PR DESCRIPTION
Check values are not types when checking if they look like pydantic models or dataclasses.

fix #960