### PR TITLE
Support indirect definition references

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3576,12 +3576,13 @@ def definitions_schema(schema: CoreSchema, definitions: list[CoreSchema]) -> Def
 class DefinitionReferenceSchema(TypedDict, total=False):
     type: Required[Literal['definition-ref']]
     schema_ref: Required[str]
+    ref: str
     metadata: Any
     serialization: SerSchema
 
 
 def definition_reference_schema(
-    schema_ref: str, metadata: Any = None, serialization: SerSchema | None = None
+    schema_ref: str, ref: str | None = None, metadata: Any = None, serialization: SerSchema | None = None
 ) -> DefinitionReferenceSchema:
     """
     Returns a schema that points to a schema stored in "definitions", this is useful for nested recursive
@@ -3606,7 +3607,9 @@ def definition_reference_schema(
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
-    return _dict_not_none(type='definition-ref', schema_ref=schema_ref, metadata=metadata, serialization=serialization)
+    return _dict_not_none(
+        type='definition-ref', schema_ref=schema_ref, ref=ref, metadata=metadata, serialization=serialization
+    )
 
 
 MYPY = False

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -140,3 +140,13 @@ def test_use_after():
         )
     )
     assert v.validate_python(['1', '2']) == (1, 2)
+
+
+def test_definition_chain():
+    v = SchemaValidator(
+        core_schema.definitions_schema(
+            core_schema.definition_reference_schema('foo'),
+            [core_schema.definition_reference_schema(ref='foo', schema_ref='bar'), core_schema.int_schema(ref='bar')],
+        ),
+    )
+    assert v.validate_python('1') == 1


### PR DESCRIPTION
This makes certain usage patterns work better in pydantic, e.g., making TypeAliasType references to other TypeAliasType's. I think we may want to optimize out reference chains at some point, but I don't think that should stop us from merging this now since this only makes more schemas acceptable, and doesn't affect any existing use of Pydantic (and the Pydantic PR I will open that makes use of this won't affect any currently-working usage, it will just allow some schemas that currently would raise schema-building errors).