### PR TITLE
Add `validate_core_schema` function and remove validation from `SchemaValidator` and `SchemaSerializer` constructors

### DIFF
--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -22,6 +22,7 @@ from ._pydantic_core import (
     Url,
     ValidationError,
     __version__,
+    _build_validator_and_serializer,
     to_json,
     to_jsonable_python,
 )
@@ -61,6 +62,7 @@ __all__ = [
     'PydanticSerializationError',
     'PydanticSerializationUnexpectedValue',
     'TzInfo',
+    '_build_validator_and_serializer',
     'to_json',
     'to_jsonable_python',
 ]

--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -22,9 +22,9 @@ from ._pydantic_core import (
     Url,
     ValidationError,
     __version__,
-    _build_validator_and_serializer,
     to_json,
     to_jsonable_python,
+    validate_core_schema,
 )
 from .core_schema import CoreConfig, CoreSchema, CoreSchemaType, ErrorType
 
@@ -62,9 +62,9 @@ __all__ = [
     'PydanticSerializationError',
     'PydanticSerializationUnexpectedValue',
     'TzInfo',
-    '_build_validator_and_serializer',
     'to_json',
     'to_jsonable_python',
+    'validate_core_schema',
 ]
 
 

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -40,11 +40,11 @@ __all__ = [
     'PydanticUndefined',
     'PydanticUndefinedType',
     'Some',
-    '_build_validator_and_serializer',
     'to_json',
     'to_jsonable_python',
     'list_all_errors',
     'TzInfo',
+    'validate_core_schema',
 ]
 __version__: str
 build_profile: str
@@ -838,6 +838,10 @@ class TzInfo(datetime.tzinfo):
     def fromutc(self, dt: datetime.datetime) -> datetime.datetime: ...
     def __deepcopy__(self, _memo: dict[Any, Any]) -> 'TzInfo': ...
 
-def _build_validator_and_serializer(
-    schema: CoreSchema, config: CoreConfig | None = None
-) -> tuple[SchemaValidator, SchemaSerializer]: ...
+def validate_core_schema(schema: CoreSchema) -> CoreSchema:
+    """Validate a CoreSchema
+    This currently uses lax mode for validation (i.e. will coerce strings to dates and such)
+    but may use strict mode in the future.
+    We may also remove this function altogether, do not rely on it being present if you are
+    using pydantic-core directly.
+    """

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -40,6 +40,7 @@ __all__ = [
     'PydanticUndefined',
     'PydanticUndefinedType',
     'Some',
+    '_build_validator_and_serializer',
     'to_json',
     'to_jsonable_python',
     'list_all_errors',
@@ -836,3 +837,7 @@ class TzInfo(datetime.tzinfo):
     def dst(self, _dt: datetime.datetime | None) -> datetime.timedelta: ...
     def fromutc(self, dt: datetime.datetime) -> datetime.datetime: ...
     def __deepcopy__(self, _memo: dict[Any, Any]) -> 'TzInfo': ...
+
+def _build_validator_and_serializer(
+    schema: CoreSchema, config: CoreConfig | None = None
+) -> tuple[SchemaValidator, SchemaSerializer]: ...

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -7,7 +7,6 @@ use pyo3::{PyTraverseError, PyVisit};
 
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
-use crate::validators::{SelfValidator, ValidatedSchema};
 
 use config::SerializationConfig;
 pub use errors::{PydanticSerializationError, PydanticSerializationUnexpectedValue};
@@ -37,16 +36,6 @@ pub struct SchemaSerializer {
 }
 
 impl SchemaSerializer {
-    pub(crate) fn new(schema: &ValidatedSchema<'_>, config: Option<&PyDict>) -> PyResult<Self> {
-        let mut definitions_builder = DefinitionsBuilder::new();
-        Ok(Self {
-            serializer: CombinedSerializer::build(schema, config, &mut definitions_builder)?,
-            definitions: definitions_builder.finish()?,
-            expected_json_size: AtomicUsize::new(1024),
-            config: SerializationConfig::from_config(config)?,
-        })
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_extra<'b, 'a: 'b>(
         &'b self,
@@ -83,10 +72,16 @@ impl SchemaSerializer {
 #[pymethods]
 impl SchemaSerializer {
     #[new]
-    pub fn py_new(py: Python, schema: &PyDict, config: Option<&PyDict>) -> PyResult<Self> {
-        let self_validator = SelfValidator::new(py)?;
-        let schema = self_validator.validate_schema(py, schema)?;
-        Self::new(&schema, config)
+    pub fn py_new(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Self> {
+        let mut definitions_builder = DefinitionsBuilder::new();
+
+        let serializer = CombinedSerializer::build(schema.downcast()?, config, &mut definitions_builder)?;
+        Ok(Self {
+            serializer,
+            definitions: definitions_builder.finish()?,
+            expected_json_size: AtomicUsize::new(1024),
+            config: SerializationConfig::from_config(config)?,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -109,9 +109,10 @@ pub struct SchemaValidator {
     validation_error_cause: bool,
 }
 
+#[pymethods]
 impl SchemaValidator {
-    /// Construct from an already validated Schema. May raise
-    pub(crate) fn new(py: Python, schema: &ValidatedSchema<'_>, config: Option<&PyDict>) -> PyResult<Self> {
+    #[new]
+    pub fn py_new(py: Python, schema: &PyAny, config: Option<&PyDict>) -> PyResult<Self> {
         let mut definitions_builder = DefinitionsBuilder::new();
 
         let mut validator = build_validator(schema, config, &mut definitions_builder)?;
@@ -138,17 +139,6 @@ impl SchemaValidator {
             hide_input_in_errors,
             validation_error_cause,
         })
-    }
-}
-
-#[pymethods]
-impl SchemaValidator {
-    #[new]
-    pub fn py_new(py: Python, schema: &PyAny, config: Option<&PyDict>) -> PyResult<Self> {
-        let self_validator = SelfValidator::new(py)?;
-        let schema = self_validator.validate_schema(py, schema)?;
-
-        Self::new(py, &schema, config)
     }
 
     pub fn __reduce__(&self, py: Python) -> PyResult<PyObject> {
@@ -368,19 +358,6 @@ pub struct SelfValidator<'py> {
     validator: &'py SchemaValidator,
 }
 
-/// Validated CoreSchema.
-///
-/// The only way to build this is by `SelfValidator::validate_schema`.
-pub struct ValidatedSchema<'py>(&'py PyDict);
-
-impl<'py> std::ops::Deref for ValidatedSchema<'py> {
-    type Target = &'py PyDict;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl<'py> SelfValidator<'py> {
     pub fn new(py: Python<'py>) -> PyResult<Self> {
         let validator = SCHEMA_DEFINITION.get_or_init(py, || match Self::build(py) {
@@ -390,7 +367,7 @@ impl<'py> SelfValidator<'py> {
         Ok(Self { validator })
     }
 
-    pub fn validate_schema(&self, py: Python<'py>, schema: &'py PyAny) -> PyResult<ValidatedSchema<'py>> {
+    pub fn validate_schema(&self, py: Python<'py>, schema: &'py PyAny) -> PyResult<&'py PyAny> {
         let mut recursion_guard = RecursionGuard::default();
         let mut state = ValidationState::new(
             Extra::new(None, None, None, None, InputType::Python),
@@ -398,7 +375,7 @@ impl<'py> SelfValidator<'py> {
             &mut recursion_guard,
         );
         match self.validator.validator.validate(py, schema, &mut state) {
-            Ok(schema_obj) => Ok(ValidatedSchema(schema_obj.into_ref(py).downcast()?)),
+            Ok(schema_obj) => Ok(schema_obj.into_ref(py)),
             Err(e) => Err(SchemaError::from_val_error(py, e)),
         }
     }
@@ -429,6 +406,12 @@ impl<'py> SelfValidator<'py> {
             validation_error_cause: false,
         })
     }
+}
+
+#[pyfunction]
+pub fn validate_core_schema<'a>(py: Python<'a>, schema: &'a PyAny) -> PyResult<&'a PyAny> {
+    let self_validator = SelfValidator::new(py)?;
+    self_validator.validate_schema(py, schema)
 }
 
 pub trait BuildValidator: Sized {
@@ -466,9 +449,9 @@ macro_rules! validator_match {
     };
 }
 
-pub fn build_validator(
-    schema: &PyAny,
-    config: Option<&PyDict>,
+pub fn build_validator<'a>(
+    schema: &'a PyAny,
+    config: Option<&'a PyDict>,
     definitions: &mut DefinitionsBuilder<CombinedValidator>,
 ) -> PyResult<CombinedValidator> {
     let dict: &PyDict = schema.downcast()?;

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -239,8 +239,8 @@ enum RegexEngine {
 }
 
 impl RegexEngine {
-    const RUST_REGEX: &str = "rust-regex";
-    const PYTHON_RE: &str = "python-re";
+    const RUST_REGEX: &'static str = "rust-regex";
+    const PYTHON_RE: &'static str = "python-re";
 }
 
 impl Pattern {

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -100,7 +100,7 @@ impl BuildValidator for WithDefaultValidator {
             _ => unreachable!(),
         };
 
-        let sub_schema = schema.get_as_req(intern!(schema.py(), "schema"))?;
+        let sub_schema: &PyAny = schema.get_as_req(intern!(schema.py(), "schema"))?;
         let validator = Box::new(build_validator(sub_schema, config, definitions)?);
 
         let copy_default = if let DefaultType::Default(default_obj) = &default {

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -100,7 +100,7 @@ impl BuildValidator for WithDefaultValidator {
             _ => unreachable!(),
         };
 
-        let sub_schema: &PyAny = schema.get_as_req(intern!(schema.py(), "schema"))?;
+        let sub_schema = schema.get_as_req(intern!(schema.py(), "schema"))?;
         let validator = Box::new(build_validator(sub_schema, config, definitions)?);
 
         let copy_default = if let DefaultType::Default(default_obj) = &default {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import hypothesis
 import pytest
 from typing_extensions import Literal
 
-from pydantic_core import ArgsKwargs, SchemaValidator, ValidationError
+from pydantic_core import ArgsKwargs, SchemaValidator, ValidationError, validate_core_schema
 from pydantic_core.core_schema import CoreConfig
 
 __all__ = 'Err', 'PyAndJson', 'plain_repr', 'infinite_generator'
@@ -53,7 +53,7 @@ class PyAndJsonValidator:
     def __init__(
         self, schema, config: CoreConfig | None = None, *, validator_type: Literal['json', 'python'] | None = None
     ):
-        self.validator = SchemaValidator(schema, config)
+        self.validator = SchemaValidator(validate_core_schema(schema), config)
         self.validator_type = validator_type
 
     def validate_python(self, py_input, strict: bool | None = None, context: Any = None):

--- a/tests/serializers/test_definitions.py
+++ b/tests/serializers/test_definitions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic_core import SchemaError, SchemaSerializer, core_schema
+from pydantic_core import SchemaError, SchemaSerializer, core_schema, validate_core_schema
 
 
 def test_custom_ser():
@@ -25,7 +25,7 @@ def test_ignored_def():
 
 def test_def_error():
     with pytest.raises(SchemaError) as exc_info:
-        SchemaSerializer(
+        validate_core_schema(
             core_schema.definitions_schema(
                 core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
                 [core_schema.int_schema(ref='foobar'), {'type': 'wrong'}],

--- a/tests/serializers/test_dict.py
+++ b/tests/serializers/test_dict.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from dirty_equals import IsStrictDict
 
-from pydantic_core import SchemaError, SchemaSerializer, core_schema
+from pydantic_core import SchemaError, SchemaSerializer, core_schema, validate_core_schema
 
 
 def test_dict_str_int():
@@ -155,4 +155,6 @@ def test_filter_runtime_int():
 )
 def test_include_error(include_value, error_msg):
     with pytest.raises(SchemaError, match=error_msg):
-        SchemaSerializer(core_schema.dict_schema(serialization=core_schema.filter_dict_schema(include=include_value)))
+        validate_core_schema(
+            core_schema.dict_schema(serialization=core_schema.filter_dict_schema(include=include_value))
+        )

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaSerializer, core_schema
+from pydantic_core import SchemaError, SchemaSerializer, core_schema, validate_core_schema
 
 
 def test_list_any():
@@ -144,8 +144,10 @@ def test_exclude(schema_func, seq_f):
 @pytest.mark.parametrize('include,exclude', [({1, 3, 5}, {5, 6}), ([1, 3, 5], [5, 6])])
 def test_filter(include, exclude):
     v = SchemaSerializer(
-        core_schema.list_schema(
-            core_schema.any_schema(), serialization=core_schema.filter_seq_schema(include=include, exclude=exclude)
+        validate_core_schema(
+            core_schema.list_schema(
+                core_schema.any_schema(), serialization=core_schema.filter_seq_schema(include=include, exclude=exclude)
+            )
         )
     )
     assert v.to_python([0, 1, 2, 3, 4, 5, 6, 7]) == [1, 3]
@@ -186,7 +188,7 @@ class RemovedContains(ImplicitContains):
 @pytest.mark.parametrize('schema_func', [core_schema.list_schema, core_schema.tuple_variable_schema])
 def test_include_error(schema_func, include_value, error_msg):
     with pytest.raises(SchemaError, match=error_msg):
-        SchemaSerializer(
+        validate_core_schema(
             schema_func(core_schema.any_schema(), serialization=core_schema.filter_seq_schema(include=include_value))
         )
 

--- a/tests/serializers/test_misc.py
+++ b/tests/serializers/test_misc.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic_core import SchemaError, SchemaSerializer, core_schema
+from pydantic_core import SchemaError, core_schema, validate_core_schema
 
 
 @pytest.mark.parametrize(
@@ -12,4 +12,4 @@ from pydantic_core import SchemaError, SchemaSerializer, core_schema
 )
 def test_invalid_ser_schema(ser_schema, msg):
     with pytest.raises(SchemaError, match=msg):
-        SchemaSerializer(core_schema.any_schema(serialization=ser_schema))
+        validate_core_schema(core_schema.any_schema(serialization=ser_schema))

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,7 +46,7 @@ mod tests {
                 ]
             }"#;
             let schema: &PyDict = py.eval(code, None, None).unwrap().extract().unwrap();
-            SchemaSerializer::py_new(py, schema, None).unwrap();
+            SchemaSerializer::py_new(schema, None).unwrap();
         });
     }
 
@@ -77,7 +77,7 @@ a = A()
             py.run(code, None, Some(locals)).unwrap();
             let a: &PyAny = locals.get_item("a").unwrap().extract().unwrap();
             let schema: &PyDict = locals.get_item("schema").unwrap().extract().unwrap();
-            let serialized: Vec<u8> = SchemaSerializer::py_new(py, schema, None)
+            let serialized: Vec<u8> = SchemaSerializer::py_new(schema, None)
                 .unwrap()
                 .to_json(py, a, None, None, None, true, false, false, false, false, true, None)
                 .unwrap()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,23 +2,23 @@ import pickle
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator
+from pydantic_core import SchemaError, SchemaValidator, validate_core_schema
 from pydantic_core import core_schema as cs
 
 
 def test_build_error_type():
     with pytest.raises(SchemaError, match="Input tag 'foobar' found using 'type' does not match any of the"):
-        SchemaValidator({'type': 'foobar', 'title': 'TestModel'})
+        validate_core_schema({'type': 'foobar', 'title': 'TestModel'})
 
 
 def test_build_error_internal():
     with pytest.raises(SchemaError, match='Input should be a valid integer, unable to parse string as an integer'):
-        SchemaValidator({'type': 'str', 'min_length': 'xxx', 'title': 'TestModel'})
+        validate_core_schema({'type': 'str', 'min_length': 'xxx', 'title': 'TestModel'})
 
 
 def test_build_error_deep():
     with pytest.raises(SchemaError, match='Input should be a valid integer, unable to parse string as an integer'):
-        SchemaValidator(
+        validate_core_schema(
             {
                 'title': 'MyTestModel',
                 'type': 'typed-dict',
@@ -34,7 +34,7 @@ def test_schema_as_string():
 
 def test_schema_wrong_type(pydantic_version):
     with pytest.raises(SchemaError) as exc_info:
-        SchemaValidator(1)
+        validate_core_schema(1)
     assert str(exc_info.value) == (
         'Invalid Schema:\n  Input should be a valid dictionary or object to'
         ' extract fields from [type=model_attributes_type, input_value=1, input_type=int]\n'
@@ -66,7 +66,7 @@ def test_schema_definition_error():
     schema = {'type': 'union', 'choices': []}
     schema['choices'].append({'type': 'nullable', 'schema': schema})
     with pytest.raises(SchemaError, match='Recursion error - cyclic reference detected'):
-        SchemaValidator(schema)
+        validate_core_schema(schema)
 
 
 def test_not_schema_definition_error():
@@ -83,17 +83,17 @@ def test_not_schema_definition_error():
 
 def test_no_type():
     with pytest.raises(SchemaError, match="Unable to extract tag using discriminator 'type'"):
-        SchemaValidator({})
+        validate_core_schema({})
 
 
 def test_wrong_type():
     with pytest.raises(SchemaError, match="Input tag 'unknown' found using 'type' does not match any of the"):
-        SchemaValidator({'type': 'unknown'})
+        validate_core_schema({'type': 'unknown'})
 
 
 def test_function_no_mode():
     with pytest.raises(SchemaError, match="Input tag 'function' found using 'type' does not match any of the"):
-        SchemaValidator({'type': 'function'})
+        validate_core_schema({'type': 'function'})
 
 
 def test_try_self_schema_discriminator():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,6 +9,7 @@ from dirty_equals import IsList
 import pydantic_core
 from pydantic_core import (
     PydanticSerializationError,
+    SchemaSerializer,
     SchemaValidator,
     ValidationError,
     core_schema,
@@ -271,7 +272,8 @@ def test_to_jsonable_python_schema_serializer():
             )
         ],
     )
-    v, s = pydantic_core._build_validator_and_serializer(c)
+    v = SchemaValidator(c)
+    s = SchemaSerializer(c)
 
     Foobar.__pydantic_validator__ = v
     Foobar.__pydantic_serializer__ = s

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,7 +9,6 @@ from dirty_equals import IsList
 import pydantic_core
 from pydantic_core import (
     PydanticSerializationError,
-    SchemaSerializer,
     SchemaValidator,
     ValidationError,
     core_schema,
@@ -272,8 +271,7 @@ def test_to_jsonable_python_schema_serializer():
             )
         ],
     )
-    v = SchemaValidator(c)
-    s = SchemaSerializer(c)
+    v, s = pydantic_core._build_validator_and_serializer(c)
 
     Foobar.__pydantic_validator__ = v
     Foobar.__pydantic_serializer__ = s

--- a/tests/validators/test_custom_error.py
+++ b/tests/validators/test_custom_error.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import PyAndJson
 
@@ -33,7 +33,7 @@ def test_custom_error_type(py_and_json: PyAndJson):
 
 def test_custom_error_error():
     with pytest.raises(SchemaError, match=r'custom_error_type\s+Field required \[type=missing'):
-        SchemaValidator({'type': 'custom-error', 'schema': {'type': 'int'}})
+        validate_core_schema({'type': 'custom-error', 'schema': {'type': 'int'}})
 
 
 def test_custom_error_invalid():

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -183,9 +183,9 @@ def test_date_strict_json_ctx():
             '2000-01-02',
             Err('Input should be less than or equal to 2000-01-01 [type=less_than_equal,'),
         ),
-        ({'lt': '2000-01-01'}, '1999-12-31', date(1999, 12, 31)),
-        ({'lt': '2000-01-01'}, '2000-01-01', Err('Input should be less than 2000-01-01 [type=less_than,')),
-        ({'ge': '2000-01-01'}, '2000-01-01', date(2000, 1, 1)),
+        ({'lt': date(2000, 1, 1)}, '1999-12-31', date(1999, 12, 31)),
+        ({'lt': date(2000, 1, 1)}, '2000-01-01', Err('Input should be less than 2000-01-01 [type=less_than,')),
+        ({'ge': date(2000, 1, 1)}, '2000-01-01', date(2000, 1, 1)),
         (
             {'ge': date(2000, 1, 1)},
             '1999-12-31',
@@ -195,8 +195,8 @@ def test_date_strict_json_ctx():
         ({'gt': date(2000, 1, 1)}, '2000-01-01', Err('Input should be greater than 2000-01-01 [type=greater_than,')),
     ],
 )
-def test_date_kwargs(kwargs: Dict[str, Any], input_value, expected):
-    v = SchemaValidator({'type': 'date', **kwargs})
+def test_date_kwargs(kwargs: Dict[str, Any], input_value: date, expected: Err | date):
+    v = SchemaValidator({'type': 'date', **kwargs})  # type: ignore
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -207,7 +207,7 @@ def test_date_kwargs(kwargs: Dict[str, Any], input_value, expected):
 
 def test_invalid_constraint():
     with pytest.raises(SchemaError, match=r'date\.gt\n  Input should be a valid date or datetime'):
-        SchemaValidator({'type': 'date', 'gt': 'foobar'})
+        validate_core_schema({'type': 'date', 'gt': 'foobar'})
 
 
 def test_dict_py():
@@ -288,4 +288,4 @@ def test_date_past_future_today():
 
 def test_offset_too_large():
     with pytest.raises(SchemaError, match=r'Input should be less than 86400 \[type=less_than,'):
-        SchemaValidator(core_schema.date_schema(now_op='past', now_utc_offset=24 * 3600))
+        validate_core_schema(core_schema.date_schema(now_op='past', now_utc_offset=24 * 3600))

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -10,7 +10,7 @@ from typing import Dict
 import pytest
 import pytz
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -284,7 +284,7 @@ def test_union():
 
 def test_invalid_constraint():
     with pytest.raises(SchemaError, match=r'datetime\.gt\n  Input should be a valid datetime'):
-        SchemaValidator({'type': 'datetime', 'gt': 'foobar'})
+        validate_core_schema({'type': 'datetime', 'gt': 'foobar'})
 
 
 @pytest.mark.parametrize(
@@ -387,7 +387,7 @@ def test_mock_utc_offset_8_hours(mocker):
 
 def test_offset_too_large():
     with pytest.raises(SchemaError, match=r'Input should be greater than -86400 \[type=greater_than,'):
-        SchemaValidator(core_schema.datetime_schema(now_op='past', now_utc_offset=-24 * 3600))
+        validate_core_schema(core_schema.datetime_schema(now_op='past', now_utc_offset=-24 * 3600))
 
 
 def test_raises_schema_error_for_unknown_constraint_kind():
@@ -395,7 +395,7 @@ def test_raises_schema_error_for_unknown_constraint_kind():
         SchemaError,
         match=(r'Input should be \'aware\' or \'naive\' \[type=literal_error, input_value=\'foo\', input_type=str\]'),
     ):
-        SchemaValidator({'type': 'datetime', 'tz_constraint': 'foo'})
+        validate_core_schema({'type': 'datetime', 'tz_constraint': 'foo'})
 
 
 def test_aware():
@@ -477,7 +477,7 @@ def test_tz_constraint_too_high():
 
 def test_tz_constraint_wrong():
     with pytest.raises(SchemaError, match="Input should be 'aware' or 'naive"):
-        SchemaValidator(core_schema.datetime_schema(tz_constraint='wrong'))
+        validate_core_schema(core_schema.datetime_schema(tz_constraint='wrong'))
 
 
 def test_tz_pickle() -> None:

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import math
 import re
@@ -184,8 +186,8 @@ def test_decimal_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_va
     ],
     ids=repr,
 )
-def test_decimal_multiple_of(py_and_json: PyAndJson, multiple_of, input_value, error):
-    v = py_and_json({'type': 'decimal', 'multiple_of': multiple_of})
+def test_decimal_multiple_of(py_and_json: PyAndJson, multiple_of: float, input_value: float, error: Err | None):
+    v = py_and_json({'type': 'decimal', 'multiple_of': Decimal(str(multiple_of))})
     if error:
         with pytest.raises(ValidationError, match=re.escape(error.message)):
             v.validate_test(input_value)

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, core_schema
+from pydantic_core import SchemaError, SchemaValidator, core_schema, validate_core_schema
 
 from ..conftest import plain_repr
 
@@ -47,7 +47,7 @@ def test_check_ref_used_ignores_metadata():
 
 def test_def_error():
     with pytest.raises(SchemaError) as exc_info:
-        SchemaValidator(
+        validate_core_schema(
             core_schema.definitions_schema(
                 core_schema.list_schema(core_schema.definition_reference_schema('foobar')),
                 [core_schema.int_schema(ref='foobar'), {'type': 'wrong'}],

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Type, Union
 import pytest
 from dirty_equals import HasRepr
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import plain_repr
 
@@ -223,12 +223,12 @@ def test_function_wrap_str():
 
 def test_function_wrap_not_callable():
     with pytest.raises(SchemaError, match='function-wrap.function.typed-dict.function\n  Input should be callable'):
-        SchemaValidator(
+        validate_core_schema(
             {'type': 'function-wrap', 'function': {'type': 'general', 'function': []}, 'schema': {'type': 'str'}}
         )
 
     with pytest.raises(SchemaError, match='function-wrap.function\n  Field required'):
-        SchemaValidator({'type': 'function-wrap', 'schema': {'type': 'str'}})
+        validate_core_schema({'type': 'function-wrap', 'schema': {'type': 'str'}})
 
 
 def test_wrap_error():
@@ -450,7 +450,7 @@ def test_function_plain_no_info():
 
 def test_plain_with_schema():
     with pytest.raises(SchemaError, match='function-plain.schema\n  Extra inputs are not permitted'):
-        SchemaValidator(
+        validate_core_schema(
             {
                 'type': 'function-plain',
                 'function': {'type': 'general', 'function': lambda x: x},

--- a/tests/validators/test_model_fields.py
+++ b/tests/validators/test_model_fields.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Mapping, Union
 import pytest
 from dirty_equals import FunctionCheck, HasRepr, IsStr
 
-from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -430,7 +430,7 @@ def test_json_error():
 
 def test_missing_schema_key():
     with pytest.raises(SchemaError, match='model-fields.fields.x.schema\n  Field required'):
-        SchemaValidator({'type': 'model-fields', 'fields': {'x': {'type': 'str'}}})
+        validate_core_schema({'type': 'model-fields', 'fields': {'x': {'type': 'str'}}})
 
 
 def test_fields_required_by_default():
@@ -734,10 +734,12 @@ def test_paths_allow_by_name(py_and_json: PyAndJson, input_value):
 def test_alias_build_error(alias_schema, error):
     with pytest.raises(SchemaError, match=error):
         SchemaValidator(
-            {
-                'type': 'model-fields',
-                'fields': {'field_a': {'type': 'model-field', 'schema': {'type': 'int'}, **alias_schema}},
-            }
+            validate_core_schema(
+                {
+                    'type': 'model-fields',
+                    'fields': {'field_a': {'type': 'model-field', 'schema': {'type': 'int'}, **alias_schema}},
+                }
+            )
         )
 
 
@@ -1491,7 +1493,7 @@ def test_bad_default_factory(default_factory, error_message):
 class TestOnError:
     def test_on_error_bad_name(self):
         with pytest.raises(SchemaError, match="Input should be 'raise', 'omit' or 'default'"):
-            SchemaValidator(
+            validate_core_schema(
                 {
                     'type': 'model-fields',
                     'fields': {

--- a/tests/validators/test_time.py
+++ b/tests/validators/test_time.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -156,7 +156,6 @@ def test_time_strict_json(input_value, expected):
         ({'ge': time(1)}, '00:59', Err('Input should be greater than or equal to 01:00:00')),
         ({'gt': time(12, 13, 14, 123_456)}, '12:13:14.123457', time(12, 13, 14, 123_457)),
         ({'gt': time(12, 13, 14, 123_456)}, '12:13:14.123456', Err('Input should be greater than 12:13:14.123456')),
-        ({'gt': '12:13:14.123456'}, '12:13:14.123456', Err('Input should be greater than 12:13:14.123456')),
     ],
 )
 def test_time_kwargs(kwargs: Dict[str, Any], input_value, expected):
@@ -192,7 +191,7 @@ def test_time_bound_ctx():
 
 def test_invalid_constraint():
     with pytest.raises(SchemaError, match='Input should be in a valid time format'):
-        SchemaValidator({'type': 'time', 'gt': 'foobar'})
+        validate_core_schema({'type': 'time', 'gt': 'foobar'})
 
 
 def test_dict_py():
@@ -294,4 +293,4 @@ def test_tz_constraint_too_high():
 
 def test_tz_constraint_wrong():
     with pytest.raises(SchemaError, match="Input should be 'aware' or 'naive"):
-        SchemaValidator(core_schema.time_schema(tz_constraint='wrong'))
+        validate_core_schema(core_schema.time_schema(tz_constraint='wrong'))

--- a/tests/validators/test_timedelta.py
+++ b/tests/validators/test_timedelta.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -143,7 +143,6 @@ def test_timedelta_strict_json(input_value, expected):
         ({'ge': timedelta(days=3)}, 'P3D', timedelta(days=3)),
         ({'ge': timedelta(days=3)}, 'P2DT1H', Err('Input should be greater than or equal to 3 days')),
         ({'gt': timedelta(days=3)}, 'P3DT1H', timedelta(days=3, hours=1)),
-        ({'gt': 'P3D'}, 'P2DT1H', Err('Input should be greater than 3 days')),
         ({'le': timedelta(seconds=-86400.123)}, '-PT86400.123S', timedelta(seconds=-86400.123)),
         ({'le': timedelta(seconds=-86400.123)}, '-PT86400.124S', timedelta(seconds=-86400.124)),
         (
@@ -197,10 +196,10 @@ def test_timedelta_kwargs_strict():
 
 def test_invalid_constraint():
     with pytest.raises(SchemaError, match='timedelta.gt\n  Input should be a valid timedelta, invalid digit in'):
-        SchemaValidator({'type': 'timedelta', 'gt': 'foobar'})
+        validate_core_schema({'type': 'timedelta', 'gt': 'foobar'})
 
     with pytest.raises(SchemaError, match='timedelta.le\n  Input should be a valid timedelta, invalid digit in'):
-        SchemaValidator({'type': 'timedelta', 'le': 'foobar'})
+        validate_core_schema({'type': 'timedelta', 'le': 'foobar'})
 
 
 def test_dict_py():

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Mapping, Union
 import pytest
 from dirty_equals import FunctionCheck
 
-from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -194,7 +194,7 @@ def test_allow_extra_invalid():
 
 def test_allow_extra_wrong():
     with pytest.raises(SchemaError, match="Input should be 'allow', 'forbid' or 'ignore'"):
-        SchemaValidator({'type': 'typed-dict', 'fields': {}, 'config': {'extra_fields_behavior': 'wrong'}})
+        validate_core_schema({'type': 'typed-dict', 'fields': {}, 'config': {'extra_fields_behavior': 'wrong'}})
 
 
 def test_str_config():
@@ -235,7 +235,7 @@ def test_json_error():
 
 def test_missing_schema_key():
     with pytest.raises(SchemaError, match='typed-dict.fields.x.schema\n  Field required'):
-        SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'type': 'str'}}})
+        validate_core_schema({'type': 'typed-dict', 'fields': {'x': {'type': 'str'}}})
 
 
 def test_fields_required_by_default():
@@ -629,10 +629,12 @@ def test_paths_allow_by_name(py_and_json: PyAndJson, input_value):
 def test_alias_build_error(alias_schema, error):
     with pytest.raises(SchemaError, match=error):
         SchemaValidator(
-            {
-                'type': 'typed-dict',
-                'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}, **alias_schema}},
-            }
+            validate_core_schema(
+                {
+                    'type': 'typed-dict',
+                    'fields': {'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'int'}, **alias_schema}},
+                }
+            )
         )
 
 
@@ -899,7 +901,7 @@ def test_bad_default_factory(default_factory, error_message):
 class TestOnError:
     def test_on_error_bad_name(self):
         with pytest.raises(SchemaError, match="Input should be 'raise', 'omit' or 'default'"):
-            SchemaValidator(
+            validate_core_schema(
                 {
                     'type': 'typed-dict',
                     'fields': {

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -1,7 +1,7 @@
 import pytest
 from dirty_equals import IsFloat, IsInt
 
-from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError, core_schema, validate_core_schema
 
 from ..conftest import plain_repr
 
@@ -234,7 +234,7 @@ def test_union_list_bool_int():
 
 def test_no_choices(pydantic_version):
     with pytest.raises(SchemaError) as exc_info:
-        SchemaValidator({'type': 'union'})
+        validate_core_schema({'type': 'union'})
 
     assert str(exc_info.value) == (
         'Invalid Schema:\n'


### PR DESCRIPTION
## Change Summary

Related to startup performance. The idea is that `pydantic` will have more control over when the CoreSchema gets validated, e.g. validating it once for both `SchemaValidator` and `SchemaSerializer`, deciding not to validate it at all based on an env var, etc.

Selected Reviewer: @samuelcolvin