### PR TITLE
Prevent panicking when `__dict__` changes during iteration

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -165,9 +165,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
             model: extra.model.map_or_else(|| Some(value), Some),
             ..*extra
         };
-        let (main_dict, extra_dict) = if let Some(main_extra_dict) = self.extract_dicts(value) {
-            main_extra_dict
-        } else {
+        let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
             td_extra.warnings.on_fallback_py(self.get_name(), value, &td_extra)?;
             return infer_to_python(value, include, exclude, &td_extra);
         };


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Gather the items of `__dict__` into a vector before iterating during serialization, so that modifications to the `__dict__` in the process (e.g. from a `@cached_property` called by a field serializer) don't cause iteration to panic.

Plus some very minor and totally optional refactoring.

## Related issue number

FIxes https://github.com/pydantic/pydantic/issues/7832

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
