### PR TITLE
Fix memory leak caused by not visiting the function in a CallValidator during gc

### DIFF
--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -67,6 +67,7 @@ impl BuildValidator for CallValidator {
 }
 
 impl_py_gc_traverse!(CallValidator {
+    function,
     arguments_validator,
     return_validator
 });


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/8239, I wouldn't be surprised if there was some connection to other memory issues we've noticed with `ValidateCall` (e.g., https://github.com/pydantic/pydantic/issues/7687, though that one seemed to be addressed by doing a full garbage collection), either way this definitely seems like a bug.

@davidhewitt not sure if it makes sense to add tests of any sort for this, otherwise I think we can just merge.