### PR TITLE
Fixing `exclude_none` for json serialization of `computed_field`s

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -73,6 +73,10 @@ impl ComputedFields {
         }
         for computed_field in &self.0 {
             let property_name_py = computed_field.property_name_py.as_ref(model.py());
+            let value = model.getattr(property_name_py).map_err(py_err_se_err)?;
+            if extra.exclude_none && value.is_none() {
+                return Ok(());
+            }
             if let Some((next_include, next_exclude)) = filter
                 .key_filter(property_name_py, include, exclude)
                 .map_err(py_err_se_err)?

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -608,7 +608,7 @@ def test_property_alias():
     assert s.to_json(Model(3, 4)) == b'{"width":3,"height":4,"Area":12,"volume":48}'
 
 
-def test_computed_field_to_python_exclude_none():
+def test_computed_field_exclude_none():
     @dataclasses.dataclass
     class Model:
         width: int
@@ -646,6 +646,8 @@ def test_computed_field_to_python_exclude_none():
         'volume': None,
     }
     assert s.to_python(Model(3, 4), mode='json', exclude_none=True) == {'width': 3, 'height': 4, 'Area': 12}
+    assert s.to_json(Model(3, 4), exclude_none=False) == b'{"width":3,"height":4,"Area":12,"volume":null}'
+    assert s.to_json(Model(3, 4), exclude_none=True) == b'{"width":3,"height":4,"Area":12}'
 
 
 @pytest.mark.skipif(cached_property is None, reason='cached_property is not available')


### PR DESCRIPTION
## Change Summary

Make sure when serializing to json, `exclude_none` takes effect on computed fields.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8250

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
