### PR TITLE
Remove `__deepcopy__`  from Url, MultiHostUrl and TzInfo

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -527,7 +527,6 @@ class Url(SupportsAllComparisons):
         """
         The URL as a string, this will punycode encode the host if required.
         """
-    def __deepcopy__(self, memo: dict) -> str: ...
     @classmethod
     def build(
         cls,
@@ -641,7 +640,6 @@ class MultiHostUrl(SupportsAllComparisons):
         """
         The URL as a string, this will punycode encode the hosts if required.
         """
-    def __deepcopy__(self, memo: dict) -> Self: ...
     @classmethod
     def build(
         cls,
@@ -836,7 +834,6 @@ class TzInfo(datetime.tzinfo):
     def utcoffset(self, _dt: datetime.datetime | None) -> datetime.timedelta: ...
     def dst(self, _dt: datetime.datetime | None) -> datetime.timedelta: ...
     def fromutc(self, dt: datetime.datetime) -> datetime.datetime: ...
-    def __deepcopy__(self, _memo: dict[Any, Any]) -> 'TzInfo': ...
 
 def validate_core_schema(schema: CoreSchema, *, strict: bool | None = None) -> CoreSchema:
     """Validate a CoreSchema

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
-use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
+use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTzInfo};
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 use speedate::{Date, DateTime, Duration, ParseError, Time, TimeConfig};
 use std::borrow::Cow;
@@ -565,10 +565,6 @@ impl TzInfo {
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
         op.matches(self.seconds.cmp(&other.seconds))
-    }
-
-    fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> PyResult<Py<Self>> {
-        Py::new(py, self.clone())
     }
 
     pub fn __reduce__(&self, py: Python) -> PyResult<PyObject> {

--- a/src/url.rs
+++ b/src/url.rs
@@ -146,11 +146,6 @@ impl PyUrl {
         true // an empty string is not a valid URL
     }
 
-    #[pyo3(signature = (_memo, /))]
-    pub fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> Py<PyAny> {
-        self.clone().into_py(py)
-    }
-
     fn __getnewargs__(&self) -> (&str,) {
         (self.__str__(),)
     }
@@ -345,10 +340,6 @@ impl PyMultiHostUrl {
 
     fn __bool__(&self) -> bool {
         true // an empty string is not a valid URL
-    }
-
-    pub fn __deepcopy__(&self, py: Python, _memo: &PyDict) -> Py<PyAny> {
-        self.clone().into_py(py)
     }
 
     fn __getnewargs__(&self) -> (String,) {

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -498,7 +498,7 @@ fn check_sub_defaults(
         if let Some(default_port) = default_port {
             lib_url
                 .set_port(Some(default_port))
-                .map_err(|_| map_parse_err(ParseError::EmptyHost))?;
+                .map_err(|()| map_parse_err(ParseError::EmptyHost))?;
         }
     }
     if let Some(ref default_path) = default_path {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,7 +22,7 @@ mod tests {
             //         'type': 'function-wrap',
             //         'function': lambda: None,
             //     },
-            let code = r#"{
+            let code = "{
                 'type': 'definitions',
                 'schema': {'type': 'definition-ref', 'schema_ref': 'C-ref'},
                 'definitions': [
@@ -44,7 +44,7 @@ mod tests {
                         },
                     },
                 ]
-            }"#;
+            }";
             let schema: &PyDict = py.eval(code, None, None).unwrap().extract().unwrap();
             SchemaSerializer::py_new(schema, None).unwrap();
         });


### PR DESCRIPTION


## Change Summary

I think since the classes are now pickleable, the deepcopy method is not needed.
Not sure if this has any performance hits.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu