### PR TITLE
support newest jiter behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,8 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 [[package]]
 name = "jiter"
 version = "0.0.5"
-source = "git+https://github.com/pydantic/jiter?branch=python-JsonResult#70db0e6783eb029f0e3f3ad284be389989192231"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e184598fea113663dd78e33a24ad3a1e7ba8ceedf71effb7406b3f2eccb63ed1"
 dependencies = [
  "ahash",
  "lexical-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,8 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jiter"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27d419c535bf7b50ad355278b1159cbf0cc8d507ea003d625b17bf0375720b8"
+version = "0.0.5"
+source = "git+https://github.com/pydantic/jiter?branch=python-JsonResult#70db0e6783eb029f0e3f3ad284be389989192231"
 dependencies = [
  "ahash",
  "lexical-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ base64 = "0.21.5"
 num-bigint = "0.4.4"
 python3-dll-a = "0.2.7"
 uuid = "1.5.0"
-jiter = {version = "0.0.4", features = ["python"]}
+#jiter = {version = "0.0.4", features = ["python"]}
+jiter = { git = "https://github.com/pydantic/jiter", branch = "python-JsonResult", version = "0.0.5", features = ["python"]}
 #jiter = {path = "../jiter", features = ["python"]}
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,7 @@ base64 = "0.21.5"
 num-bigint = "0.4.4"
 python3-dll-a = "0.2.7"
 uuid = "1.5.0"
-#jiter = {version = "0.0.4", features = ["python"]}
-jiter = { git = "https://github.com/pydantic/jiter", branch = "python-JsonResult", version = "0.0.5", features = ["python"]}
-#jiter = {path = "../jiter", features = ["python"]}
+jiter = {version = "0.0.5", features = ["python"]}
 
 [lib]
 name = "_pydantic_core"

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -385,7 +385,7 @@ def to_json(
        JSON bytes.
     """
 
-def from_json(data: str | bytes | bytearray, *, allow_inf_nan: bool = True) -> Any:
+def from_json(data: str | bytes | bytearray, *, allow_inf_nan: bool = True, cache_strings: bool = True) -> Any:
     """
     Deserialize JSON data to a Python object.
 
@@ -394,6 +394,8 @@ def from_json(data: str | bytes | bytearray, *, allow_inf_nan: bool = True) -> A
     Arguments:
         data: The JSON data to deserialize.
         allow_inf_nan: Whether to allow `Infinity`, `-Infinity` and `NaN` values as `json.loads()` does by default.
+        cache_strings: Whether to cache strings to avoid constructing new Python objects,
+            this should have a significant impact on performance while increasing memory usage slightly.
 
     Raises:
         ValueError: If deserialization fails.

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -4,8 +4,6 @@ use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyDict, PyType};
 use pyo3::{intern, prelude::*};
 
-use jiter::JsonValue;
-
 use crate::errors::{AsLocItem, ErrorTypeDefaults, InputValue, ValError, ValResult};
 use crate::tools::py_err;
 use crate::{PyMultiHostUrl, PyUrl};
@@ -88,8 +86,6 @@ pub trait Input<'a>: fmt::Debug + ToPyObject + AsLocItem + Sized {
     fn validate_args(&'a self) -> ValResult<GenericArguments<'a>>;
 
     fn validate_dataclass_args(&'a self, dataclass_name: &str) -> ValResult<GenericArguments<'a>>;
-
-    fn parse_json(&'a self) -> ValResult<JsonValue>;
 
     fn validate_str(
         &'a self,

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -14,7 +14,7 @@ use super::datetime::{
     float_as_time, int_as_datetime, int_as_duration, int_as_time, EitherDate, EitherDateTime, EitherTime,
 };
 use super::return_enums::ValidationMatch;
-use super::shared::{float_as_int, int_as_bool, map_json_err, str_as_bool, str_as_float, str_as_int};
+use super::shared::{float_as_int, int_as_bool, str_as_bool, str_as_float, str_as_int};
 use super::{
     BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericArguments, GenericIterable,
     GenericIterator, GenericMapping, Input, JsonArgs,
@@ -81,13 +81,6 @@ impl<'a> Input<'a> for JsonValue {
                     self,
                 ))
             }
-        }
-    }
-
-    fn parse_json(&'a self) -> ValResult<JsonValue> {
-        match self {
-            JsonValue::Str(s) => JsonValue::parse(s.as_bytes(), true).map_err(|e| map_json_err(self, e)),
-            _ => Err(ValError::new(ErrorTypeDefaults::JsonType, self)),
         }
     }
 
@@ -365,10 +358,6 @@ impl<'a> Input<'a> for String {
             },
             self,
         ))
-    }
-
-    fn parse_json(&'a self) -> ValResult<JsonValue> {
-        JsonValue::parse(self.as_bytes(), true).map_err(|e| map_json_err(self, e))
     }
 
     fn validate_str(

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
-use jiter::JsonValue;
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 
 use crate::errors::{AsLocItem, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
@@ -12,7 +11,7 @@ use crate::validators::decimal::create_decimal;
 use super::datetime::{
     bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, EitherDate, EitherDateTime, EitherTime,
 };
-use super::shared::{map_json_err, str_as_bool, str_as_float};
+use super::shared::{str_as_bool, str_as_float};
 use super::{
     BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericArguments, GenericIterable,
     GenericIterator, GenericMapping, Input, ValidationMatch,
@@ -83,16 +82,6 @@ impl<'a> Input<'a> for StringMapping<'a> {
         match self {
             StringMapping::String(_) => Err(ValError::new(ErrorTypeDefaults::ArgumentsType, self)),
             StringMapping::Mapping(m) => Ok(GenericArguments::StringMapping(m)),
-        }
-    }
-
-    fn parse_json(&'a self) -> ValResult<JsonValue> {
-        match self {
-            Self::String(s) => {
-                let str = py_string_str(s)?;
-                JsonValue::parse(str.as_bytes(), true).map_err(|e| map_json_err(self, e))
-            }
-            Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::JsonType, self)),
         }
     }
 

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -1,10 +1,9 @@
 use pyo3::sync::GILOnceCell;
 use pyo3::{intern, Py, PyAny, Python, ToPyObject};
 
-use jiter::JsonValueError;
 use num_bigint::BigInt;
 
-use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
+use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 
 use super::{EitherFloat, EitherInt, Input};
 static ENUM_META_OBJECT: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
@@ -18,16 +17,6 @@ pub fn get_enum_meta_object(py: Python) -> Py<PyAny> {
                 .to_object(py)
         })
         .clone()
-}
-
-pub fn map_json_err<'a>(input: &'a impl Input<'a>, error: JsonValueError) -> ValError {
-    ValError::new(
-        ErrorType::JsonInvalid {
-            error: error.to_string(),
-            context: None,
-        },
-        input,
-    )
 }
 
 pub fn str_as_bool<'a>(input: &'a impl Input<'a>, str: &str) -> ValResult<bool> {

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -2,8 +2,10 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::errors::ValResult;
-use crate::input::Input;
+use jiter::JsonValue;
+
+use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
+use crate::input::{EitherBytes, Input, ValidationMatch};
 use crate::tools::SchemaDict;
 
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
@@ -50,17 +52,52 @@ impl Validator for JsonValidator {
         input: &'data impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
-        let json_value = input.parse_json()?;
+        let v_match = validate_json_bytes(input)?;
+        let json_either_bytes = v_match.unpack(state);
+        let json_bytes = json_either_bytes.as_slice();
         match self.validator {
-            Some(ref validator) => match validator.validate(py, &json_value, state) {
-                Ok(v) => Ok(v),
-                Err(err) => Err(err),
-            },
-            None => Ok(json_value.to_object(py)),
+            Some(ref validator) => {
+                let json_value = JsonValue::parse(json_bytes, true).map_err(|e| map_json_err(input, e, json_bytes))?;
+                validator.validate(py, &json_value, state)
+            }
+            None => {
+                let obj =
+                    jiter::python_parse(py, json_bytes, true, true).map_err(|e| map_json_err(input, e, json_bytes))?;
+                Ok(obj)
+            }
         }
     }
 
     fn get_name(&self) -> &str {
         &self.name
     }
+}
+
+pub fn validate_json_bytes<'data>(input: &'data impl Input<'data>) -> ValResult<ValidationMatch<EitherBytes<'data>>> {
+    match input.validate_bytes(false) {
+        Ok(v_match) => Ok(v_match),
+        Err(ValError::LineErrors(e)) => Err(ValError::LineErrors(
+            e.into_iter().map(map_bytes_error).collect::<Vec<_>>(),
+        )),
+        Err(e) => Err(e),
+    }
+}
+
+fn map_bytes_error(line_error: ValLineError) -> ValLineError {
+    match line_error.error_type {
+        ErrorType::BytesType { .. } => {
+            ValLineError::new_custom_input(ErrorTypeDefaults::JsonType, line_error.input_value)
+        }
+        _ => line_error,
+    }
+}
+
+pub fn map_json_err<'a>(input: &'a impl Input<'a>, error: jiter::JsonError, json_bytes: &[u8]) -> ValError {
+    ValError::new(
+        ErrorType::JsonInvalid {
+            error: error.description(json_bytes),
+            context: None,
+        },
+        input,
+    )
 }

--- a/tests/validators/test_json.py
+++ b/tests/validators/test_json.py
@@ -48,36 +48,40 @@ def test_any(py_and_json: PyAndJson, input_value, expected):
 @pytest.mark.parametrize(
     'input_value,expected',
     [
-        ('{"a": 1}', {'a': 1}),
-        (b'{"a": 1}', {'a': 1}),
-        (
+        pytest.param('{"a": 1}', {'a': 1}, id='str'),
+        pytest.param(b'{"a": 1}', {'a': 1}, id='bytes'),
+        pytest.param(
             '🐈 Hello \ud800World',
             Err(
                 'Input should be a valid string, unable to parse raw data as a unicode string '
                 "[type=string_unicode, input_value='🐈 Hello \\ud800World', input_type=str]"
             ),
+            id='str_unicode',
         ),
-        (bytearray(b'{"a": 1}'), {'a': 1}),
-        (
+        pytest.param(bytearray(b'{"a": 1}'), {'a': 1}, id='bytearray'),
+        pytest.param(
             'xx',
             Err(
                 'Invalid JSON: expected value at line 1 column 1 '
                 "[type=json_invalid, input_value='xx', input_type=str]"
             ),
+            id='str_invalid',
         ),
-        (
+        pytest.param(
             b'xx',
             Err(
                 'Invalid JSON: expected value at line 1 column 1 '
                 "[type=json_invalid, input_value=b'xx', input_type=bytes]"
             ),
+            id='bytes_invalid',
         ),
-        (
+        pytest.param(
             bytearray(b'xx'),
             Err(
                 'Invalid JSON: expected value at line 1 column 1 '
                 "[type=json_invalid, input_value=bytearray(b'xx'), input_type=bytearray]"
             ),
+            id='bytearray_invalid',
         ),
     ],
 )


### PR DESCRIPTION
* use the newest jiter with support for string caching
* use jiter's `python_parse` to parse python when there's no validator, this should make JSON validation for `Any` fields significantly faster