### PR TITLE
bump pandas tests to run on 3.12

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,9 @@
 coverage==7.2.7
 dirty-equals==0.6.0
 hypothesis==6.79.4
+# TODO: remove manual override for dateutil once a version newer than 2.8.2 is
+# released which removes use of deprecated utcfromtimestamp
+git+https://github.com/dateutil/dateutil.git@f2293200747fb03d56c6c5997bfebeabe703576f
 # pandas doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
 pandas==2.1.3; python_version >= "3.9" and python_version < "3.13" and implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest==7.4.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ coverage==7.2.7
 dirty-equals==0.6.0
 hypothesis==6.79.4
 # pandas doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
-pandas==2.0.3; python_version >= "3.9" and python_version < "3.12" and implementation_name == "cpython" and platform_machine == 'x86_64'
+pandas==2.1.3; python_version >= "3.9" and python_version < "3.13" and implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest==7.4.3
 # we run codspeed benchmarks on x86_64 CPython (i.e. native github actions architecture)
 pytest-codspeed~=2.2.0; implementation_name == "cpython" and platform_machine == 'x86_64'
@@ -13,5 +13,5 @@ pytest-pretty==1.2.0
 pytest-timeout==2.2.0
 pytz==2023.3.post1
 # numpy doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
-numpy==1.25.2; python_version >= "3.9" and python_version < "3.12" and implementation_name == "cpython" and platform_machine == 'x86_64'
+numpy==1.26.2; python_version >= "3.9" and python_version < "3.13" and implementation_name == "cpython" and platform_machine == 'x86_64'
 exceptiongroup==1.1; python_version < "3.11"


### PR DESCRIPTION
## Change Summary

Because it's now possible to run pandas on 3.12 tests, we should! Also this will be useful for me locally to debug the pandas failures in #1085 

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
