### PR TITLE
uprev speedate, prevent - sign as datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "speedate"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c028e117e67c1f3224f5f834b3e48d4133dc11ec509aa19fdfa6c0987efed332"
+checksum = "242f76c50fd18cbf098607090ade73a08d39cfd84ea835f3796a2c855223b19b"
 dependencies = [
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ strum_macros = "0.25.3"
 serde_json = {version = "1.0.108", features = ["arbitrary_precision", "preserve_order"]}
 enum_dispatch = "0.3.8"
 serde = { version = "1.0.190", features = ["derive"] }
-speedate = "0.12.0"
+speedate = "0.13.0"
 smallvec = "1.11.1"
 ahash = "0.8.6"
 url = "2.4.1"

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -64,6 +64,8 @@ from ..conftest import Err, PyAndJson
             ),
             id='-inf',
         ),
+        pytest.param('-', Err('Input should be a valid date or datetime, input is too short'), id='minus'),
+        pytest.param('+', Err('Input should be a valid date or datetime, input is too short'), id='pus'),
     ],
 )
 def test_date(input_value, expected):

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -36,6 +36,8 @@ from ..conftest import Err, PyAndJson
         (float('nan'), Err('Input should be a valid datetime, NaN values not permitted [type=datetime_parsing,')),
         (float('inf'), Err('Input should be a valid datetime, dates after 9999')),
         (float('-inf'), Err('Input should be a valid datetime, dates before 1600')),
+        ('-', Err('Input should be a valid datetime, input is too short [type=datetime_parsing,')),
+        ('+', Err('Input should be a valid datetime, input is too short [type=datetime_parsing,')),
     ],
 )
 def test_datetime(input_value, expected):


### PR DESCRIPTION
## Change Summary

Disallow `'-'` as a date or datetime input.

## Related issue number

fix pydantic/pydantic#7872

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
