### PR TITLE
Simplify recursion guards to only use depth

### DIFF
--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -23,7 +23,7 @@ use serde::{ser::Error, Serialize, Serializer};
 
 use crate::errors::{py_err_string, ErrorType, ErrorTypeDefaults, InputValue, ValError, ValLineError, ValResult};
 use crate::tools::py_err;
-use crate::validators::{CombinedValidator, ValidationState, Validator};
+use crate::validators::{OuterValidator, ValidationState, Validator};
 
 use super::input_string::StringMapping;
 use super::parse_json::{JsonArray, JsonInput, JsonObject};
@@ -158,7 +158,7 @@ fn validate_iter_to_vec<'a, 's>(
     iter: impl Iterator<Item = PyResult<&'a (impl Input<'a> + 'a)>>,
     capacity: usize,
     mut max_length_check: MaxLengthCheck<'a, impl Input<'a>>,
-    validator: &'s CombinedValidator,
+    validator: &'s OuterValidator,
     state: &mut ValidationState,
 ) -> ValResult<'a, Vec<PyObject>> {
     let mut output: Vec<PyObject> = Vec::with_capacity(capacity);
@@ -224,7 +224,7 @@ fn validate_iter_to_set<'a, 's>(
     input: &'a (impl Input<'a> + 'a),
     field_type: &'static str,
     max_length: Option<usize>,
-    validator: &'s CombinedValidator,
+    validator: &'s OuterValidator,
     state: &mut ValidationState,
 ) -> ValResult<'a, ()> {
     let mut errors: Vec<ValLineError> = Vec::new();
@@ -313,7 +313,7 @@ impl<'a> GenericIterable<'a> {
         input: &'a impl Input<'a>,
         max_length: Option<usize>,
         field_type: &'static str,
-        validator: &'s CombinedValidator,
+        validator: &'s OuterValidator,
         state: &mut ValidationState,
     ) -> ValResult<'a, Vec<PyObject>> {
         let actual_length = self.generic_len();
@@ -346,7 +346,7 @@ impl<'a> GenericIterable<'a> {
         input: &'a impl Input<'a>,
         max_length: Option<usize>,
         field_type: &'static str,
-        validator: &'s CombinedValidator,
+        validator: &'s OuterValidator,
         state: &mut ValidationState,
     ) -> ValResult<'a, ()> {
         macro_rules! validate_set {

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -72,10 +72,10 @@ impl RecursionGuard {
 #[cfg(not(debug_assertions))]
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    75
+    50
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    200
+    100
 } else {
     2_000
 };
@@ -83,10 +83,10 @@ pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm",
 #[cfg(debug_assertions)]
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    50
+    25
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    100
+    75
 } else {
     1_500
 };

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -71,12 +71,12 @@ impl RecursionGuard {
 // A hard limit to avoid stack overflows when rampant recursion occurs
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    250
+    350
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    500
+    750
 } else {
-    1_000
+    1_250
 };
 
 pub trait RecursionState {

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -71,10 +71,10 @@ impl RecursionGuard {
 // A hard limit to avoid stack overflows when rampant recursion occurs
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    150
+    100
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    350
+    200
 } else {
     1_500
 };

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -71,10 +71,10 @@ impl RecursionGuard {
 // A hard limit to avoid stack overflows when rampant recursion occurs
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    350
+    150
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    750
+    350
 } else {
     1_500
 };

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -76,7 +76,7 @@ pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm",
     // PyPy and Windows in general have more restricted stack space
     750
 } else {
-    1_250
+    1_500
 };
 
 pub trait RecursionState {

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -72,23 +72,23 @@ impl RecursionGuard {
 #[cfg(not(debug_assertions))]
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    50
+    200
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    100
+    400
 } else {
-    2_000
+    1_000
 };
 
 #[cfg(debug_assertions)]
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    25
+    15
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
-    75
+    25
 } else {
-    1_500
+    500
 };
 
 pub trait RecursionState {
@@ -113,7 +113,9 @@ impl<'a, S: RecursionState> RecursionToken<'a, S> {
 
     pub fn get_state(&mut self) -> PyResult<&mut S> {
         if self.state.incr_depth() >= RECURSION_GUARD_DEPTH_LIMIT {
-            Err(PyRecursionError::new_err("Maximum recursion depth exceeded"))
+            Err(PyRecursionError::new_err(format!(
+                "Maximum recursion depth exceeded: {RECURSION_GUARD_DEPTH_LIMIT} validators traversed",
+            )))
         } else {
             Ok(self.state)
         }

--- a/src/recursion_guard.rs
+++ b/src/recursion_guard.rs
@@ -69,12 +69,24 @@ impl RecursionGuard {
 }
 
 // A hard limit to avoid stack overflows when rampant recursion occurs
+#[cfg(not(debug_assertions))]
 pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
     // wasm and windows PyPy have very limited stack sizes
-    100
+    75
 } else if cfg!(any(PyPy, windows)) {
     // PyPy and Windows in general have more restricted stack space
     200
+} else {
+    2_000
+};
+
+#[cfg(debug_assertions)]
+pub const RECURSION_GUARD_DEPTH_LIMIT: u16 = if cfg!(any(target_family = "wasm", all(windows, PyPy))) {
+    // wasm and windows PyPy have very limited stack sizes
+    50
+} else if cfg!(any(PyPy, windows)) {
+    // PyPy and Windows in general have more restricted stack space
+    100
 } else {
     1_500
 };

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -13,6 +13,7 @@ use crate::lookup_key::LookupKey;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
+use super::OuterValidator;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug)]
@@ -21,15 +22,15 @@ struct Parameter {
     name: String,
     kw_lookup_key: Option<LookupKey>,
     kwarg_key: Option<Py<PyString>>,
-    validator: CombinedValidator,
+    validator: OuterValidator,
 }
 
 #[derive(Debug)]
 pub struct ArgumentsValidator {
     parameters: Vec<Parameter>,
     positional_params_count: usize,
-    var_args_validator: Option<Box<CombinedValidator>>,
-    var_kwargs_validator: Option<Box<CombinedValidator>>,
+    var_args_validator: Option<Box<OuterValidator>>,
+    var_kwargs_validator: Option<Box<OuterValidator>>,
     loc_by_alias: bool,
 }
 
@@ -84,7 +85,9 @@ impl BuildValidator for ArgumentsValidator {
             };
 
             let has_default = match validator {
-                CombinedValidator::WithDefault(ref v) => {
+                OuterValidator {
+                    inner: CombinedValidator::WithDefault(ref v),
+                } => {
                     if v.omit_on_error() {
                         return py_schema_err!("Parameter '{}': omit_on_error cannot be used with arguments", name);
                     }

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -9,13 +9,14 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
+use super::OuterValidator;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug)]
 pub struct CallValidator {
     function: PyObject,
-    arguments_validator: Box<CombinedValidator>,
-    return_validator: Option<Box<CombinedValidator>>,
+    arguments_validator: Box<OuterValidator>,
+    return_validator: Option<Box<OuterValidator>>,
     name: String,
 }
 

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -8,6 +8,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
+use super::OuterValidator;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug, Clone)]
@@ -59,7 +60,7 @@ impl CustomError {
 
 #[derive(Debug)]
 pub struct CustomErrorValidator {
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     custom_error: CustomError,
     name: String,
 }

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -77,7 +77,8 @@ impl Validator for DefinitionRefValidator {
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        self.definition.get().unwrap().validate(py, input, state)
+        let mut token = state.descend();
+        self.definition.get().unwrap().validate(py, input, token.get_state()?)
     }
 
     fn validate_assignment<'data>(
@@ -88,10 +89,11 @@ impl Validator for DefinitionRefValidator {
         field_value: &'data PyAny,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
+        let mut token = state.descend();
         self.definition
             .get()
             .unwrap()
-            .validate_assignment(py, obj, field_name, field_value, state)
+            .validate_assignment(py, obj, field_name, field_value, token.get_state()?)
     }
 
     fn different_strict_behavior(&self, ultra_strict: bool) -> bool {

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -77,8 +77,7 @@ impl Validator for DefinitionRefValidator {
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let mut token = state.descend();
-        self.definition.get().unwrap().validate(py, input, token.get_state()?)
+        self.definition.get().unwrap().validate(py, input, state)
     }
 
     fn validate_assignment<'data>(
@@ -89,11 +88,10 @@ impl Validator for DefinitionRefValidator {
         field_value: &'data PyAny,
         state: &mut ValidationState,
     ) -> ValResult<'data, PyObject> {
-        let mut token = state.descend();
         self.definition
             .get()
             .unwrap()
-            .validate_assignment(py, obj, field_name, field_value, token.get_state()?)
+            .validate_assignment(py, obj, field_name, field_value, state)
     }
 
     fn different_strict_behavior(&self, ultra_strict: bool) -> bool {

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -8,12 +8,12 @@ use crate::tools::SchemaDict;
 use super::list::min_length_check;
 use super::set::set_build;
 use super::validation_state::ValidationState;
-use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, OuterValidator, Validator};
 
 #[derive(Debug)]
 pub struct FrozenSetValidator {
     strict: bool,
-    item_validator: Box<CombinedValidator>,
+    item_validator: Box<OuterValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,
     name: String,

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -347,6 +347,7 @@ impl Validator for FunctionWrapValidator {
                 state,
                 self.hide_input_in_errors,
                 self.validation_error_cause,
+                state.recursion_depth,
             ),
         };
         self._validate(
@@ -373,6 +374,7 @@ impl Validator for FunctionWrapValidator {
                 state,
                 self.hide_input_in_errors,
                 self.validation_error_cause,
+                state.recursion_depth,
             ),
             updated_field_name: field_name.to_string(),
             updated_field_value: field_value.to_object(py),

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -15,8 +15,8 @@ use crate::PydanticUseDefault;
 
 use super::generator::InternalValidator;
 use super::{
-    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, InputType, ValidationState,
-    Validator,
+    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, InputType, OuterValidator,
+    ValidationState, Validator,
 };
 
 struct FunctionInfo {
@@ -134,7 +134,7 @@ macro_rules! impl_validator {
 
 #[derive(Debug)]
 pub struct FunctionBeforeValidator {
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     func: PyObject,
     config: PyObject,
     name: String,
@@ -167,7 +167,7 @@ impl_validator!(FunctionBeforeValidator);
 
 #[derive(Debug)]
 pub struct FunctionAfterValidator {
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     func: PyObject,
     config: PyObject,
     name: String,
@@ -268,7 +268,7 @@ impl Validator for FunctionPlainValidator {
 
 #[derive(Debug)]
 pub struct FunctionWrapValidator {
-    validator: Arc<CombinedValidator>,
+    validator: Arc<OuterValidator>,
     func: PyObject,
     config: PyObject,
     name: String,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -235,7 +235,7 @@ pub struct InternalValidator {
 
 impl fmt::Debug for InternalValidator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.validator)
+        write!(f, "{:?}", self.validator.inner)
     }
 }
 

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -6,12 +6,13 @@ use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
 
+use super::OuterValidator;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug)]
 pub struct JsonValidator {
-    validator: Option<Box<CombinedValidator>>,
+    validator: Option<Box<OuterValidator>>,
     name: String,
 }
 
@@ -27,7 +28,9 @@ impl BuildValidator for JsonValidator {
             Some(schema) => {
                 let validator = build_validator(schema, config, definitions)?;
                 match validator {
-                    CombinedValidator::Any(_) => None,
+                    OuterValidator {
+                        inner: CombinedValidator::Any(_),
+                    } => None,
                     _ => Some(Box::new(validator)),
                 }
             }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -8,13 +8,14 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::InputType;
+use super::OuterValidator;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, Validator};
 
 #[derive(Debug)]
 pub struct JsonOrPython {
-    json: Box<CombinedValidator>,
-    python: Box<CombinedValidator>,
+    json: Box<OuterValidator>,
+    python: Box<OuterValidator>,
     name: String,
 }
 

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -7,14 +7,15 @@ use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
 
+use super::OuterValidator;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug)]
 pub struct LaxOrStrictValidator {
     strict: bool,
-    lax_validator: Box<CombinedValidator>,
-    strict_validator: Box<CombinedValidator>,
+    lax_validator: Box<OuterValidator>,
+    strict_validator: Box<OuterValidator>,
     name: String,
 }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -252,7 +252,7 @@ impl SchemaValidator {
             self_instance: None,
         };
 
-        let mut state = ValidationState::new(extra);
+        let mut state = ValidationState::new(extra, 0);
         self.validator
             .validate_assignment(py, obj, field_name, field_value, &mut state)
             .map_err(|e| self.prepare_validation_err(py, e, InputType::Python))
@@ -269,7 +269,7 @@ impl SchemaValidator {
             context,
             self_instance: None,
         };
-        let mut state = ValidationState::new(extra);
+        let mut state = ValidationState::new(extra, 0);
         let r = self.validator.default_value(py, None::<i64>, &mut state);
         match r {
             Ok(maybe_default) => match maybe_default {
@@ -311,7 +311,10 @@ impl SchemaValidator {
     where
         's: 'data,
     {
-        let mut state = ValidationState::new(Extra::new(strict, from_attributes, context, self_instance, input_type));
+        let mut state = ValidationState::new(
+            Extra::new(strict, from_attributes, context, self_instance, input_type),
+            0,
+        );
         self.validator.validate(py, input, &mut state)
     }
 
@@ -345,7 +348,7 @@ impl<'py> SelfValidator<'py> {
     }
 
     pub fn validate_schema(&self, py: Python<'py>, schema: &'py PyAny, strict: Option<bool>) -> PyResult<&'py PyAny> {
-        let mut state = ValidationState::new(Extra::new(strict, None, None, None, InputType::Python));
+        let mut state = ValidationState::new(Extra::new(strict, None, None, None, InputType::Python), 0);
         match self.validator.validator.validate(py, schema, &mut state) {
             Ok(schema_obj) => Ok(schema_obj.into_ref(py)),
             Err(e) => Err(SchemaError::from_val_error(py, e)),

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -750,6 +750,15 @@ impl Validator for OuterValidator {
             .validate_assignment(py, obj, field_name, field_value, token.get_state()?)
     }
 
+    fn default_value<'data>(
+        &self,
+        _py: Python<'data>,
+        _outer_loc: Option<impl Into<LocItem>>,
+        _state: &mut ValidationState,
+    ) -> ValResult<'data, Option<PyObject>> {
+        self.inner.default_value(_py, _outer_loc, _state)
+    }
+
     fn different_strict_behavior(&self, ultra_strict: bool) -> bool {
         self.inner.different_strict_behavior(ultra_strict)
     }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -284,7 +284,7 @@ impl SchemaValidator {
         format!(
             "SchemaValidator(title={:?}, validator={:#?}, definitions={:#?})",
             self.title.extract::<&str>(py).unwrap(),
-            self.validator,
+            self.validator.inner,
             self.definitions,
         )
     }
@@ -721,7 +721,6 @@ pub trait Validator: Send + Sync + Debug {
     fn complete(&self) -> PyResult<()>;
 }
 
-#[derive(Debug)]
 pub struct OuterValidator {
     pub inner: CombinedValidator,
 }
@@ -781,5 +780,11 @@ impl OuterValidator {
 impl PyGcTraverse for OuterValidator {
     fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.inner.py_gc_traverse(visit)
+    }
+}
+
+impl Debug for OuterValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
     }
 }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -8,7 +8,8 @@ use pyo3::{ffi, intern};
 
 use super::function::convert_err;
 use super::{
-    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator,
+    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, OuterValidator, ValidationState,
+    Validator,
 };
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
@@ -53,7 +54,7 @@ impl Revalidate {
 #[derive(Debug)]
 pub struct ModelValidator {
     revalidate: Revalidate,
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     class: Py<PyType>,
     post_init: Option<Py<PyString>>,
     frozen: bool,

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -15,6 +15,7 @@ use crate::input::{
 use crate::lookup_key::LookupKey;
 use crate::tools::SchemaDict;
 
+use super::OuterValidator;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, Validator};
 
@@ -25,7 +26,7 @@ struct Field {
     name: String,
     lookup_key: LookupKey,
     name_py: Py<PyString>,
-    validator: CombinedValidator,
+    validator: OuterValidator,
     frozen: bool,
 }
 
@@ -36,7 +37,7 @@ pub struct ModelFieldsValidator {
     fields: Vec<Field>,
     model_name: String,
     extra_behavior: ExtraBehavior,
-    extras_validator: Option<Box<CombinedValidator>>,
+    extras_validator: Option<Box<OuterValidator>>,
     strict: bool,
     from_attributes: bool,
     loc_by_alias: bool,

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -6,12 +6,13 @@ use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
 
+use super::OuterValidator;
 use super::ValidationState;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 
 #[derive(Debug)]
 pub struct NullableValidator {
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     name: String,
 }
 

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -6,12 +6,12 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::list::min_length_check;
-use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, OuterValidator, ValidationState, Validator};
 
 #[derive(Debug)]
 pub struct SetValidator {
     strict: bool,
-    item_validator: Box<CombinedValidator>,
+    item_validator: Box<OuterValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,
     name: String,
@@ -27,11 +27,11 @@ macro_rules! set_build {
             let py = schema.py();
             let item_validator = match schema.get_item(pyo3::intern!(schema.py(), "items_schema")) {
                 Some(d) => Box::new(crate::validators::build_validator(d, config, definitions)?),
-                None => Box::new(crate::validators::any::AnyValidator::build(
+                None => Box::new(OuterValidator::new(crate::validators::any::AnyValidator::build(
                     schema,
                     config,
                     definitions,
-                )?),
+                )?)),
             };
             let inner_name = item_validator.get_name();
             let max_length = schema.get_as(pyo3::intern!(py, "max_length"))?;

--- a/src/validators/validation_state.rs
+++ b/src/validators/validation_state.rs
@@ -3,17 +3,14 @@ use crate::recursion_guard::{RecursionState, RecursionToken};
 use super::Extra;
 
 pub struct ValidationState<'a> {
-    recursion_depth: u16,
+    pub recursion_depth: u16,
     // deliberately make Extra readonly
     extra: Extra<'a>,
 }
 
 impl<'a> ValidationState<'a> {
-    pub fn new(extra: Extra<'a>) -> Self {
-        Self {
-            recursion_depth: 0,
-            extra,
-        }
+    pub fn new(extra: Extra<'a>, recursion_depth: u16) -> Self {
+        Self { recursion_depth, extra }
     }
 
     pub fn with_new_extra<'r, R: 'r>(

--- a/src/validators/validation_state.rs
+++ b/src/validators/validation_state.rs
@@ -11,18 +11,13 @@ pub struct ValidationState<'a> {
 }
 
 impl<'a> ValidationState<'a> {
-    #[cfg(debug_assertions)]
     pub fn new(extra: Extra<'a>, recursion_depth: u16) -> Self {
         Self {
             recursion_depth,
             extra,
+            #[cfg(debug_assertions)]
             initial_recursion_depth: recursion_depth,
         }
-    }
-
-    #[cfg(not(debug_assertions))]
-    pub fn new(extra: Extra<'a>, recursion_depth: u16) -> Self {
-        Self { recursion_depth, extra }
     }
 
     pub fn with_new_extra<'r, R: 'r>(
@@ -35,6 +30,7 @@ impl<'a> ValidationState<'a> {
         let mut new_state = ValidationState {
             recursion_depth: self.recursion_depth,
             extra,
+            #[cfg(debug_assertions)]
             initial_recursion_depth: self.recursion_depth,
         };
         f(&mut new_state)
@@ -81,6 +77,8 @@ impl<'a> RecursionState for ValidationState<'a> {
 }
 
 #[cfg(debug_assertions)]
+// This is just a sanity check that runs in our CI to catch any mistakes
+// in the usage of ValidationState or RecursionToken.
 impl Drop for ValidationState<'_> {
     fn drop(&mut self) {
         assert!(

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -5,6 +5,7 @@ use pyo3::types::PyDict;
 use pyo3::PyTraverseError;
 use pyo3::PyVisit;
 
+use super::OuterValidator;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
@@ -70,7 +71,7 @@ enum OnError {
 pub struct WithDefaultValidator {
     default: DefaultType,
     on_error: OnError,
-    validator: Box<CombinedValidator>,
+    validator: Box<OuterValidator>,
     validate_default: bool,
     copy_default: bool,
     name: String,

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -283,7 +283,8 @@ def definition_model_data():
     data = {'width': -1}
 
     _data = data
-    for i in range(pydantic_core._pydantic_core._recursion_limit - 2):
+    # we have about 4 layers of schemas before we hit the actual field
+    for i in range(pydantic_core._pydantic_core._recursion_limit // 4):
         _data['branch'] = {'width': i}
         _data = _data['branch']
     return data

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -125,7 +125,7 @@ def test_definition_cycles(definition_schema, data):
 def test_definition_broken(definition_schema):
     data = {'name': 'x'}
     data['sub_branch'] = data
-    with pytest.raises(ValidationError, match='Recursion error - cyclic reference detected'):
+    with pytest.raises(RecursionError):
         definition_schema.validate_python(data)
 
 


### PR DESCRIPTION
From profiling of definitions @davidhewitt and I found that the recursion checking was by far the slowest part (it used a HashSet, etc.). Especially after #992. By making this change we make that a lot cheaper, which we hope will make it close to zero cost to use a definition instead of "inlining" schemas. This will make it much easier for pydantic to generate core schemas since it won't have to restructure schemas if one model is embedded in another (it can just copy the definitions).

The negative implication of this is that some errors may be less clear and happen later in recursion. In particular the scenario of:

```python
data = {}
data['a'] = data
```

Will now recurse possibly 1000 times before erroring whereas before it would error in 1 or 2 cycles. This cost is greater if there is a lot of validation going on in each cycle. But these sorts of data structures cannot occur with any sort of serialized data (JSON) so there is no security risk for a malicious API payload wasting your CPU cycles. And if you do try to validate recursive Python data you won't blow your stack and segfault (depending on the size of your validators obviously, I'm sure you could craft some schema where you have a model with 1,000,000 fields or something, and blow the tack in a single cycle, but that was already the case). The flip side is that now we are actually more resilient against other forms of segfaults because we're checking recursion depth at every validator, not just at possibly recursive definitions. As per above one could have crafted some schema that blew the stack by having a recursive definition with a ton of validators stacked in between. All this is to say that there are tradeoffs of what you catch and don't and this seems to be as good if not better than what we had before.

I'll also mention that the previous implementation of recursion tracking required two steps: increment and decrement. This new implementation uses `Drop` to make that a single step, so you can't forget to decrement. And since we implemented the `OuterValidator` thing you can't forget to increment either.

The thing that's missing is doing the same for serialization, but it seems that part of the codebase is a bit messy right now in the relationship of `SerializationState` and the serialization `Extra. @davidhewitt suggested we wait on implementing this approach for serializers until he can do a cleanup / refactor of that stuff, which is why I've left the existing `RecursionGuard` code in place for serializers (if not this would be a negative LOC diff!).