### PR TITLE
Fix validation of negative floats when using `multiple_of`

### DIFF
--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -109,7 +109,7 @@ impl Validator for ConstrainedFloatValidator {
         }
         if let Some(multiple_of) = self.multiple_of {
             let rem = float % multiple_of;
-            let threshold = float / 1e9;
+            let threshold = float.abs() / 1e9;
             if rem.abs() > threshold && (rem - multiple_of).abs() > threshold {
                 return Err(ValError::new(
                     ErrorType::MultipleOf {

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -188,6 +188,7 @@ def test_decimal_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_va
         (0.1, 1, None),
         (0.1, 1.0, None),
         (0.1, int(5e10), None),
+        (2.0, -2.0, None),
     ],
     ids=repr,
 )

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -121,6 +121,7 @@ def test_float_kwargs(py_and_json: PyAndJson, kwargs: Dict[str, Any], input_valu
         (0.1, 1, None),
         (0.1, 1.0, None),
         (0.1, int(5e10), None),
+        (2.0, -2.0, None),
     ],
     ids=repr,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/8154

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
