### PR TITLE
Fix `definition-ref` bug with `Dict` keys

### DIFF
--- a/src/serializers/type_serializers/definitions.rs
+++ b/src/serializers/type_serializers/definitions.rs
@@ -76,7 +76,7 @@ impl TypeSerializer for DefinitionRefSerializer {
     }
 
     fn json_key<'py>(&self, key: &'py PyAny, extra: &Extra) -> PyResult<Cow<'py, str>> {
-        self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+        self.definition.get().unwrap().json_key(key, extra)
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/tests/serializers/test_definitions.py
+++ b/tests/serializers/test_definitions.py
@@ -132,5 +132,5 @@ def test_defs_with_dict():
         )
     )
 
-    assert s.to_json({'foo': {'key': 'val'}}) == '{"foo":{"key":"val"}}'
+    assert s.to_json({'foo': {'key': 'val'}}) == b'{"foo":{"key":"val"}}'
     assert s.to_python({'foo': {'key': 'val'}}) == {'foo': {'key': 'val'}}

--- a/tests/serializers/test_definitions.py
+++ b/tests/serializers/test_definitions.py
@@ -113,3 +113,24 @@ def test_use_after():
         )
     )
     assert v.to_python((1, 2)) == ('1', '2')
+
+
+def test_defs_with_dict():
+    s = SchemaSerializer(
+        core_schema.definitions_schema(
+            schema=core_schema.typed_dict_schema(
+                {
+                    'foo': core_schema.typed_dict_field(
+                        core_schema.dict_schema(
+                            keys_schema=core_schema.definition_reference_schema('key'),
+                            values_schema=core_schema.definition_reference_schema('val'),
+                        )
+                    )
+                }
+            ),
+            definitions=[core_schema.str_schema(ref='key'), core_schema.str_schema(ref='val')],
+        )
+    )
+
+    assert s.to_json({'foo': {'key': 'val'}}) == '{"foo":{"key":"val"}}'
+    assert s.to_python({'foo': {'key': 'val'}}) == {'foo': {'key': 'val'}}


### PR DESCRIPTION
## Change Summary

Any dictionary key specified with a `definition-ref` was throwing an unnecessary warning during json serialization. This is no longer the case 😄.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/7639

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb