### PR TITLE
Replace definitions `Vec` with `OnceLock` slots

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -3,16 +3,17 @@
 /// Unlike json schema we let you put definitions inline, not just in a single '#/$defs/' block or similar.
 /// We use DefinitionsBuilder to collect the references / definitions into a single vector
 /// and then get a definition from a reference using an integer id (just for performance of not using a HashMap)
-use std::collections::hash_map::Entry;
+use std::{
+    collections::hash_map::Entry,
+    fmt::Debug,
+    sync::{Arc, OnceLock},
+};
 
-use pyo3::prelude::*;
+use pyo3::{prelude::*, PyTraverseError, PyVisit};
 
 use ahash::AHashMap;
 
-use crate::build_tools::py_schema_err;
-
-// An integer id for the reference
-pub type ReferenceId = usize;
+use crate::{build_tools::py_schema_err, py_gc::PyGcTraverse};
 
 /// Definitions are validators and serializers that are
 /// shared by reference.
@@ -24,91 +25,154 @@ pub type ReferenceId = usize;
 /// They get indexed by a ReferenceId, which are integer identifiers
 /// that are handed out and managed by DefinitionsBuilder when the Schema{Validator,Serializer}
 /// gets build.
-pub type Definitions<T> = [T];
+#[derive(Clone)]
+pub struct Definitions<T>(AHashMap<Arc<String>, Definition<T>>);
 
-#[derive(Clone, Debug)]
-struct Definition<T> {
-    pub id: ReferenceId,
-    pub value: Option<T>,
+impl<T> Definitions<T> {
+    pub fn values(&self) -> impl Iterator<Item = &Definition<T>> {
+        self.0.values()
+    }
+}
+
+/// Internal type which contains a definition to be filled
+pub struct Definition<T>(Arc<OnceLock<T>>);
+
+impl<T> Definition<T> {
+    pub fn get(&self) -> Option<&T> {
+        self.0.get()
+    }
+}
+
+/// Reference to a definition.
+pub struct DefinitionRef<T> {
+    name: Arc<String>,
+    value: Definition<T>,
+}
+
+// DefinitionRef can always be cloned (#[derive(Clone)] would require T: Clone)
+impl<T> Clone for DefinitionRef<T> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+impl<T> DefinitionRef<T> {
+    pub fn id(&self) -> usize {
+        Arc::as_ptr(&self.value.0) as usize
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get(&self) -> Option<&T> {
+        self.value.0.get()
+    }
+}
+
+impl<T: Debug> Debug for DefinitionRef<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // To avoid possible infinite recursion from recursive definitions,
+        // a DefinitionRef just displays debug as its name
+        self.name.fmt(f)
+    }
+}
+
+impl<T: Debug> Debug for Definitions<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> Clone for Definition<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: Debug> Debug for Definition<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.get() {
+            Some(value) => value.fmt(f),
+            None => "...".fmt(f),
+        }
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for DefinitionRef<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        if let Some(value) = self.value.0.get() {
+            value.py_gc_traverse(visit)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for Definitions<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        for value in self.0.values() {
+            if let Some(value) = value.0.get() {
+                value.py_gc_traverse(visit)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]
 pub struct DefinitionsBuilder<T> {
-    definitions: AHashMap<String, Definition<T>>,
+    definitions: Definitions<T>,
 }
 
-impl<T: Clone + std::fmt::Debug> DefinitionsBuilder<T> {
+impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
     pub fn new() -> Self {
         Self {
-            definitions: AHashMap::new(),
+            definitions: Definitions(AHashMap::new()),
         }
     }
 
     /// Get a ReferenceId for the given reference string.
-    // This ReferenceId can later be used to retrieve a definition
-    pub fn get_reference_id(&mut self, reference: &str) -> ReferenceId {
-        let next_id = self.definitions.len();
+    pub fn get_definition(&mut self, reference: &str) -> DefinitionRef<T> {
         // We either need a String copy or two hashmap lookups
         // Neither is better than the other
         // We opted for the easier outward facing API
-        match self.definitions.entry(reference.to_string()) {
-            Entry::Occupied(entry) => entry.get().id,
-            Entry::Vacant(entry) => {
-                entry.insert(Definition {
-                    id: next_id,
-                    value: None,
-                });
-                next_id
-            }
+        let name = Arc::new(reference.to_string());
+        let value = match self.definitions.0.entry(name.clone()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Definition(Arc::new(OnceLock::new()))),
+        };
+        DefinitionRef {
+            name,
+            value: value.clone(),
         }
     }
 
     /// Add a definition, returning the ReferenceId that maps to it
-    pub fn add_definition(&mut self, reference: String, value: T) -> PyResult<ReferenceId> {
-        let next_id = self.definitions.len();
-        match self.definitions.entry(reference.clone()) {
-            Entry::Occupied(mut entry) => match entry.get_mut().value.replace(value) {
-                Some(_) => py_schema_err!("Duplicate ref: `{}`", reference),
-                None => Ok(entry.get().id),
-            },
-            Entry::Vacant(entry) => {
-                entry.insert(Definition {
-                    id: next_id,
-                    value: Some(value),
-                });
-                Ok(next_id)
+    pub fn add_definition(&mut self, reference: String, value: T) -> PyResult<DefinitionRef<T>> {
+        let name = Arc::new(reference);
+        let value = match self.definitions.0.entry(name.clone()) {
+            Entry::Occupied(entry) => {
+                let definition = entry.into_mut();
+                match definition.0.set(value) {
+                    Ok(()) => definition.clone(),
+                    Err(_) => return py_schema_err!("Duplicate ref: `{}`", name),
+                }
             }
-        }
-    }
-
-    /// Retrieve an item definition using a ReferenceId
-    /// If the definition doesn't yet exist (as happens in recursive types) then we create it
-    /// At the end (in finish()) we check that there are no undefined definitions
-    pub fn get_definition(&self, reference_id: ReferenceId) -> PyResult<&T> {
-        let (reference, def) = match self.definitions.iter().find(|(_, def)| def.id == reference_id) {
-            Some(v) => v,
-            None => return py_schema_err!("Definitions error: no definition for ReferenceId `{}`", reference_id),
+            Entry::Vacant(entry) => entry.insert(Definition(Arc::new(OnceLock::from(value)))).clone(),
         };
-        match def.value.as_ref() {
-            Some(v) => Ok(v),
-            None => py_schema_err!(
-                "Definitions error: attempted to use `{}` before it was filled",
-                reference
-            ),
-        }
+        Ok(DefinitionRef { name, value })
     }
 
     /// Consume this Definitions into a vector of items, indexed by each items ReferenceId
-    pub fn finish(self) -> PyResult<Vec<T>> {
-        // We need to create a vec of defs according to the order in their ids
-        let mut defs: Vec<(usize, T)> = Vec::new();
-        for (reference, def) in self.definitions {
-            match def.value {
-                None => return py_schema_err!("Definitions error: definition {} was never filled", reference),
-                Some(v) => defs.push((def.id, v)),
+    pub fn finish(self) -> PyResult<Definitions<T>> {
+        for (reference, def) in &self.definitions.0 {
+            if def.0.get().is_none() {
+                return py_schema_err!("Definitions error: definition `{}` was never filled", reference);
             }
         }
-        defs.sort_by_key(|(id, _)| *id);
-        Ok(defs.into_iter().map(|(_, v)| v).collect())
+        Ok(self.definitions)
     }
 }

--- a/src/py_gc.rs
+++ b/src/py_gc.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ahash::AHashMap;
 use enum_dispatch::enum_dispatch;
 use pyo3::{AsPyPointer, Py, PyTraverseError, PyVisit};
@@ -32,6 +34,12 @@ impl<T: PyGcTraverse> PyGcTraverse for AHashMap<String, T> {
             item.py_gc_traverse(visit)?;
         }
         Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for Arc<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        T::py_gc_traverse(self, visit)
     }
 }
 

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -10,8 +10,6 @@ use serde::ser::Error;
 use super::config::SerializationConfig;
 use super::errors::{PydanticSerializationUnexpectedValue, UNEXPECTED_TYPE_SER_MARKER};
 use super::ob_type::ObTypeLookup;
-use super::shared::CombinedSerializer;
-use crate::definitions::Definitions;
 use crate::recursion_guard::RecursionGuard;
 
 /// this is ugly, would be much better if extra could be stored in `SerializationState`
@@ -48,7 +46,6 @@ impl SerializationState {
         Extra::new(
             py,
             mode,
-            &[],
             by_alias,
             &self.warnings,
             false,
@@ -72,7 +69,6 @@ impl SerializationState {
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct Extra<'a> {
     pub mode: &'a SerMode,
-    pub definitions: &'a Definitions<CombinedSerializer>,
     pub ob_type_lookup: &'a ObTypeLookup,
     pub warnings: &'a CollectWarnings,
     pub by_alias: bool,
@@ -98,7 +94,6 @@ impl<'a> Extra<'a> {
     pub fn new(
         py: Python<'a>,
         mode: &'a SerMode,
-        definitions: &'a Definitions<CombinedSerializer>,
         by_alias: bool,
         warnings: &'a CollectWarnings,
         exclude_unset: bool,
@@ -112,7 +107,6 @@ impl<'a> Extra<'a> {
     ) -> Self {
         Self {
             mode,
-            definitions,
             ob_type_lookup: ObTypeLookup::cached(py),
             warnings,
             by_alias,
@@ -156,7 +150,6 @@ impl SerCheck {
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct ExtraOwned {
     mode: SerMode,
-    definitions: Vec<CombinedSerializer>,
     warnings: CollectWarnings,
     by_alias: bool,
     exclude_unset: bool,
@@ -176,7 +169,6 @@ impl ExtraOwned {
     pub fn new(extra: &Extra) -> Self {
         Self {
             mode: extra.mode.clone(),
-            definitions: extra.definitions.to_vec(),
             warnings: extra.warnings.clone(),
             by_alias: extra.by_alias,
             exclude_unset: extra.exclude_unset,
@@ -196,7 +188,6 @@ impl ExtraOwned {
     pub fn to_extra<'py>(&'py self, py: Python<'py>) -> Extra<'py> {
         Extra {
             mode: &self.mode,
-            definitions: &self.definitions,
             ob_type_lookup: ObTypeLookup::cached(py),
             warnings: &self.warnings,
             by_alias: self.by_alias,

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use pyo3::{PyTraverseError, PyVisit};
 
-use crate::definitions::DefinitionsBuilder;
+use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::py_gc::PyGcTraverse;
 
 use config::SerializationConfig;
@@ -30,7 +30,7 @@ mod type_serializers;
 #[derive(Debug)]
 pub struct SchemaSerializer {
     serializer: CombinedSerializer,
-    definitions: Vec<CombinedSerializer>,
+    definitions: Definitions<CombinedSerializer>,
     expected_json_size: AtomicUsize,
     config: SerializationConfig,
 }
@@ -54,7 +54,6 @@ impl SchemaSerializer {
         Extra::new(
             py,
             mode,
-            &self.definitions,
             by_alias,
             warnings,
             exclude_unset,
@@ -184,9 +183,7 @@ impl SchemaSerializer {
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.serializer.py_gc_traverse(&visit)?;
-        for slot in &self.definitions {
-            slot.py_gc_traverse(&visit)?;
-        }
+        self.definitions.py_gc_traverse(&visit)?;
         Ok(())
     }
 }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -13,7 +13,7 @@ use serde_json::ser::PrettyFormatter;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::py_schema_error_type;
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
 use crate::tools::{py_err, SchemaDict};
 
@@ -293,7 +293,7 @@ pub(crate) trait TypeSerializer: Send + Sync + Clone + Debug {
     fn get_name(&self) -> &str;
 
     /// Used by union serializers to decide if it's worth trying again while allowing subclasses
-    fn retry_with_lax_check(&self, _definitions: &Definitions<CombinedSerializer>) -> bool {
+    fn retry_with_lax_check(&self) -> bool {
         false
     }
 

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use ahash::AHashMap;
 
 use crate::build_tools::{py_schema_error_type, ExtraBehavior};
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 
 use super::{
@@ -179,7 +179,7 @@ impl TypeSerializer for DataclassSerializer {
         &self.name
     }
 
-    fn retry_with_lax_check(&self, _definitions: &Definitions<CombinedSerializer>) -> bool {
+    fn retry_with_lax_check(&self) -> bool {
         true
     }
 }

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{py_schema_error_type, ExtraBehavior};
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::serializers::errors::PydanticSerializationUnexpectedValue;
 use crate::tools::SchemaDict;
 
@@ -228,7 +228,7 @@ impl TypeSerializer for ModelSerializer {
         &self.name
     }
 
-    fn retry_with_lax_check(&self, _definitions: &Definitions<CombinedSerializer>) -> bool {
+    fn retry_with_lax_check(&self) -> bool {
         true
     }
 }

--- a/src/serializers/type_serializers/nullable.rs
+++ b/src/serializers/type_serializers/nullable.rs
@@ -4,7 +4,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 
 use super::{infer_json_key_known, BuildSerializer, CombinedSerializer, Extra, IsType, ObType, TypeSerializer};
@@ -75,7 +75,7 @@ impl TypeSerializer for NullableSerializer {
         Self::EXPECTED_TYPE
     }
 
-    fn retry_with_lax_check(&self, definitions: &Definitions<CombinedSerializer>) -> bool {
-        self.serializer.retry_with_lax_check(definitions)
+    fn retry_with_lax_check(&self) -> bool {
+        self.serializer.retry_with_lax_check()
     }
 }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -4,7 +4,7 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 use std::borrow::Cow;
 
 use crate::build_tools::py_schema_err;
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 use crate::PydanticSerializationUnexpectedValue;
 
@@ -87,7 +87,7 @@ impl TypeSerializer for UnionSerializer {
                 },
             }
         }
-        if self.retry_with_lax_check(extra.definitions) {
+        if self.retry_with_lax_check() {
             new_extra.check = SerCheck::Lax;
             for comb_serializer in &self.choices {
                 match comb_serializer.to_python(value, include, exclude, &new_extra) {
@@ -116,7 +116,7 @@ impl TypeSerializer for UnionSerializer {
                 },
             }
         }
-        if self.retry_with_lax_check(extra.definitions) {
+        if self.retry_with_lax_check() {
             new_extra.check = SerCheck::Lax;
             for comb_serializer in &self.choices {
                 match comb_serializer.json_key(key, &new_extra) {
@@ -153,7 +153,7 @@ impl TypeSerializer for UnionSerializer {
                 },
             }
         }
-        if self.retry_with_lax_check(extra.definitions) {
+        if self.retry_with_lax_check() {
             new_extra.check = SerCheck::Lax;
             for comb_serializer in &self.choices {
                 match comb_serializer.to_python(value, include, exclude, &new_extra) {
@@ -174,10 +174,8 @@ impl TypeSerializer for UnionSerializer {
         &self.name
     }
 
-    fn retry_with_lax_check(&self, definitions: &Definitions<CombinedSerializer>) -> bool {
-        self.choices
-            .iter()
-            .any(|choice| choice.retry_with_lax_check(definitions))
+    fn retry_with_lax_check(&self) -> bool {
+        self.choices.iter().any(CombinedSerializer::retry_with_lax_check)
     }
 }
 

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -4,7 +4,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::definitions::{Definitions, DefinitionsBuilder};
+use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 use crate::validators::DefaultType;
 
@@ -67,8 +67,8 @@ impl TypeSerializer for WithDefaultSerializer {
         Self::EXPECTED_TYPE
     }
 
-    fn retry_with_lax_check(&self, definitions: &Definitions<CombinedSerializer>) -> bool {
-        self.serializer.retry_with_lax_check(definitions)
+    fn retry_with_lax_check(&self) -> bool {
+        self.serializer.retry_with_lax_check()
     }
 
     fn get_default(&self, py: Python) -> PyResult<Option<PyObject>> {

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -34,11 +34,7 @@ impl Validator for AnyValidator {
         Ok(input.to_object(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         false
     }
 
@@ -46,7 +42,7 @@ impl Validator for AnyValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -15,7 +15,7 @@ use crate::tools::SchemaDict;
 use super::validation_state::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Parameter {
     positional: bool,
     name: String,
@@ -24,7 +24,7 @@ struct Parameter {
     validator: CombinedValidator,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ArgumentsValidator {
     parameters: Vec<Parameter>,
     positional_params_count: usize,

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -332,29 +332,25 @@ impl Validator for ArgumentsValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.parameters
             .iter()
-            .any(|p| p.validator.different_strict_behavior(definitions, ultra_strict))
+            .any(|p| p.validator.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         self.parameters
-            .iter_mut()
-            .try_for_each(|parameter| parameter.validator.complete(definitions))?;
-        if let Some(v) = &mut self.var_args_validator {
-            v.complete(definitions)?;
+            .iter()
+            .try_for_each(|parameter| parameter.validator.complete())?;
+        if let Some(v) = &self.var_args_validator {
+            v.complete()?;
         }
-        if let Some(v) = &mut self.var_kwargs_validator {
-            v.complete(definitions)?;
+        if let Some(v) = &self.var_kwargs_validator {
+            v.complete()?;
         };
         Ok(())
     }

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -42,11 +42,7 @@ impl Validator for BoolValidator {
         Ok(input.validate_bool(strict)?.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -54,7 +50,7 @@ impl Validator for BoolValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -50,11 +50,7 @@ impl Validator for BytesValidator {
         Ok(either_bytes.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -62,7 +58,7 @@ impl Validator for BytesValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -112,11 +108,7 @@ impl Validator for BytesConstrainedValidator {
         Ok(either_bytes.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -124,7 +116,7 @@ impl Validator for BytesConstrainedValidator {
         "constrained-bytes"
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -11,7 +11,7 @@ use crate::tools::SchemaDict;
 use super::validation_state::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CallValidator {
     function: PyObject,
     arguments_validator: Box<CombinedValidator>,

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -98,28 +98,23 @@ impl Validator for CallValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if let Some(return_validator) = &self.return_validator {
-            if return_validator.different_strict_behavior(definitions, ultra_strict) {
+            if return_validator.different_strict_behavior(ultra_strict) {
                 return true;
             }
         }
-        self.arguments_validator
-            .different_strict_behavior(definitions, ultra_strict)
+        self.arguments_validator.different_strict_behavior(ultra_strict)
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.arguments_validator.complete(definitions)?;
-        match &mut self.return_validator {
-            Some(v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        self.arguments_validator.complete()?;
+        match &self.return_validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -36,11 +36,7 @@ impl Validator for CallableValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         false
     }
 
@@ -48,7 +44,7 @@ impl Validator for CallableValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -10,7 +10,7 @@ use crate::tools::SchemaDict;
 use super::validation_state::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ChainValidator {
     steps: Vec<CombinedValidator>,
     name: String,

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -83,21 +83,15 @@ impl Validator for ChainValidator {
         steps_iter.try_fold(value, |v, step| step.validate(py, v.into_ref(py), state))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        self.steps
-            .iter()
-            .any(|v| v.different_strict_behavior(definitions, ultra_strict))
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.steps.iter().any(|v| v.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.steps.iter_mut().try_for_each(|v| v.complete(definitions))
+    fn complete(&self) -> PyResult<()> {
+        self.steps.iter().try_for_each(CombinedValidator::complete)
     }
 }

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -57,7 +57,7 @@ impl CustomError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CustomErrorValidator {
     validator: Box<CombinedValidator>,
     custom_error: CustomError,

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -99,19 +99,15 @@ impl Validator for CustomErrorValidator {
             .map_err(|_| self.custom_error.as_val_error(input))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        self.validator.different_strict_behavior(definitions, ultra_strict)
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -426,24 +426,18 @@ impl Validator for DataclassArgsValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.fields
             .iter()
-            .any(|f| f.validator.different_strict_behavior(definitions, ultra_strict))
+            .any(|f| f.validator.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         &self.validator_name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.fields
-            .iter_mut()
-            .try_for_each(|field| field.validator.complete(definitions))
+    fn complete(&self) -> PyResult<()> {
+        self.fields.iter().try_for_each(|field| field.validator.complete())
     }
 }
 
@@ -588,13 +582,9 @@ impl Validator for DataclassValidator {
         Ok(obj.to_object(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(definitions, ultra_strict)
+            self.validator.different_strict_behavior(ultra_strict)
         } else {
             true
         }
@@ -604,8 +594,8 @@ impl Validator for DataclassValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }
 

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -19,7 +19,7 @@ use super::{
     build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Field {
     kw_only: bool,
     name: String,
@@ -30,7 +30,7 @@ struct Field {
     frozen: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DataclassArgsValidator {
     fields: Vec<Field>,
     positional_count: usize,
@@ -441,7 +441,7 @@ impl Validator for DataclassArgsValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DataclassValidator {
     strict: bool,
     validator: Box<CombinedValidator>,

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -96,11 +96,7 @@ impl Validator for DateValidator {
         Ok(date.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -108,7 +104,7 @@ impl Validator for DateValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -125,11 +125,7 @@ impl Validator for DateTimeValidator {
         Ok(datetime.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -137,7 +133,7 @@ impl Validator for DateTimeValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -230,11 +230,7 @@ impl Validator for DecimalValidator {
         Ok(decimal.into())
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         true
     }
 
@@ -242,7 +238,7 @@ impl Validator for DecimalValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -1,7 +1,12 @@
+use std::cell::RefCell;
+
+use ahash::HashSet;
+use ahash::HashSetExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
+use crate::definitions::DefinitionRef;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
@@ -39,17 +44,12 @@ impl BuildValidator for DefinitionsValidatorBuilder {
 
 #[derive(Debug, Clone)]
 pub struct DefinitionRefValidator {
-    validator_id: usize,
-    inner_name: String,
-    // we have to record the answers to `Question`s as we can't access the validator when `ask()` is called
+    definition: DefinitionRef<CombinedValidator>,
 }
 
 impl DefinitionRefValidator {
-    pub fn new(validator_id: usize) -> Self {
-        Self {
-            validator_id,
-            inner_name: "...".to_string(),
-        }
+    pub fn new(definition: DefinitionRef<CombinedValidator>) -> Self {
+        Self { definition }
     }
 }
 
@@ -61,15 +61,11 @@ impl BuildValidator for DefinitionRefValidator {
         _config: Option<&PyDict>,
         definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
-        let schema_ref: String = schema.get_as_req(intern!(schema.py(), "schema_ref"))?;
+        let schema_ref = schema.get_as_req(intern!(schema.py(), "schema_ref"))?;
 
-        let validator_id = definitions.get_reference_id(&schema_ref);
+        let definition = definitions.get_definition(schema_ref);
 
-        Ok(Self {
-            validator_id,
-            inner_name: "...".to_string(),
-        }
-        .into())
+        Ok(Self { definition }.into())
     }
 }
 
@@ -82,21 +78,22 @@ impl Validator for DefinitionRefValidator {
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
+        let validator = self.definition.get().unwrap();
         if let Some(id) = input.identity() {
-            if state.recursion_guard.contains_or_insert(id, self.validator_id) {
+            if state.recursion_guard.contains_or_insert(id, self.definition.id()) {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
                 Err(ValError::new(ErrorTypeDefaults::RecursionLoop, input))
             } else {
                 if state.recursion_guard.incr_depth() {
                     return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, input));
                 }
-                let output = validate(self.validator_id, py, input, state);
-                state.recursion_guard.remove(id, self.validator_id);
+                let output = validator.validate(py, input, state);
+                state.recursion_guard.remove(id, self.definition.id());
                 state.recursion_guard.decr_depth();
                 output
             }
         } else {
-            validate(self.validator_id, py, input, state)
+            validator.validate(py, input, state)
         }
     }
 
@@ -108,69 +105,48 @@ impl Validator for DefinitionRefValidator {
         field_value: &'data PyAny,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
+        let validator = self.definition.get().unwrap();
         if let Some(id) = obj.identity() {
-            if state.recursion_guard.contains_or_insert(id, self.validator_id) {
+            if state.recursion_guard.contains_or_insert(id, self.definition.id()) {
                 // we don't remove id here, we leave that to the validator which originally added id to `recursion_guard`
                 Err(ValError::new(ErrorTypeDefaults::RecursionLoop, obj))
             } else {
                 if state.recursion_guard.incr_depth() {
                     return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, obj));
                 }
-                let output = validate_assignment(self.validator_id, py, obj, field_name, field_value, state);
-                state.recursion_guard.remove(id, self.validator_id);
+                let output = validator.validate_assignment(py, obj, field_name, field_value, state);
+                state.recursion_guard.remove(id, self.definition.id());
                 state.recursion_guard.decr_depth();
                 output
             }
         } else {
-            validate_assignment(self.validator_id, py, obj, field_name, field_value, state)
+            validator.validate_assignment(py, obj, field_name, field_value, state)
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        if let Some(definitions) = definitions {
-            // have to unwrap here, because we can't return an error from this function, should be okay
-            let validator = definitions.get_definition(self.validator_id).unwrap();
-            validator.different_strict_behavior(None, ultra_strict)
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        thread_local! {
+            static RECURSION_SET: RefCell<Option<HashSet<usize>>> = RefCell::new(None);
+        }
+
+        let id = self as *const _ as usize;
+        // have to unwrap here, because we can't return an error from this function, should be okay
+        let validator = self.definition.get().unwrap();
+        if RECURSION_SET.with(|set| set.borrow_mut().get_or_insert_with(HashSet::new).insert(id)) {
+            let different_strict_behavior = validator.different_strict_behavior(ultra_strict);
+            RECURSION_SET.with(|set| set.borrow_mut().get_or_insert_with(HashSet::new).remove(&id));
+            different_strict_behavior
         } else {
             false
         }
     }
 
     fn get_name(&self) -> &str {
-        &self.inner_name
+        self.definition.get().map_or("...", |validator| validator.get_name())
     }
 
     /// don't need to call complete on the inner validator here, complete_validators takes care of that.
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        let validator = definitions.get_definition(self.validator_id)?;
-        self.inner_name = validator.get_name().to_string();
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
-}
-
-fn validate<'data>(
-    validator_id: usize,
-    py: Python<'data>,
-    input: &'data impl Input<'data>,
-    state: &mut ValidationState,
-) -> ValResult<'data, PyObject> {
-    let validator = state.definitions.get(validator_id).unwrap();
-    validator.validate(py, input, state)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn validate_assignment<'data>(
-    validator_id: usize,
-    py: Python<'data>,
-    obj: &'data PyAny,
-    field_name: &'data str,
-    field_value: &'data PyAny,
-    state: &mut ValidationState,
-) -> ValResult<'data, PyObject> {
-    let validator = state.definitions.get(validator_id).unwrap();
-    validator.validate_assignment(py, obj, field_name, field_value, state)
 }

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -92,14 +92,9 @@ impl Validator for DictValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.key_validator.different_strict_behavior(definitions, true)
-                || self.value_validator.different_strict_behavior(definitions, true)
+            self.key_validator.different_strict_behavior(true) || self.value_validator.different_strict_behavior(true)
         } else {
             true
         }
@@ -109,9 +104,9 @@ impl Validator for DictValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.key_validator.complete(definitions)?;
-        self.value_validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.key_validator.complete()?;
+        self.value_validator.complete()
     }
 }
 

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -16,7 +16,7 @@ use super::any::AnyValidator;
 use super::list::length_check;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DictValidator {
     strict: bool,
     key_validator: Box<CombinedValidator>,

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -76,11 +76,7 @@ impl Validator for FloatValidator {
         Ok(either_float.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         true
     }
 
@@ -88,7 +84,7 @@ impl Validator for FloatValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -179,11 +175,7 @@ impl Validator for ConstrainedFloatValidator {
         Ok(either_float.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         true
     }
 
@@ -191,7 +183,7 @@ impl Validator for ConstrainedFloatValidator {
         "constrained-float"
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -48,13 +48,9 @@ impl Validator for FrozenSetValidator {
         Ok(f_set.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.item_validator.different_strict_behavior(definitions, true)
+            self.item_validator.different_strict_behavior(true)
         } else {
             true
         }
@@ -64,7 +60,7 @@ impl Validator for FrozenSetValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.item_validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.item_validator.complete()
     }
 }

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -10,7 +10,7 @@ use super::set::set_build;
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FrozenSetValidator {
     strict: bool,
     item_validator: Box<CombinedValidator>,

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -111,14 +111,9 @@ macro_rules! impl_validator {
                 self._validate(validate, py, obj, state)
             }
 
-            fn different_strict_behavior(
-                &self,
-                definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-                ultra_strict: bool,
-            ) -> bool {
+            fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
                 if ultra_strict {
-                    self.validator
-                        .different_strict_behavior(definitions, ultra_strict)
+                    self.validator.different_strict_behavior(ultra_strict)
                 } else {
                     true
                 }
@@ -128,8 +123,8 @@ macro_rules! impl_validator {
                 &self.name
             }
 
-            fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-                self.validator.complete(definitions)
+            fn complete(&self) -> PyResult<()> {
+                self.validator.complete()
             }
         }
     };
@@ -255,11 +250,7 @@ impl Validator for FunctionPlainValidator {
         r.map_err(|e| convert_err(py, e, input))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         // best guess, should we change this?
         !ultra_strict
     }
@@ -268,7 +259,7 @@ impl Validator for FunctionPlainValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -387,13 +378,9 @@ impl Validator for FunctionWrapValidator {
         self._validate(Py::new(py, handler)?.into_ref(py), py, obj, state)
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(definitions, ultra_strict)
+            self.validator.different_strict_behavior(ultra_strict)
         } else {
             true
         }
@@ -403,8 +390,8 @@ impl Validator for FunctionWrapValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }
 

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -54,11 +54,7 @@ impl Validator for IntValidator {
         Ok(either_int.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -66,7 +62,7 @@ impl Validator for IntValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -151,11 +147,7 @@ impl Validator for ConstrainedIntValidator {
         Ok(either_int.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -163,7 +155,7 @@ impl Validator for ConstrainedIntValidator {
         "constrained-int"
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -83,11 +83,7 @@ impl Validator for IsInstanceValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         false
     }
 
@@ -95,7 +91,7 @@ impl Validator for IsInstanceValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -62,11 +62,7 @@ impl Validator for IsSubclassValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         false
     }
 
@@ -74,7 +70,7 @@ impl Validator for IsSubclassValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -9,7 +9,7 @@ use crate::tools::SchemaDict;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct JsonValidator {
     validator: Option<Box<CombinedValidator>>,
     name: String,

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -61,13 +61,9 @@ impl Validator for JsonValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if let Some(ref v) = self.validator {
-            v.different_strict_behavior(definitions, ultra_strict)
+            v.different_strict_behavior(ultra_strict)
         } else {
             false
         }
@@ -77,9 +73,9 @@ impl Validator for JsonValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        match self.validator {
-            Some(ref mut v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        match &self.validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -63,21 +63,16 @@ impl Validator for JsonOrPython {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        self.json.different_strict_behavior(definitions, ultra_strict)
-            || self.python.different_strict_behavior(definitions, ultra_strict)
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.json.different_strict_behavior(ultra_strict) || self.python.different_strict_behavior(ultra_strict)
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.json.complete(definitions)?;
-        self.python.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.json.complete()?;
+        self.python.complete()
     }
 }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -11,7 +11,7 @@ use super::InputType;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct JsonOrPython {
     json: Box<CombinedValidator>,
     python: Box<CombinedValidator>,

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -10,7 +10,7 @@ use crate::tools::SchemaDict;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LaxOrStrictValidator {
     strict: bool,
     lax_validator: Box<CombinedValidator>,

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -68,13 +68,9 @@ impl Validator for LaxOrStrictValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.strict_validator.different_strict_behavior(definitions, true)
+            self.strict_validator.different_strict_behavior(true)
         } else {
             true
         }
@@ -84,8 +80,8 @@ impl Validator for LaxOrStrictValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.lax_validator.complete(definitions)?;
-        self.strict_validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.lax_validator.complete()?;
+        self.strict_validator.complete()
     }
 }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -13,7 +15,7 @@ pub struct ListValidator {
     item_validator: Option<Box<CombinedValidator>>,
     min_length: Option<usize>,
     max_length: Option<usize>,
-    name: String,
+    name: OnceLock<String>,
 }
 
 pub fn get_items_schema(
@@ -99,14 +101,12 @@ impl BuildValidator for ListValidator {
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
         let item_validator = get_items_schema(schema, config, definitions)?;
-        let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
-        let name = format!("{}[{inner_name}]", Self::EXPECTED_TYPE);
         Ok(Self {
             strict: crate::build_tools::is_strict(schema, config)?,
             item_validator,
             min_length: schema.get_as(pyo3::intern!(py, "min_length"))?,
             max_length: schema.get_as(pyo3::intern!(py, "max_length"))?,
-            name,
+            name: OnceLock::new(),
         }
         .into())
     }
@@ -138,14 +138,10 @@ impl Validator for ListValidator {
         Ok(output.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(definitions, true),
+                Some(ref v) => v.different_strict_behavior(true),
                 None => false,
             }
         } else {
@@ -154,14 +150,14 @@ impl Validator for ListValidator {
     }
 
     fn get_name(&self) -> &str {
-        &self.name
+        self.name.get().map_or("list[...]", String::as_str)
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        if let Some(ref mut v) = self.item_validator {
-            v.complete(definitions)?;
+    fn complete(&self) -> PyResult<()> {
+        if let Some(v) = &self.item_validator {
+            v.complete()?;
             let inner_name = v.get_name();
-            self.name = format!("{}[{inner_name}]", Self::EXPECTED_TYPE);
+            let _ = self.name.set(format!("{}[{inner_name}]", Self::EXPECTED_TYPE));
         }
         Ok(())
     }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -198,11 +198,7 @@ impl Validator for LiteralValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -210,7 +206,7 @@ impl Validator for LiteralValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -22,7 +22,7 @@ struct BoolLiteral {
 }
 
 #[derive(Debug, Clone)]
-pub struct LiteralLookup<T: Clone + Debug> {
+pub struct LiteralLookup<T: Debug> {
     // Specialized lookups for ints, bools and strings because they
     // (1) are easy to convert between Rust and Python
     // (2) hashing them in Rust is very fast
@@ -35,7 +35,7 @@ pub struct LiteralLookup<T: Clone + Debug> {
     pub values: Vec<T>,
 }
 
-impl<T: Clone + Debug> LiteralLookup<T> {
+impl<T: Debug> LiteralLookup<T> {
     pub fn new<'py>(py: Python<'py>, expected: impl Iterator<Item = (&'py PyAny, T)>) -> PyResult<Self> {
         let mut expected_int = AHashMap::new();
         let mut expected_str: AHashMap<String, usize> = AHashMap::new();
@@ -135,7 +135,7 @@ impl<T: Clone + Debug> LiteralLookup<T> {
     }
 }
 
-impl<T: PyGcTraverse + Clone + Debug> PyGcTraverse for LiteralLookup<T> {
+impl<T: PyGcTraverse + Debug> PyGcTraverse for LiteralLookup<T> {
     fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.expected_py.py_gc_traverse(visit)?;
         self.values.py_gc_traverse(visit)?;

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -98,7 +98,7 @@ impl PySome {
 }
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SchemaValidator {
     validator: CombinedValidator,
     definitions: Definitions<CombinedValidator>,
@@ -141,9 +141,10 @@ impl SchemaValidator {
         })
     }
 
-    pub fn __reduce__(&self, py: Python) -> PyResult<PyObject> {
-        let args = (self.schema.as_ref(py),);
-        let cls = Py::new(py, self.clone())?.getattr(py, "__class__")?;
+    pub fn __reduce__(slf: &PyCell<Self>) -> PyResult<PyObject> {
+        let py = slf.py();
+        let args = (slf.try_borrow()?.schema.to_object(py),);
+        let cls = slf.getattr("__class__")?;
         Ok((cls, args).into_py(py))
     }
 
@@ -598,7 +599,7 @@ impl<'a> Extra<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[enum_dispatch(PyGcTraverse)]
 pub enum CombinedValidator {
     // typed dict e.g. heterogeneous dicts or simply a model
@@ -694,7 +695,7 @@ pub enum CombinedValidator {
 /// This trait must be implemented by all validators, it allows various validators to be accessed consistently,
 /// validators defined in `build_validator` also need `EXPECTED_TYPE` as a const, but that can't be part of the trait
 #[enum_dispatch(CombinedValidator)]
-pub trait Validator: Send + Sync + Clone + Debug {
+pub trait Validator: Send + Sync + Debug {
     /// Do the actual validation for this schema/type
     fn validate<'data>(
         &self,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -116,8 +116,8 @@ impl SchemaValidator {
         let mut definitions_builder = DefinitionsBuilder::new();
 
         let validator = build_validator(schema, config, &mut definitions_builder)?;
-        validator.complete()?;
         let definitions = definitions_builder.finish()?;
+        validator.complete()?;
         for val in definitions.values() {
             val.get().unwrap().complete()?;
         }
@@ -387,8 +387,8 @@ impl<'py> SelfValidator<'py> {
             Ok(v) => v,
             Err(err) => return py_schema_err!("Error building self-schema:\n  {}", err),
         };
-        validator.complete()?;
         let definitions = definitions_builder.finish()?;
+        validator.complete()?;
         for val in definitions.values() {
             val.get().unwrap().complete()?;
         }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -50,7 +50,7 @@ impl Revalidate {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ModelValidator {
     revalidate: Revalidate,
     validator: Box<CombinedValidator>,

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -206,13 +206,9 @@ impl Validator for ModelValidator {
         Ok(model.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.validator.different_strict_behavior(definitions, ultra_strict)
+            self.validator.different_strict_behavior(ultra_strict)
         } else {
             true
         }
@@ -222,8 +218,8 @@ impl Validator for ModelValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }
 

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -415,26 +415,20 @@ impl Validator for ModelFieldsValidator {
         Ok((new_data.to_object(py), new_extra, fields_set.to_object(py)).to_object(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.fields
             .iter()
-            .any(|f| f.validator.different_strict_behavior(definitions, ultra_strict))
+            .any(|f| f.validator.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.fields
-            .iter_mut()
-            .try_for_each(|f| f.validator.complete(definitions))?;
-        match &mut self.extras_validator {
-            Some(v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        self.fields.iter().try_for_each(|f| f.validator.complete())?;
+        match &self.extras_validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -20,7 +20,7 @@ use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuild
 
 use std::ops::ControlFlow;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Field {
     name: String,
     lookup_key: LookupKey,
@@ -31,7 +31,7 @@ struct Field {
 
 impl_py_gc_traverse!(Field { validator });
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ModelFieldsValidator {
     fields: Vec<Field>,
     model_name: String,

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -36,11 +36,7 @@ impl Validator for NoneValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        _ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, _ultra_strict: bool) -> bool {
         false
     }
 
@@ -48,7 +44,7 @@ impl Validator for NoneValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -9,7 +9,7 @@ use crate::tools::SchemaDict;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NullableValidator {
     validator: Box<CombinedValidator>,
     name: String,

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -45,19 +45,15 @@ impl Validator for NullableValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        self.validator.different_strict_behavior(definitions, ultra_strict)
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -8,7 +8,7 @@ use crate::tools::SchemaDict;
 use super::list::min_length_check;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SetValidator {
     strict: bool,
     item_validator: Box<CombinedValidator>,

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -70,13 +70,9 @@ impl Validator for SetValidator {
         Ok(set.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            self.item_validator.different_strict_behavior(definitions, true)
+            self.item_validator.different_strict_behavior(true)
         } else {
             true
         }
@@ -86,7 +82,7 @@ impl Validator for SetValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.item_validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.item_validator.complete()
     }
 }

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -51,11 +51,7 @@ impl Validator for StrValidator {
         Ok(either_str.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -63,7 +59,7 @@ impl Validator for StrValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -150,11 +146,7 @@ impl Validator for StrConstrainedValidator {
         Ok(py_string.into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -162,7 +154,7 @@ impl Validator for StrConstrainedValidator {
         "constrained-str"
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -10,7 +10,7 @@ use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StrValidator {
     strict: bool,
     coerce_numbers_to_str: bool,

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -78,11 +78,7 @@ impl Validator for TimeValidator {
         Ok(time.try_into_py(py)?)
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -90,7 +86,7 @@ impl Validator for TimeValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -101,11 +101,7 @@ impl Validator for TimeDeltaValidator {
         Ok(py_timedelta.into())
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -113,7 +109,7 @@ impl Validator for TimeDeltaValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -10,7 +10,7 @@ use crate::tools::SchemaDict;
 use super::list::{get_items_schema, min_length_check};
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TupleVariableValidator {
     strict: bool,
     item_validator: Option<Box<CombinedValidator>>,
@@ -27,7 +27,7 @@ impl BuildValidator for TupleVariableValidator {
         definitions: &mut DefinitionsBuilder<CombinedValidator>,
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        let item_validator = get_items_schema(schema, config, definitions)?;
+        let item_validator = get_items_schema(schema, config, definitions)?.map(Box::new);
         let inner_name = item_validator.as_ref().map_or("any", |v| v.get_name());
         let name = format!("tuple[{inner_name}, ...]");
         Ok(Self {
@@ -83,7 +83,7 @@ impl Validator for TupleVariableValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TuplePositionalValidator {
     strict: bool,
     items_validators: Vec<CombinedValidator>,

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -60,14 +60,10 @@ impl Validator for TupleVariableValidator {
         Ok(PyTuple::new(py, &output).into_py(py))
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
             match self.item_validator {
-                Some(ref v) => v.different_strict_behavior(definitions, true),
+                Some(ref v) => v.different_strict_behavior(true),
                 None => false,
             }
         } else {
@@ -79,9 +75,9 @@ impl Validator for TupleVariableValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        match self.item_validator {
-            Some(ref mut v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        match &self.item_validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }
@@ -242,20 +238,12 @@ impl Validator for TuplePositionalValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         if ultra_strict {
-            if self
-                .items_validators
-                .iter()
-                .any(|v| v.different_strict_behavior(definitions, true))
-            {
+            if self.items_validators.iter().any(|v| v.different_strict_behavior(true)) {
                 true
             } else if let Some(ref v) = self.extras_validator {
-                v.different_strict_behavior(definitions, true)
+                v.different_strict_behavior(true)
             } else {
                 false
             }
@@ -268,12 +256,10 @@ impl Validator for TuplePositionalValidator {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.items_validators
-            .iter_mut()
-            .try_for_each(|v| v.complete(definitions))?;
-        match &mut self.extras_validator {
-            Some(v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        self.items_validators.iter().try_for_each(CombinedValidator::complete)?;
+        match &self.extras_validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -307,26 +307,20 @@ impl Validator for TypedDictValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.fields
             .iter()
-            .any(|f| f.validator.different_strict_behavior(definitions, ultra_strict))
+            .any(|f| f.validator.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.fields
-            .iter_mut()
-            .try_for_each(|f| f.validator.complete(definitions))?;
-        match &mut self.extras_validator {
-            Some(v) => v.complete(definitions),
+    fn complete(&self) -> PyResult<()> {
+        self.fields.iter().try_for_each(|f| f.validator.complete())?;
+        match &self.extras_validator {
+            Some(v) => v.complete(),
             None => Ok(()),
         }
     }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -20,7 +20,7 @@ use super::{
     build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct TypedDictField {
     name: String,
     lookup_key: LookupKey,
@@ -31,7 +31,7 @@ struct TypedDictField {
 
 impl_py_gc_traverse!(TypedDictField { validator });
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TypedDictValidator {
     fields: Vec<TypedDictField>,
     extra_behavior: ExtraBehavior,

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -65,7 +65,7 @@ impl FromStr for UnionMode {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UnionValidator {
     mode: UnionMode,
     choices: Vec<(CombinedValidator, Option<String>)>,
@@ -375,7 +375,7 @@ impl PyGcTraverse for Discriminator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TaggedUnionValidator {
     discriminator: Discriminator,
     lookup: LiteralLookup<CombinedValidator>,

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyTuple};
@@ -18,11 +19,11 @@ use super::custom_error::CustomError;
 use super::literal::LiteralLookup;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 enum UnionMode {
     Smart {
-        strict_required: bool,
-        ultra_strict_required: bool,
+        strict_required: AtomicBool,
+        ultra_strict_required: AtomicBool,
     },
     LeftToRight,
 }
@@ -31,8 +32,23 @@ impl UnionMode {
     // construct smart with some default values
     const fn default_smart() -> Self {
         Self::Smart {
-            strict_required: true,
-            ultra_strict_required: false,
+            strict_required: AtomicBool::new(true),
+            ultra_strict_required: AtomicBool::new(false),
+        }
+    }
+}
+
+impl Clone for UnionMode {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Smart {
+                strict_required,
+                ultra_strict_required,
+            } => Self::Smart {
+                strict_required: AtomicBool::new(strict_required.load(Ordering::SeqCst)),
+                ultra_strict_required: AtomicBool::new(ultra_strict_required.load(Ordering::SeqCst)),
+            },
+            Self::LeftToRight => Self::LeftToRight,
         }
     }
 }
@@ -216,44 +232,46 @@ impl Validator for UnionValidator {
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        match self.mode {
+        match &self.mode {
             UnionMode::Smart {
                 strict_required,
                 ultra_strict_required,
-            } => self.validate_smart(py, input, state, strict_required, ultra_strict_required),
+            } => self.validate_smart(
+                py,
+                input,
+                state,
+                strict_required.load(Ordering::SeqCst),
+                ultra_strict_required.load(Ordering::SeqCst),
+            ),
             UnionMode::LeftToRight => self.validate_left_to_right(py, input, state),
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.choices
             .iter()
-            .any(|(v, _)| v.different_strict_behavior(definitions, ultra_strict))
+            .any(|(v, _)| v.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.choices.iter_mut().try_for_each(|(v, _)| v.complete(definitions))?;
+    fn complete(&self) -> PyResult<()> {
+        self.choices.iter().try_for_each(|(v, _)| v.complete())?;
         if let UnionMode::Smart {
-            ref mut strict_required,
-            ref mut ultra_strict_required,
-        } = self.mode
+            strict_required,
+            ultra_strict_required,
+        } = &self.mode
         {
-            *strict_required = self
-                .choices
-                .iter()
-                .any(|(v, _)| v.different_strict_behavior(Some(definitions), false));
-            *ultra_strict_required = self
-                .choices
-                .iter()
-                .any(|(v, _)| v.different_strict_behavior(Some(definitions), true));
+            strict_required.store(
+                self.choices.iter().any(|(v, _)| v.different_strict_behavior(false)),
+                Ordering::SeqCst,
+            );
+            ultra_strict_required.store(
+                self.choices.iter().any(|(v, _)| v.different_strict_behavior(true)),
+                Ordering::SeqCst,
+            );
         }
 
         Ok(())
@@ -476,26 +494,19 @@ impl Validator for TaggedUnionValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.lookup
             .values
             .iter()
-            .any(|v| v.different_strict_behavior(definitions, ultra_strict))
+            .any(|v| v.different_strict_behavior(ultra_strict))
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.lookup
-            .values
-            .iter_mut()
-            .try_for_each(|validator| validator.complete(definitions))
+    fn complete(&self) -> PyResult<()> {
+        self.lookup.values.iter().try_for_each(CombinedValidator::complete)
     }
 }
 

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -92,11 +92,7 @@ impl Validator for UrlValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -104,7 +100,7 @@ impl Validator for UrlValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }
@@ -232,11 +228,7 @@ impl Validator for MultiHostUrlValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -244,7 +236,7 @@ impl Validator for MultiHostUrlValidator {
         &self.name
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -122,11 +122,7 @@ impl Validator for UuidValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        _definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         !ultra_strict
     }
 
@@ -134,7 +130,7 @@ impl Validator for UuidValidator {
         Self::EXPECTED_TYPE
     }
 
-    fn complete(&mut self, _definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
+    fn complete(&self) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/validators/validation_state.rs
+++ b/src/validators/validation_state.rs
@@ -1,25 +1,16 @@
-use crate::{definitions::Definitions, recursion_guard::RecursionGuard};
+use crate::recursion_guard::RecursionGuard;
 
-use super::{CombinedValidator, Extra};
+use super::Extra;
 
 pub struct ValidationState<'a> {
     pub recursion_guard: &'a mut RecursionGuard,
-    pub definitions: &'a Definitions<CombinedValidator>,
     // deliberately make Extra readonly
     extra: Extra<'a>,
 }
 
 impl<'a> ValidationState<'a> {
-    pub fn new(
-        extra: Extra<'a>,
-        definitions: &'a Definitions<CombinedValidator>,
-        recursion_guard: &'a mut RecursionGuard,
-    ) -> Self {
-        Self {
-            recursion_guard,
-            definitions,
-            extra,
-        }
+    pub fn new(extra: Extra<'a>, recursion_guard: &'a mut RecursionGuard) -> Self {
+        Self { recursion_guard, extra }
     }
 
     pub fn with_new_extra<'r, R: 'r>(
@@ -31,7 +22,6 @@ impl<'a> ValidationState<'a> {
         // but lifetimes get in a tangle. Maybe someone brave wants to have a go at unpicking lifetimes.
         let mut new_state = ValidationState {
             recursion_guard: self.recursion_guard,
-            definitions: self.definitions,
             extra,
         };
         f(&mut new_state)

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -66,7 +66,7 @@ enum OnError {
     Default,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WithDefaultValidator {
     default: DefaultType,
     on_error: OnError,

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -182,20 +182,16 @@ impl Validator for WithDefaultValidator {
         }
     }
 
-    fn different_strict_behavior(
-        &self,
-        definitions: Option<&DefinitionsBuilder<CombinedValidator>>,
-        ultra_strict: bool,
-    ) -> bool {
-        self.validator.different_strict_behavior(definitions, ultra_strict)
+    fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
+        self.validator.different_strict_behavior(ultra_strict)
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn complete(&mut self, definitions: &DefinitionsBuilder<CombinedValidator>) -> PyResult<()> {
-        self.validator.complete(definitions)
+    fn complete(&self) -> PyResult<()> {
+        self.validator.complete()
     }
 }
 

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -1,3 +1,4 @@
+import datetime
 import platform
 from dataclasses import dataclass
 from typing import List, Optional
@@ -243,7 +244,7 @@ def test_model_class():
 
 
 def test_invalid_schema():
-    with pytest.raises(SchemaError, match='Definitions error: attempted to use `Branch` before it was filled'):
+    with pytest.raises(SchemaError, match='Definitions error: definition `Branch` was never filled'):
         SchemaValidator(
             {
                 'type': 'list',
@@ -986,4 +987,101 @@ def test_cyclic_data_threeway() -> None:
             'msg': 'Recursion error - cyclic reference detected',
             'input': cyclic_data,
         }
+    ]
+
+
+def test_complex_recursive_type() -> None:
+    schema = core_schema.definitions_schema(
+        core_schema.definition_reference_schema('JsonType'),
+        [
+            core_schema.nullable_schema(
+                core_schema.union_schema(
+                    [
+                        core_schema.list_schema(core_schema.definition_reference_schema('JsonType')),
+                        core_schema.dict_schema(
+                            core_schema.str_schema(), core_schema.definition_reference_schema('JsonType')
+                        ),
+                        core_schema.str_schema(),
+                        core_schema.int_schema(),
+                        core_schema.float_schema(),
+                        core_schema.bool_schema(),
+                    ]
+                ),
+                ref='JsonType',
+            )
+        ],
+    )
+
+    validator = SchemaValidator(schema)
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({'a': datetime.date(year=1992, month=12, day=11)})
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'list_type',
+            'loc': ('list[nullable[union[list[...],dict[str,...],str,int,float,bool]]]',),
+            'msg': 'Input should be a valid list',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
+        {
+            'type': 'list_type',
+            'loc': ('dict[str,...]', 'a', 'list[nullable[union[list[...],dict[str,...],str,int,float,bool]]]'),
+            'msg': 'Input should be a valid list',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'dict_type',
+            'loc': ('dict[str,...]', 'a', 'dict[str,...]'),
+            'msg': 'Input should be a valid dictionary',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'string_type',
+            'loc': ('dict[str,...]', 'a', 'str'),
+            'msg': 'Input should be a valid string',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'int_type',
+            'loc': ('dict[str,...]', 'a', 'int'),
+            'msg': 'Input should be a valid integer',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'float_type',
+            'loc': ('dict[str,...]', 'a', 'float'),
+            'msg': 'Input should be a valid number',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'bool_type',
+            'loc': ('dict[str,...]', 'a', 'bool'),
+            'msg': 'Input should be a valid boolean',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
+            'type': 'string_type',
+            'loc': ('str',),
+            'msg': 'Input should be a valid string',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
+        {
+            'type': 'int_type',
+            'loc': ('int',),
+            'msg': 'Input should be a valid integer',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
+        {
+            'type': 'float_type',
+            'loc': ('float',),
+            'msg': 'Input should be a valid number',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
+        {
+            'type': 'bool_type',
+            'loc': ('bool',),
+            'msg': 'Input should be a valid boolean',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
     ]


### PR DESCRIPTION
## Change Summary

This PR reworks the way definitions work so that instead of storing them in a global `Vec` they are shared inside `Arc`s with a `OnceLock` internally meaning that there is one opportunity to build them.

The hope is that this transformation may pave the way for reusing `SchemaValidator` inside core schema as a compiled subgraph to reduce memory consumption and simplify the defs transformations needed in `pydantic`.

## Related issue number

Related to https://github.com/pydantic/pydantic/issues/7617

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin