### PR TITLE
Fix validation of `Literal` from JSON keys when used as `dict` key

### DIFF
--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -9,7 +9,7 @@ use pyo3::{intern, PyTraverseError, PyVisit};
 
 use crate::build_tools::{py_schema_err, py_schema_error_type};
 use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::Input;
+use crate::input::{Input, ValidationMatch};
 use crate::py_gc::PyGcTraverse;
 use crate::tools::SchemaDict;
 
@@ -116,8 +116,17 @@ impl<T: Debug> LiteralLookup<T> {
             }
         }
         if let Some(expected_strings) = &self.expected_str {
-            // dbg!(expected_strings);
-            if let Ok(either_str) = input.exact_str() {
+            let validation_result = if input.is_python() {
+                input.exact_str()
+            } else {
+                // Strings coming from JSON are treated as "strict" but not "exact" for reasons
+                // of parsing types like UUID; see the implementation of `validate_str` for Json
+                // inputs for justification. We might change that eventually, but for now we need
+                // to work around this when loading from JSON
+                input.validate_str(true, false).map(ValidationMatch::into_inner)
+            };
+
+            if let Ok(either_str) = validation_result {
                 let cow = either_str.as_cow()?;
                 if let Some(id) = expected_strings.get(cow.as_ref()) {
                     return Ok(Some((input, &self.values[*id])));

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -123,6 +123,7 @@ impl<T: Debug> LiteralLookup<T> {
                 // of parsing types like UUID; see the implementation of `validate_str` for Json
                 // inputs for justification. We might change that eventually, but for now we need
                 // to work around this when loading from JSON
+                // V3 TODO: revisit making this "exact" for JSON inputs
                 input.validate_str(true, false).map(ValidationMatch::into_inner)
             };
 


### PR DESCRIPTION
## Change Summary

Fix bug introduced in pydantic v2.5 such that when a `Literal` type is used as the key for a dictionary, a validation error was raised when validating JSON (when the correct value was provided).

## Related issue number

Fix #https://github.com/pydantic/pydantic/issues/8133

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt