### PR TITLE
feat: Computed field serialization for TypedDict

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -200,11 +200,7 @@ fn has_ser_function(schema: &PyDict) -> bool {
     let ser_schema = schema
         .get_as::<&PyDict>(intern!(py, "serialization"))
         .unwrap_or_default();
-
-    match ser_schema {
-        Some(s) => s.contains(intern!(py, "function")).unwrap_or_default(),
-        None => false,
-    }
+    ser_schema.is_some_and(|s| s.contains(intern!(py, "function")).unwrap_or_default())
 }
 
 fn get_next_value<'a>(

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -211,8 +211,10 @@ fn get_next_value<'a>(
     input_value: &'a PyAny,
     ob_type_lookup: &'a ObTypeLookup,
 ) -> PyResult<&'a PyAny> {
-    let next_value = match ob_type_lookup.get_type(input_value) {
-        ObType::Unknown | ObType::Dataclass => input_value.getattr(field.property_name_py.as_ref(input_value.py())),
+    match ob_type_lookup.get_type(input_value) {
+        ObType::Dataclass | ObType::PydanticSerializable | ObType::Unknown => {
+            input_value.getattr(field.property_name_py.as_ref(input_value.py()))
+        }
         _ => {
             if field.has_ser_func {
                 Ok(input_value)
@@ -223,6 +225,5 @@ fn get_next_value<'a>(
                 )))
             }
         }
-    };
-    next_value
+    }
 }

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -1,3 +1,4 @@
+use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
 use pyo3::{intern, PyTraverseError, PyVisit};
@@ -211,20 +212,46 @@ fn get_next_value<'a>(
     input_value: &'a PyAny,
     ob_type_lookup: &'a ObTypeLookup,
 ) -> PyResult<&'a PyAny> {
+    // Backwards compatiability.
+    let legacy_result = match ob_type_lookup.get_type(input_value) {
+        ObType::Dataclass | ObType::PydanticSerializable | ObType::Unknown => {
+            py_get_attrs(input_value, field.property_name_py.as_ref(input_value.py()))
+        }
+        _ => Ok(None),
+    };
+    let legacy_next_value = match legacy_result {
+        Ok(res) => res,
+        Err(err) => return Err(err),
+    };
+    if legacy_next_value.is_some() {
+        return Ok(legacy_next_value.unwrap());
+    }
+
+    // Default behavior: If custom serialization function provided, compute value based on input.
+    if field.has_ser_func {
+        return Ok(input_value);
+    }
+
+    // Fallback behavior: Check if computed field is a property of input object.
     let property_name = field.property_name_py.as_ref(input_value.py());
-    match ob_type_lookup.get_type(input_value) {
-        ObType::Dataclass | ObType::PydanticSerializable => input_value.getattr(property_name),
-        _ => {
-            if field.has_ser_func {
-                Ok(input_value)
+    if input_value.hasattr(property_name).unwrap_or_default() {
+        return input_value.getattr(property_name);
+    }
+
+    Err(PydanticSerializationError::new_err(format!(
+        "No serialization function found for '{}'",
+        property_name
+    )))
+}
+
+fn py_get_attrs<'a>(obj: &'a PyAny, attr_name: &PyString) -> PyResult<Option<&'a PyAny>> {
+    match obj.getattr(attr_name) {
+        Ok(attr) => Ok(Some(attr)),
+        Err(err) => {
+            if err.get_type(obj.py()).is_subclass_of::<PyAttributeError>()? {
+                Ok(None)
             } else {
-                if input_value.hasattr(property_name).unwrap_or_default() {
-                    return input_value.getattr(property_name);
-                }
-                Err(PydanticSerializationError::new_err(format!(
-                    "no serialization function found for {}",
-                    field.property_name
-                )))
+                Err(err)
             }
         }
     }

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -209,8 +209,8 @@ fn get_next_value<'a>(
     ob_type_lookup: &'a ObTypeLookup,
 ) -> PyResult<&'a PyAny> {
     let py = input_value.py();
-    let mut legacy_attr_error: Option<PyErr> = None;
     // Backwards compatiability.
+    let mut legacy_attr_error: Option<PyErr> = None;
     let legacy_result = match ob_type_lookup.get_type(input_value) {
         ObType::Dataclass | ObType::PydanticSerializable => {
             match input_value.getattr(field.property_name_py.as_ref(py)) {

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -690,12 +690,12 @@ def test_property_attribute_error():
             ),
         )
     )
-    with pytest.raises(AttributeError, match="^'Model' object has no attribute 'area'$"):
+    with pytest.raises(PydanticSerializationError, match="^No serialization function found for 'area'$"):
         s.to_python(Model(3))
-    with pytest.raises(AttributeError, match="^'Model' object has no attribute 'area'$"):
+    with pytest.raises(PydanticSerializationError, match="^No serialization function found for 'area'$"):
         s.to_python(Model(3), mode='json')
 
-    e = "^Error serializing to JSON: AttributeError: 'Model' object has no attribute 'area'$"
+    e = "^Error serializing to JSON: PydanticSerializationError: No serialization function found for 'area'$"
     with pytest.raises(PydanticSerializationError, match=e):
         s.to_json(Model(3))
 

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -690,12 +690,12 @@ def test_property_attribute_error():
             ),
         )
     )
-    with pytest.raises(PydanticSerializationError, match="^No serialization function found for 'area'$"):
+    with pytest.raises(AttributeError, match="^'Model' object has no attribute 'area'$"):
         s.to_python(Model(3))
-    with pytest.raises(PydanticSerializationError, match="^No serialization function found for 'area'$"):
+    with pytest.raises(AttributeError, match="^'Model' object has no attribute 'area'$"):
         s.to_python(Model(3), mode='json')
 
-    e = "^Error serializing to JSON: PydanticSerializationError: No serialization function found for 'area'$"
+    e = "^Error serializing to JSON: AttributeError: 'Model' object has no attribute 'area'$"
     with pytest.raises(PydanticSerializationError, match=e):
         s.to_json(Model(3))
 

--- a/tests/serializers/test_typed_dict.py
+++ b/tests/serializers/test_typed_dict.py
@@ -354,6 +354,7 @@ def test_computed_fields_with_plain_serializer_function():
     s = SchemaSerializer(schema)
     value = {'0': 0, '1': 1}
     assert s.to_python(value) == {'0': 0, '1': 1, '2': 2}
+    assert s.to_json(value) == b'{"0":0,"1":1,"2":2}'
 
     def ser_foo(_v: dict):
         return 'bar'
@@ -368,6 +369,7 @@ def test_computed_fields_with_plain_serializer_function():
     )
     s = SchemaSerializer(schema)
     assert s.to_python({}) == {'foo': 'bar'}
+    assert s.to_json({}) == b'{"foo":"bar"}'
 
 
 def test_computed_fields_with_warpped_serializer_function():
@@ -402,3 +404,4 @@ def test_computed_fields_with_warpped_serializer_function():
     s = SchemaSerializer(schema)
     value = {'one': 1, 'two': 2, 'three': 3}
     assert s.to_python(value) == {'one': 1, 'two': 2, 'three': 3, 'columns': ['ONE', 'TWO', 'THREE']}
+    assert s.to_json(value) == b'{"one":1,"two":2,"three":3,"columns":["ONE","TWO","THREE"]}'

--- a/tests/serializers/test_typed_dict.py
+++ b/tests/serializers/test_typed_dict.py
@@ -405,3 +405,23 @@ def test_computed_fields_with_warpped_serializer_function():
     value = {'one': 1, 'two': 2, 'three': 3}
     assert s.to_python(value) == {'one': 1, 'two': 2, 'three': 3, 'columns': ['ONE', 'TWO', 'THREE']}
     assert s.to_json(value) == b'{"one":1,"two":2,"three":3,"columns":["ONE","TWO","THREE"]}'
+
+
+def test_computed_fields_with_typed_dict_model():
+    class Model(TypedDict):
+        x: int
+
+    def ser_y(v: Any) -> str:
+        return f'{v["x"]}.00'
+
+    s = SchemaSerializer(
+        core_schema.typed_dict_schema(
+            {'x': core_schema.typed_dict_field(core_schema.int_schema())},
+            computed_fields=[
+                core_schema.computed_field(
+                    'y', core_schema.str_schema(serialization=core_schema.plain_serializer_function_ser_schema(ser_y))
+                )
+            ],
+        )
+    )
+    assert s.to_python(Model(x=1000)) == {'x': 1000, 'y': '1000.00'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Updated computed field serialization to use the serialization function directly (if one exists) instead of always looking up a model attribute. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #657 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin