### PR TITLE
Don't build dummy objects when populating `ObTypeLookup`

### DIFF
--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -59,29 +59,26 @@ pub enum IsType {
 
 impl ObTypeLookup {
     fn new(py: Python) -> Self {
-        let lib_url = url::Url::parse("https://example.com").unwrap();
         Self {
             none: py.None().as_ref(py).get_type_ptr() as usize,
-            int: 0i32.into_py(py).as_ref(py).get_type_ptr() as usize,
-            bool: true.into_py(py).as_ref(py).get_type_ptr() as usize,
-            float: 0f32.into_py(py).as_ref(py).get_type_ptr() as usize,
-            list: PyList::empty(py).get_type_ptr() as usize,
-            dict: PyDict::new(py).get_type_ptr() as usize,
+            int: PyInt::type_object_raw(py) as usize,
+            bool: PyBool::type_object_raw(py) as usize,
+            float: PyFloat::type_object_raw(py) as usize,
+            list: PyList::type_object_raw(py) as usize,
+            dict: PyDict::type_object_raw(py) as usize,
             decimal_object: py.import("decimal").unwrap().getattr("Decimal").unwrap().to_object(py),
-            string: PyString::new(py, "s").get_type_ptr() as usize,
-            bytes: PyBytes::new(py, b"s").get_type_ptr() as usize,
-            bytearray: PyByteArray::new(py, b"s").get_type_ptr() as usize,
-            tuple: PyTuple::empty(py).get_type_ptr() as usize,
-            set: PySet::empty(py).unwrap().get_type_ptr() as usize,
-            frozenset: PyFrozenSet::empty(py).unwrap().get_type_ptr() as usize,
-            datetime: PyDateTime::new(py, 2000, 1, 1, 0, 0, 0, 0, None)
-                .unwrap()
-                .get_type_ptr() as usize,
-            date: PyDate::new(py, 2000, 1, 1).unwrap().get_type_ptr() as usize,
-            time: PyTime::new(py, 0, 0, 0, 0, None).unwrap().get_type_ptr() as usize,
-            timedelta: PyDelta::new(py, 0, 0, 0, false).unwrap().get_type_ptr() as usize,
-            url: PyUrl::new(lib_url.clone()).into_py(py).as_ref(py).get_type_ptr() as usize,
-            multi_host_url: PyMultiHostUrl::new(lib_url, None).into_py(py).as_ref(py).get_type_ptr() as usize,
+            string: PyString::type_object_raw(py) as usize,
+            bytes: PyBytes::type_object_raw(py) as usize,
+            bytearray: PyByteArray::type_object_raw(py) as usize,
+            tuple: PyTuple::type_object_raw(py) as usize,
+            set: PySet::type_object_raw(py) as usize,
+            frozenset: PyFrozenSet::type_object_raw(py) as usize,
+            datetime: PyDateTime::type_object_raw(py) as usize,
+            date: PyDate::type_object_raw(py) as usize,
+            time: PyTime::type_object_raw(py) as usize,
+            timedelta: PyDelta::type_object_raw(py) as usize,
+            url: PyUrl::type_object_raw(py) as usize,
+            multi_host_url: PyMultiHostUrl::type_object_raw(py) as usize,
             enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().to_object(py),
             generator_object: py
                 .import("types")


### PR DESCRIPTION
## Change Summary

Slight simplification that I noticed while working on #1085.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin