### PR TITLE
Restore manylinux-compatible PGO builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,7 @@ jobs:
       - name: build initial wheel
         uses: PyO3/maturin-action@v1
         with:
+          manylinux: auto
           args: >
             --release
             --out pgo-wheel
@@ -538,6 +539,7 @@ jobs:
       - name: build pgo-optimized wheel
         uses: PyO3/maturin-action@v1
         with:
+          manylinux: auto
           args: >
             --release
             --out dist


### PR DESCRIPTION
## Change Summary

Looks like omitting `manylinux` option is not the same as 'auto', cc @messense 

## Related issue number

Fix #1065 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin