### PR TITLE
feat: add `ser_json_bytes` mode `'hex'`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -101,7 +101,7 @@ class CoreConfig(TypedDict, total=False):
     allow_inf_nan: bool  # default: True
     # the config options are used to customise serialization to JSON
     ser_json_timedelta: Literal['iso8601', 'float']  # default: 'iso8601'
-    ser_json_bytes: Literal['utf8', 'base64']  # default: 'utf8'
+    ser_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'
     # used to hide input data from ValidationError repr
     hide_input_in_errors: bool
     validation_error_cause: bool  # default: False

--- a/tests/serializers/test_bytes.py
+++ b/tests/serializers/test_bytes.py
@@ -105,6 +105,13 @@ def test_bytes_base64():
     assert base64.b64decode(s.to_python(b'foo bar', mode='json').encode()) == b'foo bar'
 
 
+def test_bytes_hex():
+    s = SchemaSerializer(core_schema.bytes_schema(), {'ser_json_bytes': 'hex'})
+    assert s.to_python(b'\xff\xff') == b'\xff\xff'
+    assert s.to_json(b'\xff\xff') == b'"ffff"'
+    assert s.to_python(b'\xff\xff', mode='json') == 'ffff' == b'\xff\xff'.hex()
+
+
 def test_bytes_base64_dict_key():
     s = SchemaSerializer(core_schema.dict_schema(core_schema.bytes_schema()), {'ser_json_bytes': 'base64'})
 


### PR DESCRIPTION
## Change Summary
Add `'hex'` mode to `ser_json_bytes` to serialize bytes as the hexadecimal string representation

## Related issue number
closes #937

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu