### PR TITLE
drop Python 3.7, and PyPy 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
-          - 'pypy3.7'
-          - 'pypy3.8'
           - 'pypy3.9'
           - 'pypy3.10'
 
@@ -385,19 +382,19 @@ jobs:
           - os: linux
             manylinux: auto
             target: armv7
-            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
+            interpreter: 3.8 3.9 3.10 3.11 3.12
           - os: linux
             manylinux: auto
             target: ppc64le
-            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
+            interpreter: 3.8 3.9 3.10 3.11 3.12
           - os: linux
             manylinux: auto
             target: s390x
-            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
+            interpreter: 3.8 3.9 3.10 3.11 3.12
           - os: linux
             manylinux: auto
             target: x86_64
-            interpreter: pypy3.7 pypy3.8 pypy3.9 pypy3.10
+            interpreter: pypy3.9 pypy3.10
 
           # musllinux
           - os: linux
@@ -414,7 +411,7 @@ jobs:
             target: x86_64
           - os: macos
             target: aarch64
-            interpreter: 3.7 3.8 3.9 pypy3.8 pypy3.9 pypy3.10
+            interpreter: 3.8 3.9 pypy3.9 pypy3.10
 
           # windows;
           # x86_64 pypy builds are not PGO optimized
@@ -422,11 +419,11 @@ jobs:
           # aarch64 only 3.11 and up, also not PGO optimized
           - os: windows
             target: x86_64
-            interpreter: pypy3.8 pypy3.9 pypy3.10
+            interpreter: pypy3.9 pypy3.10
           - os: windows
             target: i686
             python-architecture: x86
-            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
+            interpreter: 3.8 3.9 3.10 3.11 3.12
           - os: windows
             target: aarch64
             interpreter: 3.11 3.12
@@ -451,7 +448,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux == 'manylinux' && 'auto' || matrix.manylinux }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.7 3.8 3.9 3.10 3.11 3.12 pypy3.7 pypy3.8 pypy3.9 pypy3.10' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 pypy3.9 pypy3.10' }}
           rust-toolchain: stable
           docker-options: -e CI
 
@@ -472,7 +469,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, windows, macos]
-        interpreter: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        interpreter: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           # standard runners with override for macos arm
           - os: linux
@@ -484,8 +481,6 @@ jobs:
             runs-on: macos-latest-xlarge
         exclude:
           # macos arm only supported from 3.10 and up
-          - os: macos
-            interpreter: '3.7'
           - os: macos
             interpreter: '3.8'
           - os: macos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.14.5"
+version = "2.15.0"
 dependencies = [
  "ahash",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.14.5"
+version = "2.15.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ except ValidationError as e:
 
 You'll need rust stable [installed](https://rustup.rs/), or rust nightly if you want to generate accurate coverage.
 
-With rust and python 3.7+ installed, compiling pydantic-core should be possible with roughly the following:
+With rust and python 3.8+ installed, compiling pydantic-core should be possible with roughly the following:
 
 ```bash
 # clone this repo or your fork

--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -188,11 +188,7 @@ def all_literal_values(type_: type[core_schema.Literal]) -> list[any]:
 
 
 def eval_forward_ref(type_: Any) -> Any:
-    try:
-        return type_._evaluate(core_schema.__dict__, None, set())
-    except TypeError:
-        # for older python (3.7 at least)
-        return type_._evaluate(core_schema.__dict__, None)
+    return type_._evaluate(core_schema.__dict__, None, set())
 
 
 def main() -> None:

--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -188,7 +188,11 @@ def all_literal_values(type_: type[core_schema.Literal]) -> list[any]:
 
 
 def eval_forward_ref(type_: Any) -> Any:
-    return type_._evaluate(core_schema.__dict__, None, set())
+    try:
+        return type_._evaluate(core_schema.__dict__, None, set())
+    except TypeError:
+        # for Python 3.8
+        return type_._evaluate(core_schema.__dict__, None)
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = 'maturin'
 
 [project]
 name = 'pydantic_core'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 authors = [
     {name = 'Samuel Colvin', email = 's@muelcolvin.com'}
 ]
@@ -16,7 +16,6 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
## Change Summary

Time to clean up some old technologies!

I've also pushed a version bump to `2.15.0` in this PR, so that `pydantic` main branch can start building against a newer core.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu