### PR TITLE
Don't accept NaN in float and decimal constraints

### DIFF
--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -129,7 +131,7 @@ impl Validator for ConstrainedFloatValidator {
             }
         }
         if let Some(le) = self.le {
-            if float > le {
+            if !matches!(float.partial_cmp(&le), Some(Ordering::Less | Ordering::Equal)) {
                 return Err(ValError::new(
                     ErrorType::LessThanEqual {
                         le: le.into(),
@@ -140,7 +142,7 @@ impl Validator for ConstrainedFloatValidator {
             }
         }
         if let Some(lt) = self.lt {
-            if float >= lt {
+            if !matches!(float.partial_cmp(&lt), Some(Ordering::Less)) {
                 return Err(ValError::new(
                     ErrorType::LessThan {
                         lt: lt.into(),
@@ -151,7 +153,7 @@ impl Validator for ConstrainedFloatValidator {
             }
         }
         if let Some(ge) = self.ge {
-            if float < ge {
+            if !matches!(float.partial_cmp(&ge), Some(Ordering::Greater | Ordering::Equal)) {
                 return Err(ValError::new(
                     ErrorType::GreaterThanEqual {
                         ge: ge.into(),
@@ -162,7 +164,7 @@ impl Validator for ConstrainedFloatValidator {
             }
         }
         if let Some(gt) = self.gt {
-            if float <= gt {
+            if !matches!(float.partial_cmp(&gt), Some(Ordering::Greater)) {
                 return Err(ValError::new(
                     ErrorType::GreaterThan {
                         gt: gt.into(),

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -148,12 +148,16 @@ def test_decimal_strict_json(input_value, expected):
         ({'le': 0}, 0, Decimal(0)),
         ({'le': 0}, -1, Decimal(-1)),
         ({'le': 0}, 0.1, Err('Input should be less than or equal to 0')),
+        ({'lt': 0, 'allow_inf_nan': True}, float('nan'), Err('Input should be less than 0')),
+        ({'gt': 0, 'allow_inf_nan': True}, float('inf'), Decimal('inf')),
         ({'lt': 0}, 0, Err('Input should be less than 0')),
         ({'lt': 0.123456}, 1, Err('Input should be less than 0.123456')),
     ],
 )
 def test_decimal_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_value, expected):
     v = py_and_json({'type': 'decimal', **kwargs})
+    if v.validator_type == 'json' and isinstance(input_value, float) and not math.isfinite(input_value):
+        expected = Err('Invalid JSON')
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -86,10 +86,14 @@ def test_float_strict(py_and_json: PyAndJson, input_value, expected):
         ({'le': 0}, 0.1, Err('Input should be less than or equal to 0')),
         ({'lt': 0}, 0, Err('Input should be less than 0')),
         ({'lt': 0.123456}, 1, Err('Input should be less than 0.123456')),
+        ({'lt': 0, 'allow_inf_nan': True}, float('nan'), Err('Input should be less than 0')),
+        ({'gt': 0, 'allow_inf_nan': True}, float('inf'), float('inf')),
     ],
 )
 def test_float_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_value, expected):
     v = py_and_json({'type': 'float', **kwargs})
+    if v.validator_type == 'json' and isinstance(input_value, float) and not math.isfinite(input_value):
+        expected = Err('Invalid JSON')
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)


### PR DESCRIPTION
## Change Summary

Constraints for `float` and `decimal` don't currently treat `NaN` correctly - `NaN` does not ordered with any other value. This PR makes `NaN` inputs rejected if the validator has a constraint e.g. `> 0`.

## Related issue number

Related to https://github.com/pydantic/pydantic/issues/7296#issuecomment-1777181788

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb