### PR TITLE
Fix typo in is_instance_schema docstring

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1196,7 +1196,7 @@ def is_instance_schema(
     serialization: SerSchema | None = None,
 ) -> IsInstanceSchema:
     """
-    Returns a schema that checks if a value is an instance of a class, equivalent to python's `isinstnace` method, e.g.:
+    Returns a schema that checks if a value is an instance of a class, equivalent to python's `isinstance` method, e.g.:
 
     ```py
     from pydantic_core import SchemaValidator, core_schema


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary
Just a quick typo fix in the docstring of the is_instance_schema function.

<!-- Please give a short summary of the changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb