### PR TITLE
Use stricter serializer for unions of simple types

### DIFF
--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -86,7 +86,7 @@ impl TypeSerializer for NoneSerializer {
 }
 
 macro_rules! build_simple_serializer {
-    ($struct_name:ident, $expected_type:literal, $rust_type:ty, $ob_type:expr, $key_method:ident) => {
+    ($struct_name:ident, $expected_type:literal, $rust_type:ty, $ob_type:expr, $key_method:ident, $subtypes_allowed:expr) => {
         #[derive(Debug, Clone)]
         pub struct $struct_name;
 
@@ -164,6 +164,10 @@ macro_rules! build_simple_serializer {
             fn get_name(&self) -> &str {
                 Self::EXPECTED_TYPE
             }
+
+            fn retry_with_lax_check(&self) -> bool {
+                $subtypes_allowed
+            }
         }
     };
 }
@@ -172,7 +176,7 @@ pub(crate) fn to_str_json_key(key: &PyAny) -> PyResult<Cow<str>> {
     Ok(key.str()?.to_string_lossy())
 }
 
-build_simple_serializer!(IntSerializer, "int", Int, ObType::Int, to_str_json_key);
+build_simple_serializer!(IntSerializer, "int", Int, ObType::Int, to_str_json_key, true);
 
 pub(crate) fn bool_json_key(key: &PyAny) -> PyResult<Cow<str>> {
     let v = if key.is_true().unwrap_or(false) {
@@ -183,4 +187,4 @@ pub(crate) fn bool_json_key(key: &PyAny) -> PyResult<Cow<str>> {
     Ok(Cow::Borrowed(v))
 }
 
-build_simple_serializer!(BoolSerializer, "bool", bool, ObType::Bool, bool_json_key);
+build_simple_serializer!(BoolSerializer, "bool", bool, ObType::Bool, bool_json_key, false);

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -1,6 +1,8 @@
 import dataclasses
 import json
 import re
+import uuid
+from decimal import Decimal
 from typing import Any, ClassVar, Union
 
 import pytest
@@ -510,3 +512,87 @@ def test_union_serializes_list_of_model_subclass_from_definition() -> None:
     )
 
     assert s.to_python([DBUser(name='John', password='secret')]) == [{'name': 'John'}]
+
+
+EXAMPLE_UUID = uuid.uuid4()
+
+
+@pytest.mark.parametrize('order', ['direct', 'inverse'])
+@pytest.mark.parametrize(
+    'core_schema_left,core_schema_right,input_value,expected_value',
+    [
+        (core_schema.int_schema(), core_schema.bool_schema(), True, True),
+        (core_schema.int_schema(), core_schema.bool_schema(), 1, 1),
+        (core_schema.str_schema(), core_schema.int_schema(), 1, 1),
+        (core_schema.str_schema(), core_schema.int_schema(), '1', '1'),
+        (
+            core_schema.decimal_schema(),
+            core_schema.int_schema(),
+            Decimal('1'),
+            Decimal('1'),
+        ),
+        (core_schema.decimal_schema(), core_schema.int_schema(), 1, 1),
+        (
+            core_schema.decimal_schema(),
+            core_schema.float_schema(),
+            Decimal('1.'),
+            Decimal('1.'),
+        ),
+        (
+            core_schema.uuid_schema(),
+            core_schema.str_schema(),
+            EXAMPLE_UUID,
+            EXAMPLE_UUID,
+        ),
+        (
+            core_schema.uuid_schema(),
+            core_schema.str_schema(),
+            str(EXAMPLE_UUID),
+            str(EXAMPLE_UUID),
+        ),
+    ],
+)
+def test_union_serializer_picks_exact_type_over_subclass(
+    core_schema_left, core_schema_right, input_value, expected_value, order
+):
+    s = SchemaSerializer(
+        core_schema.union_schema(
+            [core_schema_left, core_schema_right] if order == 'direct' else [core_schema_right, core_schema_left]
+        )
+    )
+    assert s.to_python(input_value) == expected_value
+
+
+@pytest.mark.parametrize('order', ['direct', 'inverse'])
+@pytest.mark.parametrize(
+    'core_schema_left,core_schema_right,input_value,expected_value',
+    [
+        (core_schema.int_schema(), core_schema.bool_schema(), True, True),
+        (core_schema.int_schema(), core_schema.bool_schema(), 1, 1),
+        (core_schema.str_schema(), core_schema.int_schema(), 1, 1),
+        (core_schema.str_schema(), core_schema.int_schema(), '1', '1'),
+        (
+            core_schema.decimal_schema(),
+            core_schema.int_schema(),
+            Decimal('1'),
+            '1',
+        ),
+        (core_schema.decimal_schema(), core_schema.int_schema(), 1, 1),
+        (
+            core_schema.decimal_schema(),
+            core_schema.float_schema(),
+            Decimal('1.'),
+            '1',
+        ),
+    ],
+)
+def test_union_serializer_picks_exact_type_over_subclass_json(
+    core_schema_left, core_schema_right, input_value, expected_value, order
+):
+    s = SchemaSerializer(
+        core_schema.union_schema(
+            [core_schema_left, core_schema_right] if order == 'direct' else [core_schema_right, core_schema_left]
+        )
+    )
+    assert s.to_python(input_value, mode='json') == expected_value
+    assert s.to_json(input_value) == json.dumps(expected_value).encode()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

This PR forces simple serializer to fail in case of strict extra.check mode if current type is a subtype of expected type (but not the type itself). With this union serializer is given a chance to find a better serializer during strict pass.

## Related issue number
This fixes `Union[bool, int]` case of https://github.com/pydantic/pydantic/issues/6830 (which was reported in https://github.com/pydantic/pydantic/issues/7294). Ambiguity of union serializer in case of arbitrary types (e.g. with is-instance schema) is not fixed.
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin