### PR TITLE
unify 'profile.profiling' configuration

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -52,8 +52,7 @@ jobs:
           key: v1
 
       - name: Compile pydantic-core for profiling
-        run: |
-          pip install -e . --config-settings=build-args='--verbose --profile codspeed' -v
+        run: make build-profiling
         env:
           CONST_RANDOM_SEED: 0 # Fix the compile time RNG seed
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/profdata"
@@ -65,8 +64,7 @@ jobs:
         run: rustup run stable bash -c '$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata'
 
       - name: Compile pydantic-core for benchmarking
-        run: |
-          pip install -e . --config-settings=build-args='--verbose --profile codspeed' -v
+        run: make build-profiling
         env:
           CONST_RANDOM_SEED: 0 # Fix the compile time RNG seed
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,9 @@ strip = true
 debug = true
 strip = false
 
-[profile.codspeed]
+# This is separate to benchmarks because `bench` ends up building testing
+# harnesses into code, as it's a special cargo profile.
+[profile.profiling]
 inherits = "release"
 debug = true
 strip = false

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ endif
 build-profiling:
 	@rm -f python/pydantic_core/*.so
 ifneq ($(USE_MATURIN),)
-	CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=true maturin develop --release
+	maturin develop '--profile profiling'
 else
-	CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=true pip install -v -e .
+	pip install -v -e . --config-settings=build-args='--profile profiling'
 endif
 
 .PHONY: build-coverage


### PR DESCRIPTION
## Change Summary

Just makes things a bit more uniform in how configuration is applied for profiling locally & on codspeed.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
