### PR TITLE
Avoid using `?` with `get_item` to handle unhashable inputs properly

### DIFF
--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -136,9 +136,9 @@ impl<T: Debug> LiteralLookup<T> {
         }
         // must be an enum or bytes
         if let Some(expected_py) = &self.expected_py {
-            // We don't use ? to unpack the result of get_item in the next line because unhashable
-            // inputs will produce a TypeError, which in this case we just want to treat as a
-            // validation failure
+            // We don't use ? to unpack the result of `get_item` in the next line because unhashable
+            // inputs will produce a TypeError, which in this case we just want to treat equivalently
+            // to a failed lookup
             if let Ok(Some(v)) = expected_py.as_ref(py).get_item(input) {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -136,7 +136,10 @@ impl<T: Debug> LiteralLookup<T> {
         }
         // must be an enum or bytes
         if let Some(expected_py) = &self.expected_py {
-            if let Some(v) = expected_py.as_ref(py).get_item(input)? {
+            // We don't use ? to unpack the result of get_item in the next line because unhashable
+            // inputs will produce a TypeError, which in this case we just want to treat as a
+            // validation failure
+            if let Ok(Some(v)) = expected_py.as_ref(py).get_item(input) {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));
             }

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -771,3 +771,32 @@ def test_int_not_coerced_to_enum():
     assert validator.validate_python(1) is not BinaryEnum.ONE
     assert validator.validate_python(BinaryEnum.ZERO) is BinaryEnum.ZERO
     assert validator.validate_python(BinaryEnum.ONE) is BinaryEnum.ONE
+
+
+def test_model_and_literal_union() -> None:
+    # see https://github.com/pydantic/pydantic/issues/8183
+    class ModelA:
+        pass
+
+    validator = SchemaValidator(
+        {
+            'type': 'union',
+            'choices': [
+                {
+                    'type': 'model',
+                    'cls': ModelA,
+                    'schema': {
+                        'type': 'model-fields',
+                        'fields': {
+                            'a': {'type': 'model-field', 'schema': {'type': 'int'}},
+                        },
+                    },
+                },
+                {'type': 'literal', 'expected': [True]},
+            ],
+        }
+    )
+
+    # should raise ValidationError for Literal check, not TypeError
+    assert validator.validate_python({'a': 42})
+    assert validator.validate_python(True)

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -799,5 +799,7 @@ def test_model_and_literal_union() -> None:
 
     # validation against Literal[True] fails bc of the unhashable dict
     # A ValidationError is raised, not a ValueError, which allows the validation against the union to continue
-    assert validator.validate_python({'a': 42})
-    assert validator.validate_python(True)
+    m = validator.validate_python({'a': 42})
+    assert isinstance(m, ModelA)
+    assert m.a == 42
+    assert validator.validate_python(True) is True

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -797,6 +797,7 @@ def test_model_and_literal_union() -> None:
         }
     )
 
-    # should raise ValidationError for Literal check, not TypeError
+    # validation against Literal[True] fails bc of the unhashable dict
+    # A ValidationError is raised, not a ValueError, which allows the validation against the union to continue
     assert validator.validate_python({'a': 42})
     assert validator.validate_python(True)


### PR DESCRIPTION
## Change Summary

Avoid using `?` to unpack the result of `get_item` in the case where unhashable inputs would produce a TypeError which bubbles all of the way up. We would want to treat this instead just like a ValidationError.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8183

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
