### PR TITLE
Annotation fix: core_schema.py - return type of _dict_not_none function

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3820,7 +3820,7 @@ ErrorType = Literal[
 ]
 
 
-def _dict_not_none(**kwargs: Any) -> Any:
+def _dict_not_none(**kwargs: Any) -> dict[str, Any]:
     return {k: v for k, v in kwargs.items() if v is not None}
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

A small change to the return type of the function `_dict_not_none`. `Any` can be narrowed down to `dict[str, Any]`.

<!-- Please give a short summary of the changes. -->


## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
