### PR TITLE
Expose API for setting the global "show errors in reprs" flag

### DIFF
--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -23,6 +23,7 @@ from ._pydantic_core import (
     ValidationError,
     __version__,
     from_json,
+    set_errors_include_url,
     to_json,
     to_jsonable_python,
     validate_core_schema,
@@ -65,6 +66,7 @@ __all__ = [
     'TzInfo',
     'to_json',
     'from_json',
+    'set_errors_include_url',
     'to_jsonable_python',
     'validate_core_schema',
 ]

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -44,6 +44,7 @@ __all__ = [
     'from_json',
     'to_jsonable_python',
     'list_all_errors',
+    'set_errors_include_url',
     'TzInfo',
     'validate_core_schema',
 ]
@@ -848,6 +849,16 @@ def list_all_errors() -> list[ErrorTypeInfo]:
 
     Returns:
         A list of `ErrorTypeInfo` typed dicts.
+    """
+
+def set_errors_include_url(flag: bool) -> None:
+    """
+    Set whether `repr`s of errors should include URLs to documentation on the error.
+
+    Defaults to `true` unless the `PYDANTIC_ERRORS_OMIT_URL` is set.
+
+    Args:
+        flag: Whether to include URLs in error `repr`s.
     """
 @final
 class TzInfo(datetime.tzinfo):

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -9,7 +9,7 @@ mod value_exception;
 pub use self::line_error::{AsErrorValue, InputValue, ValError, ValLineError, ValResult};
 pub use self::location::{AsLocItem, LocItem};
 pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
-pub use self::validation_exception::ValidationError;
+pub use self::validation_exception::{set_errors_include_url, ValidationError};
 pub use self::value_exception::{PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault};
 
 pub fn py_err_string(py: Python, err: PyErr) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ pub use self::url::{PyMultiHostUrl, PyUrl};
 pub use argument_markers::{ArgsKwargs, PydanticUndefinedType};
 pub use build_tools::SchemaError;
 pub use errors::{
-    list_all_errors, PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault, ValidationError,
+    list_all_errors, set_errors_include_url, PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault,
+    ValidationError,
 };
 pub use serializers::{
     to_json, to_jsonable_python, PydanticSerializationError, PydanticSerializationUnexpectedValue, SchemaSerializer,
@@ -110,6 +111,7 @@ fn _pydantic_core(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(from_json, m)?)?;
     m.add_function(wrap_pyfunction!(to_jsonable_python, m)?)?;
     m.add_function(wrap_pyfunction!(list_all_errors, m)?)?;
+    m.add_function(wrap_pyfunction!(set_errors_include_url, m)?)?;
     m.add_function(wrap_pyfunction!(validate_core_schema, m)?)?;
     Ok(())
 }

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -16,6 +16,7 @@ from pydantic_core import (
     SchemaValidator,
     ValidationError,
     core_schema,
+    set_errors_include_url,
 )
 from pydantic_core._pydantic_core import list_all_errors
 
@@ -1074,3 +1075,14 @@ def test_hide_input_in_json() -> None:
 
     for error in exc_info.value.errors(include_input=False):
         assert 'input' not in error
+
+
+def test_hide_url_in_repr() -> None:
+    s = SchemaValidator({'type': 'int'})
+    with pytest.raises(ValidationError) as exc_info:
+        s.validate_python('definitely not an int')
+
+    set_errors_include_url(False)
+    assert 'https' not in repr(exc_info.value)
+    set_errors_include_url(True)
+    assert 'https' in repr(exc_info.value)


### PR DESCRIPTION
## Change Summary

This PR adds a public API to set the global "include documentation URLs in error reprs" flag that was previously only available via the undocumented `PYDANTIC_ERRORS_OMIT_URL` environment variable (which was only read once as `pydantic_core` was initialized, and couldn't be changed afterwards).

To do that, the GILOnceCell holding the value was changed to a lower-level GILProtected.

## Related issue number

https://github.com/pydantic/pydantic/discussions/7485 is tangentially related.

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
  * Docstring added to the .pyi stub. 
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu