### PR TITLE
Fix bug re `custom_init` on members of `Union`

### DIFF
--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -257,7 +257,10 @@ impl ModelValidator {
             // this work with from_attributes, and would essentially allow you to
             // handle init vars by adding them to the __init__ signature.
             if let Some(kwargs) = input.as_kwargs(py) {
-                return Ok(self.class.call(py, (), Some(kwargs))?);
+                return Ok(self
+                    .class
+                    .call(py, (), Some(kwargs))
+                    .map_err(|e| convert_err(py, e, input))?);
             }
         }
 

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -257,10 +257,10 @@ impl ModelValidator {
             // this work with from_attributes, and would essentially allow you to
             // handle init vars by adding them to the __init__ signature.
             if let Some(kwargs) = input.as_kwargs(py) {
-                return Ok(self
+                return self
                     .class
                     .call(py, (), Some(kwargs))
-                    .map_err(|e| convert_err(py, e, input))?);
+                    .map_err(|e| convert_err(py, e, input));
             }
         }
 

--- a/tests/validators/test_model_init.py
+++ b/tests/validators/test_model_init.py
@@ -479,3 +479,48 @@ def test_leak_model(validator):
     gc.collect()
 
     assert ref() is None
+
+
+def test_model_custom_init_with_union() -> None:
+    class A:
+        def __init__(self, **kwargs):
+            assert 'a' in kwargs
+            self.a = kwargs.get('a')
+
+    class B:
+        def __init__(self, **kwargs):
+            assert 'b' in kwargs
+            self.b = kwargs.get('b')
+
+    schema = {
+        'type': 'union',
+        'choices': [
+            {
+                'type': 'model',
+                'cls': A,
+                'schema': {
+                    'type': 'model-fields',
+                    'fields': {'a': {'type': 'model-field', 'schema': {'type': 'bool'}}},
+                    'model_name': 'A',
+                },
+                'custom_init': True,
+                'ref': '__main__.A:4947206928',
+            },
+            {
+                'type': 'model',
+                'cls': B,
+                'schema': {
+                    'type': 'model-fields',
+                    'fields': {'b': {'type': 'model-field', 'schema': {'type': 'bool'}}},
+                    'model_name': 'B',
+                },
+                'custom_init': True,
+                'ref': '__main__.B:4679932848',
+            },
+        ],
+    }
+
+    validator = SchemaValidator(schema)
+
+    assert validator.validate_python({'a': False}).a is False
+    assert validator.validate_python({'b': True}).b is True


### PR DESCRIPTION
## Change Summary

When members of a `Union` have a custom init func defined, ensure that validation works as expected.
Thanks @dmontagu for the suggested fix 🌟 

See issue linked below for more details!

## Related issue number

Fix #https://github.com/pydantic/pydantic/issues/8119

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu