### PR TITLE
Fix `regex_engine` being rejected by `validate_core_schema`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -106,6 +106,7 @@ class CoreConfig(TypedDict, total=False):
     hide_input_in_errors: bool
     validation_error_cause: bool  # default: False
     coerce_numbers_to_str: bool  # default: False
+    regex_engine: Literal['rust-regex', 'python-re']  # default: 'rust-regex'
 
 
 IncExCall: TypeAlias = 'set[int | str] | dict[int | str, IncExCall] | None'


### PR DESCRIPTION
## Change Summary

Makes it actually possible to set `regex_engine` in https://github.com/pydantic/pydantic/pull/7768

## Related issue number

Part of https://github.com/pydantic/pydantic/issues/7714

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
