### PR TITLE
Fix bug allowing validation of `bool` types with `coerce_numbers_to_str=True`

### DIFF
--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -246,13 +246,11 @@ impl<'a> Input<'a> for PyAny {
                 Err(_) => return Err(ValError::new(ErrorTypeDefaults::StringUnicode, self)),
             };
             Ok(s.into())
-        } else if coerce_numbers_to_str && PyBool::is_exact_type_of(self) {
-            // bools are a subclass of int, so check for bool type in this specific case
-            Err(ValError::new(ErrorTypeDefaults::StringType, self))
-        } else if coerce_numbers_to_str && {
+        } else if coerce_numbers_to_str && !PyBool::is_exact_type_of(self) && {
             let py = self.py();
             let decimal_type: Py<PyType> = get_decimal_type(py);
 
+            // only allow int, float, and decimal (not bool)
             self.is_instance_of::<PyInt>()
                 || self.is_instance_of::<PyFloat>()
                 || self.is_instance(decimal_type.as_ref(py)).unwrap_or_default()

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -246,6 +246,9 @@ impl<'a> Input<'a> for PyAny {
                 Err(_) => return Err(ValError::new(ErrorTypeDefaults::StringUnicode, self)),
             };
             Ok(s.into())
+        } else if coerce_numbers_to_str && PyBool::is_exact_type_of(self) {
+            // bools are a subclass of int, so check for bool type in this specific case
+            Err(ValError::new(ErrorTypeDefaults::StringType, self))
         } else if coerce_numbers_to_str && {
             let py = self.py();
             let decimal_type: Py<PyType> = get_decimal_type(py);

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -277,6 +277,16 @@ def test_coerce_numbers_to_str_disabled_in_strict_mode() -> None:
         v.validate_json('42')
 
 
+def test_coerce_numbers_to_str_raises_for_bool() -> None:
+    config = core_schema.CoreConfig(coerce_numbers_to_str=True)
+
+    v = SchemaValidator(core_schema.str_schema(strict=True), config)
+    with pytest.raises(ValidationError):
+        v.validate_python(True)
+    with pytest.raises(ValidationError):
+        v.validate_json(False)
+
+
 @pytest.mark.parametrize(
     ('number', 'expected_str'),
     [

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -280,7 +280,7 @@ def test_coerce_numbers_to_str_disabled_in_strict_mode() -> None:
 def test_coerce_numbers_to_str_raises_for_bool() -> None:
     config = core_schema.CoreConfig(coerce_numbers_to_str=True)
 
-    v = SchemaValidator(core_schema.str_schema(strict=True), config)
+    v = SchemaValidator(core_schema.str_schema(), config)
     with pytest.raises(ValidationError):
         v.validate_python(True)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Change Summary

Setting the `coerce_numbers_to_str` flag shouldn't allow the validation of `bool` types, so this is fixed here. Though `bool` is a subclass of `int` we didn't specify (nor intend, to the best of my understanding) for this behavior to be allowed.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/7820

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt