### PR TITLE
Fix bug with UUID validation from json with a wrap validator

### DIFF
--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -14,7 +14,7 @@ use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
 use super::return_enums::{EitherBytes, EitherInt, EitherString};
 use super::{EitherFloat, GenericArguments, GenericIterable, GenericIterator, GenericMapping, ValidationMatch};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InputType {
     Python,
     Json,

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -8,6 +8,7 @@ use ahash::AHashSet;
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
 use crate::errors::{AsLocItem, ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
+use crate::input::InputType;
 use crate::input::{BorrowInput, GenericArguments, Input, ValidationMatch};
 use crate::lookup_key::LookupKey;
 use crate::tools::SchemaDict;
@@ -535,7 +536,7 @@ impl Validator for DataclassValidator {
             } else {
                 Ok(input.to_object(py))
             }
-        } else if state.strict_or(self.strict) && input.is_python() {
+        } else if state.strict_or(self.strict) && state.extra().input_type == InputType::Python {
             Err(ValError::new(
                 ErrorType::DataclassExactType {
                     class_name: self.get_name().to_string(),

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
+use crate::input::InputType;
 use crate::tools::SchemaDict;
 
 use super::model::create_class;
@@ -108,7 +109,7 @@ impl Validator for UuidValidator {
                 }
             }
             Ok(py_input.to_object(py))
-        } else if state.strict_or(self.strict) && input.is_python() {
+        } else if state.strict_or(self.strict) && state.extra().input_type == InputType::Python {
             Err(ValError::new(
                 ErrorType::IsInstanceOf {
                     class: class.name().unwrap_or("UUID").to_string(),
@@ -118,8 +119,9 @@ impl Validator for UuidValidator {
             ))
         } else {
             // In python mode this is a coercion, in JSON mode we treat a UUID string as an
-            // exact match
-            if input.is_python() {
+            // exact match.
+            // TODO V3: we might want to remove the JSON special case
+            if state.extra().input_type == InputType::Python {
                 state.floor_exactness(Exactness::Lax);
             }
             let uuid = self.get_uuid(input)?;

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -1510,6 +1510,27 @@ def test_dataclass_json():
     ]
 
 
+def test_dataclass_wrap_json():
+    # https://github.com/pydantic/pydantic/issues/8147
+    schema = core_schema.no_info_wrap_validator_function(
+        lambda v, handler: handler(v),
+        core_schema.dataclass_schema(
+            FooDataclass,
+            core_schema.dataclass_args_schema(
+                'FooDataclass',
+                [
+                    core_schema.dataclass_field(name='a', schema=core_schema.str_schema()),
+                    core_schema.dataclass_field(name='b', schema=core_schema.bool_schema()),
+                ],
+            ),
+            ['a', 'b'],
+        ),
+    )
+    v = SchemaValidator(schema)
+    assert v.validate_json('{"a": "hello", "b": true}') == FooDataclass(a='hello', b=True)
+    assert v.validate_json('{"a": "hello", "b": true}', strict=True) == FooDataclass(a='hello', b=True)
+
+
 @pytest.mark.xfail(
     condition=platform.python_implementation() == 'PyPy', reason='https://foss.heptapod.net/pypy/pypy/-/issues/3899'
 )

--- a/tests/validators/test_uuid.py
+++ b/tests/validators/test_uuid.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import pytest
 
-from pydantic_core import SchemaValidator, ValidationError
+from pydantic_core import SchemaValidator, ValidationError, core_schema
 
 from ..conftest import Err, PyAndJson
 
@@ -197,3 +197,16 @@ def test_uuid_copy():
     assert repr(output) == "UUID('a6cc5730-2261-11ee-9c43-2eb5a363657c')"
     assert c == output
     assert isinstance(output, UUID)
+
+
+def test_uuid_wrap_json():
+    # https://github.com/pydantic/pydantic/issues/8147
+    schema = core_schema.no_info_wrap_validator_function(lambda v, handler: handler(v), core_schema.uuid_schema())
+    v = SchemaValidator(schema)
+
+    assert v.validate_python(UUID('a6cc5730-2261-11ee-9c43-2eb5a363657c'), strict=True) == UUID(
+        'a6cc5730-2261-11ee-9c43-2eb5a363657c'
+    )
+    assert v.validate_json('"a6cc5730-2261-11ee-9c43-2eb5a363657c"', strict=True) == UUID(
+        'a6cc5730-2261-11ee-9c43-2eb5a363657c'
+    )


### PR DESCRIPTION
## Change Summary

The wrap validator was changing the input from raw JSON input to a Python `str`, which was then breaking the UUID validator due to check of `input.is_python()` rather than using `InputType` enum.

I noticed the same pattern for dataclasses so I fixed that at the same time.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/8147

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
