### PR TITLE
Allow duplicate refs

### DIFF
--- a/tests/serializers/test_definitions.py
+++ b/tests/serializers/test_definitions.py
@@ -38,31 +38,37 @@ def test_def_error():
 
 
 def test_repeated_ref():
-    with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
-        SchemaSerializer(
-            core_schema.tuple_positional_schema(
-                [
-                    core_schema.int_schema(ref='foobar'),
-                    core_schema.definition_reference_schema('foobar'),
-                    core_schema.int_schema(ref='foobar'),
-                ]
-            )
+    s = SchemaSerializer(
+        core_schema.tuple_positional_schema(
+            [
+                # this schema will get ignored and an int will be used instead
+                # this would be a bug in whatever (pydantic python side)
+                # generated this schema, this test only documents the current behavior in pydantic-core
+                core_schema.date_schema(ref='foobar'),
+                core_schema.definition_reference_schema('foobar'),
+                core_schema.int_schema(ref='foobar'),
+            ]
         )
+    )
+
+    assert s.to_python((1, 2, 1)) == (1, 2, 1)
 
 
 def test_repeat_after():
-    with pytest.raises(SchemaError, match='SchemaError: Duplicate ref: `foobar`'):
-        SchemaSerializer(
-            core_schema.tuple_positional_schema(
-                [
-                    core_schema.definitions_schema(
-                        core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
-                        [core_schema.int_schema(ref='foobar')],
-                    ),
-                    core_schema.int_schema(ref='foobar'),
-                ]
-            )
+    s = SchemaSerializer(
+        core_schema.tuple_positional_schema(
+            [
+                core_schema.definitions_schema(
+                    core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
+                    # see note above about how this schema is ignored
+                    [core_schema.date_schema(ref='foobar')],
+                ),
+                core_schema.int_schema(ref='foobar'),
+            ]
         )
+    )
+
+    assert s.to_python(([1], 2)) == ([1], 2)
 
 
 def test_deep():


### PR DESCRIPTION
This should allow simplifying the logic for flattening and inlining defs in pydantic into a single pass by always inlining and leaving the refs in place
