### PR TITLE
Add lax_str and lax_int support for enum values not inherited from str/int

### DIFF
--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -255,17 +255,9 @@ impl<'a> Input<'a> for PyAny {
                 || self.is_instance(decimal_type.as_ref(py)).unwrap_or_default()
         } {
             Ok(self.str()?.into())
-        } else if let Some(enum_val) = maybe_as_enum(self.py(), self) {
+        } else if let Some(enum_val) = maybe_as_enum(self) {
             return Ok(enum_val.str()?.into());
         } else {
-            // let py = self.py();
-            // // Enum value not inherited from `str`
-            // let enum_object = py.import("enum").unwrap().getattr("EnumMeta").unwrap().to_object(py);
-            // let meta_type = self.get_type().get_type();
-            // if meta_type.is(&enum_object) {
-            //     let val = self.getattr(intern!(py, "value"))?;
-            //     return Ok(val.str()?.into());
-            // }
             Err(ValError::new(ErrorTypeDefaults::StringType, self))
         }
     }
@@ -349,7 +341,7 @@ impl<'a> Input<'a> for PyAny {
             decimal_as_int(self.py(), self, decimal)
         } else if let Ok(float) = self.extract::<f64>() {
             float_as_int(self, float)
-        } else if let Some(enum_val) = maybe_as_enum(self.py(), self) {
+        } else if let Some(enum_val) = maybe_as_enum(self) {
             Ok(EitherInt::Py(enum_val))
         } else {
             Err(ValError::new(ErrorTypeDefaults::IntType, self))
@@ -771,7 +763,8 @@ fn maybe_as_string(v: &PyAny, unicode_error: ErrorType) -> ValResult<Option<Cow<
 }
 
 /// Utility for extracting an enum value, if possible.
-fn maybe_as_enum<'a>(py: Python<'a>, v: &'a PyAny) -> Option<&'a PyAny> {
+fn maybe_as_enum<'a>(v: &'a PyAny) -> Option<&'a PyAny> {
+    let py = v.py();
     let enum_meta_object = py.import("enum").unwrap().getattr("EnumMeta").unwrap().to_object(py);
     let meta_type = v.get_type().get_type();
     if meta_type.is(&enum_meta_object) {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -259,7 +259,7 @@ impl<'a> Input<'a> for PyAny {
         } {
             Ok(self.str()?.into())
         } else if let Some(enum_val) = maybe_as_enum(self) {
-            return Ok(enum_val.str()?.into());
+            Ok(enum_val.str()?.into())
         } else {
             Err(ValError::new(ErrorTypeDefaults::StringType, self))
         }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -21,7 +21,10 @@ use super::datetime::{
     float_as_duration, float_as_time, int_as_datetime, int_as_duration, int_as_time, EitherDate, EitherDateTime,
     EitherTime,
 };
-use super::shared::{decimal_as_int, float_as_int, int_as_bool, map_json_err, str_as_bool, str_as_float, str_as_int};
+use super::shared::{
+    decimal_as_int, float_as_int, get_enum_meta_object, int_as_bool, map_json_err, str_as_bool, str_as_float,
+    str_as_int,
+};
 use super::{
     py_string_str, BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericArguments,
     GenericIterable, GenericIterator, GenericMapping, Input, JsonInput, PyArgs,
@@ -765,7 +768,7 @@ fn maybe_as_string(v: &PyAny, unicode_error: ErrorType) -> ValResult<Option<Cow<
 /// Utility for extracting an enum value, if possible.
 fn maybe_as_enum<'a>(v: &'a PyAny) -> Option<&'a PyAny> {
     let py = v.py();
-    let enum_meta_object = py.import("enum").unwrap().getattr("EnumMeta").unwrap().to_object(py);
+    let enum_meta_object = get_enum_meta_object(py);
     let meta_type = v.get_type().get_type();
     if meta_type.is(&enum_meta_object) {
         v.getattr(intern!(py, "value")).ok()

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -766,7 +766,7 @@ fn maybe_as_string(v: &PyAny, unicode_error: ErrorType) -> ValResult<Option<Cow<
 }
 
 /// Utility for extracting an enum value, if possible.
-fn maybe_as_enum<'a>(v: &'a PyAny) -> Option<&'a PyAny> {
+fn maybe_as_enum(v: &PyAny) -> Option<&PyAny> {
     let py = v.py();
     let enum_meta_object = get_enum_meta_object(py);
     let meta_type = v.get_type().get_type();

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -12,8 +12,8 @@ static ENUM_META_OBJECT: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
 pub fn get_enum_meta_object(py: Python) -> Py<PyAny> {
     ENUM_META_OBJECT
         .get_or_init(py, || {
-            py.import("enum")
-                .and_then(|enum_module| enum_module.getattr("EnumMeta"))
+            py.import(intern!(py, "enum"))
+                .and_then(|enum_module| enum_module.getattr(intern!(py, "EnumMeta")))
                 .unwrap()
                 .to_object(py)
         })

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -1,10 +1,24 @@
 use num_bigint::BigInt;
-use pyo3::{intern, PyAny, Python};
+use pyo3::sync::GILOnceCell;
+use pyo3::{intern, Py, PyAny, Python, ToPyObject};
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 
 use super::parse_json::{JsonArray, JsonInput};
 use super::{EitherFloat, EitherInt, Input};
+
+static ENUM_META_OBJECT: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+
+pub fn get_enum_meta_object(py: Python) -> Py<PyAny> {
+    ENUM_META_OBJECT
+        .get_or_init(py, || {
+            py.import("enum")
+                .and_then(|enum_module| enum_module.getattr("EnumMeta"))
+                .unwrap()
+                .to_object(py)
+        })
+        .clone()
+}
 
 pub fn map_json_err<'a>(input: &'a impl Input<'a>, error: serde_json::Error) -> ValError<'a> {
     ValError::new(

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -82,7 +82,12 @@ impl ObTypeLookup {
             timedelta: PyDelta::new(py, 0, 0, 0, false).unwrap().get_type_ptr() as usize,
             url: PyUrl::new(lib_url.clone()).into_py(py).as_ref(py).get_type_ptr() as usize,
             multi_host_url: PyMultiHostUrl::new(lib_url, None).into_py(py).as_ref(py).get_type_ptr() as usize,
-            enum_object: py.import("enum").unwrap().getattr("EnumMeta").unwrap().to_object(py),
+            enum_object: py
+                .import(intern!(py, "enum"))
+                .unwrap()
+                .getattr(intern!(py, "EnumMeta"))
+                .unwrap()
+                .to_object(py),
             generator_object: py
                 .import("types")
                 .unwrap()

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -82,7 +82,7 @@ impl ObTypeLookup {
             timedelta: PyDelta::new(py, 0, 0, 0, false).unwrap().get_type_ptr() as usize,
             url: PyUrl::new(lib_url.clone()).into_py(py).as_ref(py).get_type_ptr() as usize,
             multi_host_url: PyMultiHostUrl::new(lib_url, None).into_py(py).as_ref(py).get_type_ptr() as usize,
-            enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().to_object(py),
+            enum_object: py.import("enum").unwrap().getattr("EnumMeta").unwrap().to_object(py),
             generator_object: py
                 .import("types")
                 .unwrap()

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -82,12 +82,7 @@ impl ObTypeLookup {
             timedelta: PyDelta::new(py, 0, 0, 0, false).unwrap().get_type_ptr() as usize,
             url: PyUrl::new(lib_url.clone()).into_py(py).as_ref(py).get_type_ptr() as usize,
             multi_host_url: PyMultiHostUrl::new(lib_url, None).into_py(py).as_ref(py).get_type_ptr() as usize,
-            enum_object: py
-                .import(intern!(py, "enum"))
-                .unwrap()
-                .getattr(intern!(py, "EnumMeta"))
-                .unwrap()
-                .to_object(py),
+            enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().to_object(py),
             generator_object: py
                 .import("types")
                 .unwrap()
@@ -264,8 +259,9 @@ impl ObTypeLookup {
     fn is_enum(&self, op_value: Option<&PyAny>, py_type: &PyType) -> bool {
         // only test on the type itself, not base types
         if op_value.is_some() {
+            let enum_meta_type = self.enum_object.as_ref(py_type.py()).get_type();
             let meta_type = py_type.get_type();
-            meta_type.is(&self.enum_object)
+            meta_type.is(enum_meta_type)
         } else {
             false
         }

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -459,3 +459,16 @@ def test_float_subclass() -> None:
     v_lax = v.validate_python(FloatSubclass(1))
     assert v_lax == 1
     assert type(v_lax) == int
+
+
+def test_int_subclass_plain_enum() -> None:
+    v = SchemaValidator({'type': 'int'})
+
+    from enum import Enum
+
+    class PlainEnum(Enum):
+        ONE = 1
+
+    v_lax = v.validate_python(PlainEnum.ONE)
+    assert v_lax == 1
+    assert type(v_lax) == int

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -249,6 +249,21 @@ def test_lax_subclass(FruitEnum, kwargs):
     assert repr(p) == "'pear'"
 
 
+@pytest.mark.parametrize('kwargs', [{}, {'to_lower': True}], ids=repr)
+def test_lax_subclass_plain_enum(kwargs):
+    v = SchemaValidator(core_schema.str_schema(**kwargs))
+
+    from enum import Enum
+
+    class PlainEnum(Enum):
+        ONE = 'one'
+
+    p = v.validate_python(PlainEnum.ONE)
+    assert p == 'one'
+    assert type(p) is str
+    assert repr(p) == "'one'"
+
+
 def test_subclass_preserved() -> None:
     class StrSubclass(str):
         pass


### PR DESCRIPTION
## Change Summary
Add support for Enum values not inherited from `str`/`int` for `lax_str` and `lax_int`

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Fix #399 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
