### PR TITLE
Correct deprecation message for general_after_validator_function

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3862,7 +3862,7 @@ def field_after_validator_function(function: WithInfoValidatorFunction, field_na
 @deprecated('`general_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.')
 def general_after_validator_function(*args, **kwargs):
     warnings.warn(
-        '`with_info_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.',
+        '`general_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.',
         DeprecationWarning,
     )
     return with_info_after_validator_function(*args, **kwargs)


### PR DESCRIPTION
## Change Summary

Fix this deprecation message added in #980, which had confusing copy-pasta.

(Discovered from encountering this warning from django-ninja: https://github.com/vitalik/django-ninja/issues/920 .)

## Related issue number

n/a

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt