### PR TITLE
Fix type-checking when using deprecated `FieldValidationInfo`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3909,6 +3909,9 @@ _deprecated_import_lookup = {
     'FieldWrapValidatorFunction': WithInfoWrapValidatorFunction,
 }
 
+if TYPE_CHECKING:
+    FieldValidationInfo = ValidationInfo
+
 
 def __getattr__(attr_name: str) -> object:
     new_attr = _deprecated_import_lookup.get(attr_name)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -23,6 +23,10 @@ def foo(bar: str) -> None:
     ...
 
 
+def validator_deprecated(value: Any, info: core_schema.FieldValidationInfo) -> None:
+    ...
+
+
 def validator(value: Any, info: core_schema.ValidationInfo) -> None:
     ...
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

I've restored type-checking for downstream projects that still use the deprecated `core_schema.FieldValidationInfo` class for type hints as suggested by @dmontagu in https://github.com/pydantic/pydantic-core/issues/994#issuecomment-1739191280.

## Related issue number

Fixes #994.

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
