### PR TITLE
run pydantic integration tests with lax xfail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,9 @@ jobs:
 
       - run: pdm info && pdm list
         working-directory: pydantic
-      - run: pdm run pytest
+        # Run pytest with lax xfail because we often add tests to pydantic
+        # which xfail on a pending release of pydantic-core
+      - run: pdm run pytest --override-ini=xfail_strict=False
         working-directory: pydantic
 
   lint:


### PR DESCRIPTION
## Change Summary

We seem to be getting in a pattern where we add tests to pydantic which xfail waiting for a release of pydantic-core, this PR makes xpass lax so that these tests don't immediately go red on all pydantic-core PRs until the release.

Possibly one could argue that pydantic-core CI going red due to fixes waiting for release is a desirable thing to add pressure to release, in which case just close this.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb