### PR TITLE
add default comparison

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2186,6 +2186,7 @@ def with_default_schema(
     *,
     default: Any = PydanticUndefined,
     default_factory: Callable[[], Any] | None = None,
+    default_comparison: Callable[[Any, Any], bool] | None = None,
     on_error: Literal['raise', 'omit', 'default'] | None = None,
     validate_default: bool | None = None,
     strict: bool | None = None,
@@ -2211,6 +2212,7 @@ def with_default_schema(
         schema: The schema to add a default value to
         default: The default value to use
         default_factory: A function that returns the default value to use
+        default_comparison: A function to compare the default value with any other given
         on_error: What to do if the schema validation fails. One of 'raise', 'omit', 'default'
         validate_default: Whether the default value should be validated
         strict: Whether the underlying schema should be validated with strict mode
@@ -2222,6 +2224,7 @@ def with_default_schema(
         type='default',
         schema=schema,
         default_factory=default_factory,
+        default_comparison=default_comparison,
         on_error=on_error,
         validate_default=validate_default,
         strict=strict,

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -68,12 +68,9 @@ impl SerField {
 }
 
 fn exclude_default(value: &PyAny, extra: &Extra, serializer: &CombinedSerializer) -> PyResult<bool> {
+    let py = value.py();
     if extra.exclude_defaults {
-        if let Some(default) = serializer.get_default(value.py())? {
-            if value.eq(default)? {
-                return Ok(true);
-            }
-        }
+        return serializer.compare_with_default(py, value);
     }
     Ok(false)
 }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -301,6 +301,10 @@ pub(crate) trait TypeSerializer: Send + Sync + Clone + Debug {
     fn get_default(&self, _py: Python) -> PyResult<Option<PyObject>> {
         Ok(None)
     }
+
+    fn compare_with_default(&self, _py: Python, _value: &PyAny) -> PyResult<bool> {
+        Ok(false)
+    }
 }
 
 pub(crate) struct PydanticSerializer<'py> {


### PR DESCRIPTION
This PR tries to solve this pydantic [issue](https://github.com/pydantic/pydantic/issues/7307) . In my work I use objects of the type `np.ndarray` or `pd.DataFrame` a lot and excluding the defaults values has been a bit annoying due to the error mentioned in the issue. The idea of this PR is to add an extra optional argument in `Field` that I called `default_comparison`, which is a callable that receives two arguments value and default and replaces the `__eq__` call of the object with a call to this function 

## Checklist

* [ x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb