### PR TITLE
fix "run-on-arch" tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,11 +643,11 @@ jobs:
             if command -v apt-get &> /dev/null; then
               echo "installing python & pip with apt-get..."
               apt-get update
-              apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+              apt-get install -y --no-install-recommends python3 python3-pip python3-venv git
             else
               echo "installing python & pip with apk..."
               apk update
-              apk add python3 py3-pip
+              apk add python3 py3-pip git
             fi
           run: |
             set -x

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,9 @@ pandas==2.1.3; python_version >= "3.9" and python_version < "3.13" and implement
 pytest==7.4.3
 # we run codspeed benchmarks on x86_64 CPython (i.e. native github actions architecture)
 pytest-codspeed~=2.2.0; implementation_name == "cpython" and platform_machine == 'x86_64'
-pytest-examples==0.0.10
+# pytest-examples currently depends on aiohttp via black; we don't want to build
+# it on platforms like aarch64 musllinux in CI
+pytest-examples==0.0.10; implementation_name == "cpython" and platform_machine == 'x86_64'
 pytest-speed==0.3.5
 pytest-mock==3.11.1
 pytest-pretty==1.2.0

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -12,7 +12,7 @@ except ImportError:
         return []
 
 
-@pytest.mark.skipif(sys.platform not in {'linux', 'darwin'}, reason='Only on linux and macos')
+@pytest.mark.skipif(CodeExample is None or sys.platform not in {'linux', 'darwin'}, reason='Only on linux and macos')
 @pytest.mark.parametrize('example', find_examples('python/pydantic_core/core_schema.py'), ids=str)
 def test_docstrings(example: CodeExample, eval_example: EvalExample):
     eval_example.set_config(quotes='single')
@@ -25,7 +25,7 @@ def test_docstrings(example: CodeExample, eval_example: EvalExample):
         eval_example.run_print_check(example)
 
 
-@pytest.mark.skipif(sys.platform not in {'linux', 'darwin'}, reason='Only on linux and macos')
+@pytest.mark.skipif(CodeExample is None or sys.platform not in {'linux', 'darwin'}, reason='Only on linux and macos')
 @pytest.mark.parametrize('example', find_examples('README.md'), ids=str)
 def test_readme(example: CodeExample, eval_example: EvalExample):
     eval_example.set_config(line_length=100, quotes='single')


### PR DESCRIPTION
## Change Summary

I think a recent action update caused these images to be missing `git`.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
