### PR TITLE
Remove needless uses of `PyString::intern`

### DIFF
--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -39,7 +39,7 @@ impl BuildSerializer for DataclassArgsBuilder {
             let field_info: &PyDict = item.downcast()?;
             let name: String = field_info.get_as_req(intern!(py, "name"))?;
 
-            let key_py: Py<PyString> = PyString::intern(py, &name).into_py(py);
+            let key_py: Py<PyString> = PyString::new(py, &name).into_py(py);
 
             if field_info.get_as(intern!(py, "serialization_exclude"))? == Some(true) {
                 fields.insert(name, SerField::new(py, key_py, None, None, true));

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -73,7 +73,7 @@ impl BuildValidator for ArgumentsValidator {
                     }
                     None => Some(LookupKey::from_string(py, &name)),
                 };
-                kwarg_key = Some(PyString::intern(py, &name).into());
+                kwarg_key = Some(PyString::new(py, &name).into());
             }
 
             let schema: &PyAny = arg.get_as_req(intern!(py, "schema"))?;

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -477,7 +477,7 @@ impl BuildValidator for DataclassValidator {
         let validator = build_validator(sub_schema, config, definitions)?;
 
         let post_init = if schema.get_as::<bool>(intern!(py, "post_init"))?.unwrap_or(false) {
-            Some(PyString::intern(py, "__post_init__").into_py(py))
+            Some(PyString::new(py, "__post_init__").into_py(py))
         } else {
             None
         };

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -89,7 +89,7 @@ impl BuildValidator for ModelValidator {
             class: class.into(),
             post_init: schema
                 .get_as::<&str>(intern!(py, "post_init"))?
-                .map(|s| PyString::intern(py, s).into_py(py)),
+                .map(|s| PyString::new(py, s).into_py(py)),
             frozen: schema.get_as(intern!(py, "frozen"))?.unwrap_or(false),
             custom_init: schema.get_as(intern!(py, "custom_init"))?.unwrap_or(false),
             root_model: schema.get_as(intern!(py, "root_model"))?.unwrap_or(false),

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -93,7 +93,7 @@ impl BuildValidator for ModelFieldsValidator {
             fields.push(Field {
                 name: field_name.to_string(),
                 lookup_key,
-                name_py: PyString::intern(py, field_name).into(),
+                name_py: PyString::new(py, field_name).into(),
                 validator,
                 frozen: field_info.get_as::<bool>(intern!(py, "frozen"))?.unwrap_or(false),
             });

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -120,7 +120,7 @@ impl BuildValidator for TypedDictValidator {
             fields.push(TypedDictField {
                 name: field_name.to_string(),
                 lookup_key,
-                name_py: PyString::intern(py, field_name).into(),
+                name_py: PyString::new(py, field_name).into(),
                 validator,
                 required,
             });


### PR DESCRIPTION
## Change Summary

While working on #1085 I noticed that we have some calls to `PyString::intern` in the validator build step. This isn't great; it's plain and simple a memory leak because:
- These strings are already held onto by the validators, no need to intern them
- Interning them means they will outlive the validators if they're destroyed

It's only a very minor issue, as validator build normally happens only on startup, but still worth cleaning up.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu