### PR TITLE
Remove lifetime from errors

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,7 +6,7 @@ mod types;
 mod validation_exception;
 mod value_exception;
 
-pub use self::line_error::{InputValue, ValError, ValLineError, ValResult};
+pub use self::line_error::{AsErrorValue, InputValue, ValError, ValLineError, ValResult};
 pub use self::location::{AsLocItem, LocItem};
 pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
 pub use self::validation_exception::ValidationError;

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -2,9 +2,10 @@ use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
-use crate::input::{Input, InputType};
+use crate::input::InputType;
 use crate::tools::extract_i64;
 
+use super::line_error::AsErrorValue;
 use super::{ErrorType, ValError};
 
 #[pyclass(extends=PyException, module="pydantic_core._pydantic_core")]
@@ -105,7 +106,7 @@ impl PydanticCustomError {
 }
 
 impl PydanticCustomError {
-    pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
+    pub fn into_val_error(self, input: &impl AsErrorValue) -> ValError {
         let error_type = ErrorType::CustomError {
             error_type: self.error_type,
             message_template: self.message_template,
@@ -184,7 +185,7 @@ impl PydanticKnownError {
 }
 
 impl PydanticKnownError {
-    pub fn into_val_error<'a>(self, input: &'a impl Input<'a>) -> ValError<'a> {
+    pub fn into_val_error(self, input: &impl AsErrorValue) -> ValError {
         ValError::new(self.error_type, input)
     }
 }

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -286,7 +286,7 @@ impl<'a> EitherDateTime<'a> {
     }
 }
 
-pub fn bytes_as_date<'a>(input: &'a impl Input<'a>, bytes: &[u8]) -> ValResult<'a, EitherDate<'a>> {
+pub fn bytes_as_date<'a>(input: &'a impl Input<'a>, bytes: &[u8]) -> ValResult<EitherDate<'a>> {
     match Date::parse_bytes(bytes) {
         Ok(date) => Ok(date.into()),
         Err(err) => Err(ValError::new(
@@ -303,7 +303,7 @@ pub fn bytes_as_time<'a>(
     input: &'a impl Input<'a>,
     bytes: &[u8],
     microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-) -> ValResult<'a, EitherTime<'a>> {
+) -> ValResult<EitherTime<'a>> {
     match Time::parse_bytes_with_config(
         bytes,
         &TimeConfig {
@@ -326,7 +326,7 @@ pub fn bytes_as_datetime<'a, 'b>(
     input: &'a impl Input<'a>,
     bytes: &'b [u8],
     microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-) -> ValResult<'a, EitherDateTime<'a>> {
+) -> ValResult<EitherDateTime<'a>> {
     match DateTime::parse_bytes_with_config(
         bytes,
         &TimeConfig {
@@ -455,7 +455,7 @@ pub fn float_as_time<'a>(input: &'a impl Input<'a>, timestamp: f64) -> ValResult
     int_as_time(input, timestamp.floor() as i64, microseconds.round() as u32)
 }
 
-fn map_timedelta_err<'a>(input: &'a impl Input<'a>, err: ParseError) -> ValError<'a> {
+fn map_timedelta_err<'a>(input: &'a impl Input<'a>, err: ParseError) -> ValError {
     ValError::new(
         ErrorType::TimeDeltaParsing {
             error: Cow::Borrowed(err.get_documentation().unwrap_or_default()),
@@ -469,7 +469,7 @@ pub fn bytes_as_timedelta<'a, 'b>(
     input: &'a impl Input<'a>,
     bytes: &'b [u8],
     microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-) -> ValResult<'a, EitherTimedelta<'a>> {
+) -> ValResult<EitherTimedelta<'a>> {
     match Duration::parse_bytes_with_config(
         bytes,
         &TimeConfig {

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -111,7 +111,7 @@ impl LookupKey {
     pub fn py_get_dict_item<'data, 's>(
         &'s self,
         dict: &'data PyDict,
-    ) -> ValResult<'data, Option<(&'s LookupPath, &'data PyAny)>> {
+    ) -> ValResult<Option<(&'s LookupPath, &'data PyAny)>> {
         match self {
             Self::Simple { py_key, path, .. } => match dict.get_item(py_key)? {
                 Some(value) => Ok(Some((path, value))),
@@ -148,7 +148,7 @@ impl LookupKey {
     pub fn py_get_string_mapping_item<'data, 's>(
         &'s self,
         dict: &'data PyDict,
-    ) -> ValResult<'data, Option<(&'s LookupPath, StringMapping<'data>)>> {
+    ) -> ValResult<Option<(&'s LookupPath, StringMapping<'data>)>> {
         if let Some((path, py_any)) = self.py_get_dict_item(dict)? {
             let value = StringMapping::new_value(py_any)?;
             Ok(Some((path, value)))
@@ -160,7 +160,7 @@ impl LookupKey {
     pub fn py_get_mapping_item<'data, 's>(
         &'s self,
         dict: &'data PyMapping,
-    ) -> ValResult<'data, Option<(&'s LookupPath, &'data PyAny)>> {
+    ) -> ValResult<Option<(&'s LookupPath, &'data PyAny)>> {
         match self {
             Self::Simple { py_key, path, .. } => match dict.get_item(py_key) {
                 Ok(value) => Ok(Some((path, value))),
@@ -198,7 +198,7 @@ impl LookupKey {
         &'s self,
         obj: &'data PyAny,
         kwargs: Option<&'data PyDict>,
-    ) -> ValResult<'data, Option<(&'s LookupPath, &'data PyAny)>> {
+    ) -> ValResult<Option<(&'s LookupPath, &'data PyAny)>> {
         match self._py_get_attr(obj, kwargs) {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -266,7 +266,7 @@ impl LookupKey {
     pub fn json_get<'data, 's>(
         &'s self,
         dict: &'data JsonObject,
-    ) -> ValResult<'data, Option<(&'s LookupPath, &'data JsonValue)>> {
+    ) -> ValResult<Option<(&'s LookupPath, &'data JsonValue)>> {
         match self {
             Self::Simple { key, path, .. } => match dict.get(key) {
                 Some(value) => Ok(Some((path, value))),
@@ -316,7 +316,7 @@ impl LookupKey {
         input: &'d impl Input<'d>,
         loc_by_alias: bool,
         field_name: &str,
-    ) -> ValLineError<'d> {
+    ) -> ValLineError {
         if loc_by_alias {
             let lookup_path = match self {
                 Self::Simple { path, .. } => path,
@@ -369,12 +369,7 @@ impl LookupPath {
         }
     }
 
-    pub fn apply_error_loc<'a>(
-        &self,
-        mut line_error: ValLineError<'a>,
-        loc_by_alias: bool,
-        field_name: &str,
-    ) -> ValLineError<'a> {
+    pub fn apply_error_loc(&self, mut line_error: ValLineError, loc_by_alias: bool, field_name: &str) -> ValLineError {
         if loc_by_alias {
             for path_item in self.iter().rev() {
                 line_error = line_error.with_outer_location(path_item.clone().into());

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -32,7 +32,7 @@ impl Validator for AnyValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         // in a union, Any should be preferred to doing lax coercions
         state.floor_exactness(Exactness::Strict);
         Ok(input.to_object(py))

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -166,7 +166,7 @@ impl Validator for ArgumentsValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let args = input.validate_args()?;
 
         let mut output_args: Vec<PyObject> = Vec::with_capacity(self.positional_params_count);

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -35,7 +35,7 @@ impl Validator for BoolValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
         input

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -45,7 +45,7 @@ impl Validator for BytesValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         input
             .validate_bytes(state.strict_or(self.strict))
             .map(|m| m.unpack(state).into_py(py))
@@ -71,7 +71,7 @@ impl Validator for BytesConstrainedValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let either_bytes = input.validate_bytes(state.strict_or(self.strict))?.unpack(state);
         let len = either_bytes.len()?;
 

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -77,7 +77,7 @@ impl Validator for CallValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let args = self.arguments_validator.validate(py, input, state)?;
 
         let return_value = if let Ok((args, kwargs)) = args.extract::<(&PyTuple, &PyDict)>(py) {

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -30,7 +30,7 @@ impl Validator for CallableValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         state.floor_exactness(Exactness::Lax);
         match input.callable() {
             true => Ok(input.to_object(py)),

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -75,7 +75,7 @@ impl Validator for ChainValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let mut steps_iter = self.steps.iter();
         let first_step = steps_iter.next().unwrap();
         let value = first_step.validate(py, input, state)?;

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -144,7 +144,7 @@ impl Validator for DataclassArgsValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let args = input.validate_dataclass_args(&self.dataclass_name)?;
 
         let output_dict = PyDict::new(py);
@@ -202,8 +202,7 @@ impl Validator for DataclassArgsValidator {
                                             ErrorTypeDefaults::MultipleArgumentValues,
                                             kw_value,
                                             field.name.clone(),
-                                        )
-                                        .into_owned(py),
+                                        ),
                                     );
                                 }
                                 // found a positional argument, validate it
@@ -226,10 +225,9 @@ impl Validator for DataclassArgsValidator {
                                             errors.extend(line_errors.into_iter().map(|err| {
                                                 lookup_path
                                                     .apply_error_loc(err, self.loc_by_alias, &field.name)
-                                                    .into_owned(py)
                                             }));
                                         }
-                                        Err(err) => return Err(err.into_owned(py)),
+                                        Err(err) => return Err(err),
                                     }
                                 }
                                 // found neither, check if there is a default value, otherwise error
@@ -294,8 +292,7 @@ impl Validator for DataclassArgsValidator {
                                                                 ErrorTypeDefaults::UnexpectedKeywordArgument,
                                                                 value,
                                                                 raw_key.as_loc_item(),
-                                                            )
-                                                            .into_owned(py),
+                                                            ),
                                                         );
                                                     }
                                                     ExtraBehavior::Ignore => {}
@@ -375,7 +372,7 @@ impl Validator for DataclassArgsValidator {
         field_name: &'data str,
         field_value: &'data PyAny,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let dict: &PyDict = obj.downcast()?;
 
         let ok = |output: PyObject| {
@@ -518,7 +515,7 @@ impl Validator for DataclassValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if let Some(self_instance) = state.extra().self_instance {
             // in the case that self_instance is Some, we're calling validation from within `BaseModel.__init__`
             return self.validate_init(py, self_instance, input, state);
@@ -560,7 +557,7 @@ impl Validator for DataclassValidator {
         field_name: &'data str,
         field_value: &'data PyAny,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if self.frozen {
             return Err(ValError::new(ErrorTypeDefaults::FrozenInstance, field_value));
         }
@@ -600,7 +597,7 @@ impl DataclassValidator {
         self_instance: &'s PyAny,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on the self_instance
         // instance anymore
         let state = &mut state.rebind_extra(|extra| extra.self_instance = None);
@@ -627,7 +624,7 @@ impl DataclassValidator {
         dc: &PyAny,
         val_output: PyObject,
         input: &'data impl Input<'data>,
-    ) -> ValResult<'data, ()> {
+    ) -> ValResult<()> {
         let (dc_dict, post_init_kwargs): (&PyAny, &PyAny) = val_output.extract(py)?;
         if self.slots {
             let dc_dict: &PyDict = dc_dict.downcast()?;

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -44,7 +44,7 @@ impl Validator for DateValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let date = match input.validate_date(strict) {
             Ok(val_match) => val_match.unpack(state),
@@ -109,7 +109,7 @@ impl Validator for DateValidator {
 /// "exact date", e.g. has a zero time component.
 ///
 /// Ok(None) means that this is not relevant to dates (the input was not a datetime nor a string)
-fn date_from_datetime<'data>(input: &'data impl Input<'data>) -> Result<Option<EitherDate<'data>>, ValError<'data>> {
+fn date_from_datetime<'data>(input: &'data impl Input<'data>) -> Result<Option<EitherDate<'data>>, ValError> {
     let either_dt = match input.validate_datetime(false, speedate::MicrosecondsPrecisionOverflowBehavior::Truncate) {
         Ok(val_match) => val_match.into_inner(),
         // if the error was a parsing error, update the error type from DatetimeParsing to DateFromDatetimeParsing

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -63,7 +63,7 @@ impl Validator for DateTimeValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let datetime = input
             .validate_datetime(strict, self.microseconds_precision)?
@@ -263,7 +263,7 @@ impl TZConstraint {
         }
     }
 
-    pub(super) fn tz_check<'d>(&self, tz_offset: Option<i32>, input: &'d impl Input<'d>) -> ValResult<'d, ()> {
+    pub(super) fn tz_check<'d>(&self, tz_offset: Option<i32>, input: &'d impl Input<'d>) -> ValResult<()> {
         match (self, tz_offset) {
             (TZConstraint::Aware(_), None) => return Err(ValError::new(ErrorTypeDefaults::TimezoneAware, input)),
             (TZConstraint::Aware(Some(tz_expected)), Some(tz_actual)) => {

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -83,11 +83,7 @@ impl_py_gc_traverse!(DecimalValidator {
     gt
 });
 
-fn extract_decimal_digits_info<'data>(
-    decimal: &PyAny,
-    normalized: bool,
-    py: Python<'data>,
-) -> ValResult<'data, (u64, u64)> {
+fn extract_decimal_digits_info(decimal: &PyAny, normalized: bool, py: Python<'_>) -> ValResult<(u64, u64)> {
     let mut normalized_decimal: Option<&PyAny> = None;
     if normalized {
         normalized_decimal = Some(decimal.call_method0(intern!(py, "normalize")).unwrap_or(decimal));
@@ -124,7 +120,7 @@ impl Validator for DecimalValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let decimal = input.validate_decimal(state.strict_or(self.strict), py)?;
 
         if !self.allow_inf_nan || self.check_digits {
@@ -269,11 +265,7 @@ impl Validator for DecimalValidator {
     }
 }
 
-pub(crate) fn create_decimal<'a>(
-    arg: &'a PyAny,
-    input: &'a impl Input<'a>,
-    py: Python<'a>,
-) -> ValResult<'a, &'a PyAny> {
+pub(crate) fn create_decimal<'a>(arg: &'a PyAny, input: &'a impl Input<'a>, py: Python<'a>) -> ValResult<&'a PyAny> {
     let decimal_type_obj: Py<PyType> = get_decimal_type(py);
     decimal_type_obj
         .call1(py, (arg,))
@@ -293,10 +285,10 @@ pub(crate) fn create_decimal<'a>(
 
 fn handle_decimal_new_error<'a>(
     py: Python<'a>,
-    input: InputValue<'a>,
+    input: InputValue,
     error: PyErr,
     decimal_exception: &'a PyAny,
-) -> ValError<'a> {
+) -> ValError {
     if error.matches(py, decimal_exception) {
         ValError::new_custom_input(ErrorTypeDefaults::DecimalParsing, input)
     } else if error.matches(py, PyTypeError::type_object(py)) {

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -72,7 +72,7 @@ impl Validator for DefinitionRefValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let validator = self.definition.get().unwrap();
         if let Some(id) = input.identity() {
             if state.recursion_guard.contains_or_insert(id, self.definition.id()) {
@@ -99,7 +99,7 @@ impl Validator for DefinitionRefValidator {
         field_name: &'data str,
         field_value: &'data PyAny,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let validator = self.definition.get().unwrap();
         if let Some(id) = obj.identity() {
             if state.recursion_guard.contains_or_insert(id, self.definition.id()) {

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -69,7 +69,7 @@ impl Validator for FloatValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         if !self.allow_inf_nan && !either_float.as_f64().is_finite() {
             return Err(ValError::new(ErrorTypeDefaults::FiniteNumber, input));
@@ -101,7 +101,7 @@ impl Validator for ConstrainedFloatValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         let float: f64 = either_float.as_f64();
         if !self.allow_inf_nan && !float.is_finite() {

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -33,7 +33,7 @@ impl Validator for FrozenSetValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let collection = input.validate_frozenset(state.strict_or(self.strict))?;
         let exactness = match &collection {
             GenericIterable::FrozenSet(_) => Exactness::Exact,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -64,7 +64,7 @@ impl Validator for GeneratorValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let iterator = input.validate_iter()?;
         let validator = self.item_validator.as_ref().map(|v| {
             InternalValidator::new(

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -48,7 +48,7 @@ impl Validator for IntValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         input
             .validate_int(state.strict_or(self.strict))
             .map(|val_match| val_match.unpack(state).into_py(py))
@@ -77,7 +77,7 @@ impl Validator for ConstrainedIntValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let either_int = input.validate_int(state.strict_or(self.strict))?.unpack(state);
         let int_value = either_int.as_int()?;
 

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -61,7 +61,7 @@ impl Validator for IsInstanceValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if !input.is_python() {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(
                 "Cannot check isinstance when validating from json, \

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -48,7 +48,7 @@ impl Validator for IsSubclassValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         match input.input_is_subclass(self.class.as_ref(py))? {
             true => Ok(input.to_object(py)),
             false => Err(ValError::new(

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -49,12 +49,12 @@ impl Validator for JsonValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let json_value = input.parse_json()?;
         match self.validator {
             Some(ref validator) => match validator.validate(py, &json_value, state) {
                 Ok(v) => Ok(v),
-                Err(err) => Err(err.into_owned(py)),
+                Err(err) => Err(err),
             },
             None => Ok(json_value.to_object(py)),
         }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -54,7 +54,7 @@ impl Validator for JsonOrPython {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         match state.extra().input_type {
             InputType::Python => self.python.validate(py, input, state),
             _ => self.json.validate(py, input, state),

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -61,7 +61,7 @@ impl Validator for LaxOrStrictValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if state.strict_or(self.strict) {
             self.strict_validator.validate(py, input, state)
         } else {

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -121,7 +121,7 @@ impl Validator for ListValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let seq = input.validate_list(state.strict_or(self.strict))?;
         let exactness = match &seq {
             GenericIterable::List(_) | GenericIterable::JsonArray(_) => Exactness::Exact,

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -95,7 +95,7 @@ impl<T: Debug> LiteralLookup<T> {
         &self,
         py: Python<'data>,
         input: &'data I,
-    ) -> ValResult<'data, Option<(&'data I, &T)>> {
+    ) -> ValResult<Option<(&'data I, &T)>> {
         if let Some(expected_bool) = &self.expected_bool {
             if let Ok(bool_value) = input.validate_bool(true) {
                 if bool_value.into_inner() {
@@ -195,7 +195,7 @@ impl Validator for LiteralValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         match self.lookup.validate(py, input)? {
             Some((_, v)) => Ok(v.clone()),
             None => Err(ValError::new(

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -330,7 +330,7 @@ impl SchemaValidator {
         context: Option<&'data PyAny>,
         self_instance: Option<&PyAny>,
         recursion_guard: &'data mut RecursionGuard,
-    ) -> ValResult<'data, PyObject>
+    ) -> ValResult<PyObject>
     where
         's: 'data,
     {
@@ -701,15 +701,15 @@ pub trait Validator: Send + Sync + Debug {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject>;
+    ) -> ValResult<PyObject>;
 
     /// Get a default value, currently only used by `WithDefaultValidator`
-    fn default_value<'data>(
+    fn default_value(
         &self,
-        _py: Python<'data>,
+        _py: Python<'_>,
         _outer_loc: Option<impl Into<LocItem>>,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, Option<PyObject>> {
+    ) -> ValResult<Option<PyObject>> {
         Ok(None)
     }
 
@@ -722,7 +722,7 @@ pub trait Validator: Send + Sync + Debug {
         _field_name: &'data str,
         _field_value: &'data PyAny,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let py_err = PyTypeError::new_err(format!("validate_assignment is not supported for {}", self.get_name()));
         Err(py_err.into())
     }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -109,7 +109,7 @@ impl Validator for ModelValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if let Some(self_instance) = state.extra().self_instance {
             // in the case that self_instance is Some, we're calling validation from within `BaseModel.__init__`
             return self.validate_init(py, self_instance, input, state);
@@ -157,7 +157,7 @@ impl Validator for ModelValidator {
         field_name: &'data str,
         field_value: &'data PyAny,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if self.frozen {
             return Err(ValError::new(ErrorTypeDefaults::FrozenInstance, field_value));
         } else if self.root_model {
@@ -222,7 +222,7 @@ impl ModelValidator {
         self_instance: &'s PyAny,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on self_instance
         // anymore
         let state = &mut state.rebind_extra(|extra| extra.self_instance = None);
@@ -249,7 +249,7 @@ impl ModelValidator {
         input: &'data impl Input<'data>,
         existing_fields_set: Option<&'data PyAny>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if self.custom_init {
             // If we wanted, we could introspect the __init__ signature, and store the
             // keyword arguments and types, and create a validator for them.
@@ -291,7 +291,7 @@ impl ModelValidator {
         instance: PyObject,
         input: &'data impl Input<'data>,
         extra: &Extra,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if let Some(ref post_init) = self.post_init {
             instance
                 .call_method1(py, post_init.as_ref(py), (extra.context,))

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -123,7 +123,7 @@ impl Validator for ModelFieldsValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
 
@@ -205,11 +205,11 @@ impl Validator for ModelFieldsValidator {
                                     for err in line_errors {
                                         errors.push(
                                             lookup_path.apply_error_loc(err, self.loc_by_alias, &field.name)
-                                            .into_owned(py)
+
                                         );
                                     }
                                 }
-                                Err(err) => return ControlFlow::Break(err.into_owned(py)),
+                                Err(err) => return ControlFlow::Break(err),
                             }
                             continue;
                         }
@@ -258,14 +258,14 @@ impl Validator for ModelFieldsValidator {
                                     errors.push(
                                         err.with_outer_location(raw_key.as_loc_item())
                                             .with_type(ErrorTypeDefaults::InvalidKey)
-                                            .into_owned(py)
+
                                     );
                                 }
                                 continue;
                             }
-                            Err(err) => return Err(err.into_owned(py)),
+                            Err(err) => return Err(err),
                         };
-                        let cow = either_str.as_cow().map_err(|err| err.into_owned(py))?;
+                        let cow = either_str.as_cow().map_err(|err| err)?;
                         if used_keys.contains(cow.as_ref()) {
                             continue;
                         }
@@ -280,7 +280,7 @@ impl Validator for ModelFieldsValidator {
                                         value,
                                         raw_key.as_loc_item(),
                                     )
-                                    .into_owned(py)
+
                                 );
                             }
                             ExtraBehavior::Ignore => {}
@@ -294,10 +294,10 @@ impl Validator for ModelFieldsValidator {
                                         }
                                         Err(ValError::LineErrors(line_errors)) => {
                                             for err in line_errors {
-                                                errors.push(err.with_outer_location(raw_key.as_loc_item()).into_owned(py));
+                                                errors.push(err.with_outer_location(raw_key.as_loc_item()));
                                             }
                                         }
-                                        Err(err) => return Err(err.into_owned(py)),
+                                        Err(err) => return Err(err),
                                     }
                                 } else {
                                     model_extra_dict.set_item(py_key, value.to_object(py))?;
@@ -342,7 +342,7 @@ impl Validator for ModelFieldsValidator {
         field_name: &'data str,
         field_value: &'data PyAny,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let dict: &PyDict = obj.downcast()?;
 
         let get_updated_dict = |output: PyObject| {
@@ -350,7 +350,7 @@ impl Validator for ModelFieldsValidator {
             Ok(dict)
         };
 
-        let prepare_result = |result: ValResult<'data, PyObject>| match result {
+        let prepare_result = |result: ValResult<PyObject>| match result {
             Ok(output) => get_updated_dict(output),
             Err(ValError::LineErrors(line_errors)) => {
                 let errors = line_errors

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -29,7 +29,7 @@ impl Validator for NoneValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         _state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         match input.is_none() {
             true => Ok(py.None()),
             false => Err(ValError::new(ErrorTypeDefaults::NoneRequired, input)),

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -38,7 +38,7 @@ impl Validator for NullableValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         match input.is_none() {
             true => Ok(py.None()),
             false => self.validator.validate(py, input, state),

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -63,7 +63,7 @@ impl Validator for SetValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let collection = input.validate_set(state.strict_or(self.strict))?;
         let exactness = match &collection {
             GenericIterable::Set(_) => Exactness::Exact,

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -46,7 +46,7 @@ impl Validator for StrValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)
             .map(|val_match| val_match.unpack(state).into_py(py))
@@ -78,7 +78,7 @@ impl Validator for StrConstrainedValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let either_str = input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)?
             .unpack(state);

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -45,7 +45,7 @@ impl Validator for TimeValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let time = input
             .validate_time(state.strict_or(self.strict), self.microseconds_precision)?
             .unpack(state);

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -70,7 +70,7 @@ impl Validator for TimeDeltaValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let timedelta = input
             .validate_timedelta(state.strict_or(self.strict), self.microseconds_precision)?
             .unpack(state);

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -50,7 +50,7 @@ impl Validator for TupleVariableValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let seq = input.validate_tuple(state.strict_or(self.strict))?;
         let exactness = match &seq {
             GenericIterable::Tuple(_) | GenericIterable::JsonArray(_) => Exactness::Exact,
@@ -118,12 +118,12 @@ fn validate_tuple_positional<'s, 'data, T: Iterator<Item = PyResult<&'data I>>, 
     input: &'data impl Input<'data>,
     state: &mut ValidationState,
     output: &mut Vec<PyObject>,
-    errors: &mut Vec<ValLineError<'data>>,
+    errors: &mut Vec<ValLineError>,
     extras_validator: &Option<Box<CombinedValidator>>,
     items_validators: &[CombinedValidator],
     collection_iter: &mut T,
     actual_length: Option<usize>,
-) -> ValResult<'data, ()> {
+) -> ValResult<()> {
     for (index, validator) in items_validators.iter().enumerate() {
         match collection_iter.next() {
             Some(result) => match validator.validate(py, result?, state) {
@@ -186,7 +186,7 @@ impl Validator for TuplePositionalValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let collection = input.validate_tuple(state.strict_or(self.strict))?;
         let exactness: crate::validators::Exactness = match &collection {
             GenericIterable::Tuple(_) | GenericIterable::JsonArray(_) => Exactness::Exact,

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -148,7 +148,7 @@ impl Validator for TypedDictValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;
 
@@ -205,11 +205,10 @@ impl Validator for TypedDictValidator {
                                         errors.push(
                                             lookup_path
                                             .apply_error_loc(err, self.loc_by_alias, &field.name)
-                                            .into_owned(py)
                                         );
                                     }
                                 }
-                                Err(err) => return ControlFlow::Break(err.into_owned(py)),
+                                Err(err) => return ControlFlow::Break(err),
                             }
                             continue;
                         }
@@ -259,14 +258,14 @@ impl Validator for TypedDictValidator {
                                     errors.push(
                                         err.with_outer_location(raw_key.as_loc_item())
                                             .with_type(ErrorTypeDefaults::InvalidKey)
-                                            .into_owned(py)
+
                                     );
                                 }
                                 continue;
                             }
-                            Err(err) => return Err(err.into_owned(py)),
+                            Err(err) => return Err(err),
                         };
-                        let cow = either_str.as_cow().map_err(|err| err.into_owned(py))?;
+                        let cow = either_str.as_cow().map_err(|err| err)?;
                         if used_keys.contains(cow.as_ref()) {
                             continue;
                         }
@@ -281,7 +280,7 @@ impl Validator for TypedDictValidator {
                                         value,
                                         raw_key.as_loc_item(),
                                     )
-                                    .into_owned(py)
+
                                 );
                             }
                             ExtraBehavior::Ignore => {}
@@ -297,11 +296,11 @@ impl Validator for TypedDictValidator {
                                                 errors.push(
                                                     err
                                                     .with_outer_location(raw_key.as_loc_item())
-                                                    .into_owned(py)
+
                                                 );
                                             }
                                         }
-                                        Err(err) => return Err(err.into_owned(py)),
+                                        Err(err) => return Err(err),
                                     }
                                 } else {
                                     output_dict.set_item(py_key, value.to_object(py))?;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -90,7 +90,7 @@ impl Validator for UuidValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         let class = get_uuid_type(py)?;
         if let Some(py_input) = input.input_is_instance(class) {
             if let Some(expected_version) = self.version {
@@ -135,7 +135,7 @@ impl Validator for UuidValidator {
 }
 
 impl UuidValidator {
-    fn get_uuid<'s, 'data>(&'s self, input: &'data impl Input<'data>) -> ValResult<'data, Uuid> {
+    fn get_uuid<'s, 'data>(&'s self, input: &'data impl Input<'data>) -> ValResult<Uuid> {
         let uuid = match input.exact_str().ok() {
             Some(either_string) => {
                 let cow = either_string.as_cow()?;
@@ -198,7 +198,7 @@ impl UuidValidator {
     ///
     /// This implementation does not use the Python `__init__` function to speed up the process,
     /// as the `__init__` function in the Python `uuid` module performs extensive checks.
-    fn create_py_uuid<'py>(&self, py: Python<'py>, py_type: &PyType, uuid: &Uuid) -> ValResult<'py, Py<PyAny>> {
+    fn create_py_uuid(&self, py: Python<'_>, py_type: &PyType, uuid: &Uuid) -> ValResult<Py<PyAny>> {
         let class = create_class(py_type)?;
         let dc = class.as_ref(py);
         let int = uuid.as_u128();

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -131,7 +131,7 @@ impl Validator for WithDefaultValidator {
         py: Python<'data>,
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, PyObject> {
+    ) -> ValResult<PyObject> {
         if input.to_object(py).is(&PydanticUndefinedType::py_undefined()) {
             Ok(self.default_value(py, None::<usize>, state)?.unwrap())
         } else {
@@ -149,12 +149,12 @@ impl Validator for WithDefaultValidator {
         }
     }
 
-    fn default_value<'data>(
+    fn default_value(
         &self,
-        py: Python<'data>,
+        py: Python<'_>,
         outer_loc: Option<impl Into<LocItem>>,
         state: &mut ValidationState,
-    ) -> ValResult<'data, Option<PyObject>> {
+    ) -> ValResult<Option<PyObject>> {
         match self.default.default_value(py)? {
             Some(stored_dft) => {
                 let dft: Py<PyAny> = if self.copy_default {


### PR DESCRIPTION
## Change Summary

Working on integrating the upcoming PyO3 API into `pydantic-core`, in the short term I'm having to lean into the `BorrowInput` trait more. There's a lot of pain with respect to lifetimes, especially in the error branches.

This bins off the lifetime in `ValError`, which will make the problem much simpler.

The only meaningful performance change this will introduce is that we'll now copy string inputs instead of borrow them. In the long term we can find a better solution to this once we've done the PyO3 churn.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu