### PR TITLE
dataclass serialization speedups

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -15,7 +15,7 @@ use super::extra::Extra;
 use super::filter::SchemaFilter;
 use super::infer::{infer_json_key, infer_serialize, infer_to_python, SerializeInfer};
 use super::shared::PydanticSerializer;
-use super::shared::{CombinedSerializer, DictIterator, TypeSerializer};
+use super::shared::{CombinedSerializer, TypeSerializer};
 
 /// representation of a field for serialization
 #[derive(Debug, Clone)]
@@ -321,7 +321,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
             return infer_to_python(value, include, exclude, &td_extra);
         };
 
-        let output_dict = self.main_to_python(py, DictIterator::new(main_dict), include, exclude, td_extra)?;
+        let output_dict = self.main_to_python(py, main_dict.iter().map(Ok), include, exclude, td_extra)?;
 
         // this is used to include `__pydantic_extra__` in serialization on models
         if let Some(extra_dict) = extra_dict {
@@ -373,7 +373,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
         // NOTE! As above, we maintain the order of the input dict assuming that's right
         // we don't both with `used_fields` here because on unions, `to_python(..., mode='json')` is used
         let mut map = self.main_serde_serialize(
-            DictIterator::new(main_dict),
+            main_dict.iter().map(Ok),
             expected_len,
             serializer,
             include,

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
 use ahash::AHashMap;
+use pyo3::types::iter::PyDictIterator;
 use serde::ser::SerializeMap;
 
 use crate::serializers::extra::SerCheck;
@@ -100,6 +101,15 @@ pub struct GeneralFieldsSerializer {
     required_fields: usize,
 }
 
+macro_rules! option_length {
+    ($op_has_len:expr) => {
+        match $op_has_len {
+            Some(ref has_len) => has_len.len(),
+            None => 0,
+        }
+    };
+}
+
 impl GeneralFieldsSerializer {
     pub(super) fn new(
         fields: AHashMap<String, SerField>,
@@ -136,15 +146,154 @@ impl GeneralFieldsSerializer {
             }
         }
     }
-}
 
-macro_rules! option_length {
-    ($op_has_len:expr) => {
-        match $op_has_len {
-            Some(ref has_len) => has_len.len(),
-            None => 0,
+    pub fn main_to_python<'py>(
+        &self,
+        py: Python<'py>,
+        main_iter: impl Iterator<Item = PyResult<(&'py PyString, &'py PyAny)>>,
+        include: Option<&'py PyAny>,
+        exclude: Option<&'py PyAny>,
+        extra: Extra,
+    ) -> PyResult<&'py PyDict> {
+        let output_dict = PyDict::new(py);
+        let mut used_req_fields: usize = 0;
+
+        // NOTE! we maintain the order of the input dict assuming that's right
+        for result in main_iter {
+            let (key, value) = result?;
+            let key_str = key.to_str()?;
+            let op_field = self.fields.get(key_str);
+            if extra.exclude_none && value.is_none() {
+                if let Some(field) = op_field {
+                    if field.required {
+                        used_req_fields += 1;
+                    }
+                }
+                continue;
+            }
+            let field_extra = Extra {
+                field_name: Some(key_str),
+                ..extra
+            };
+            if let Some((next_include, next_exclude)) = self.filter.key_filter(key, include, exclude)? {
+                if let Some(field) = op_field {
+                    if let Some(ref serializer) = field.serializer {
+                        if !exclude_default(value, &field_extra, serializer)? {
+                            let value = serializer.to_python(value, next_include, next_exclude, &field_extra)?;
+                            let output_key = field.get_key_py(output_dict.py(), &field_extra);
+                            output_dict.set_item(output_key, value)?;
+                        }
+                    }
+
+                    if field.required {
+                        used_req_fields += 1;
+                    }
+                } else if self.mode == FieldsMode::TypedDictAllow {
+                    let value = match &self.extra_serializer {
+                        Some(serializer) => serializer.to_python(value, next_include, next_exclude, &field_extra)?,
+                        None => infer_to_python(value, next_include, next_exclude, &field_extra)?,
+                    };
+                    output_dict.set_item(key, value)?;
+                } else if field_extra.check == SerCheck::Strict {
+                    return Err(PydanticSerializationUnexpectedValue::new_err(None));
+                }
+            }
         }
-    };
+
+        if extra.check.enabled()
+            // If any of these are true we can't count fields
+            && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none)
+            // Check for missing fields, we can't have extra fields here
+            && self.required_fields > used_req_fields
+        {
+            Err(PydanticSerializationUnexpectedValue::new_err(None))
+        } else {
+            Ok(output_dict)
+        }
+    }
+
+    pub fn main_serde_serialize<'py, S: serde::ser::Serializer>(
+        &self,
+        main_iter: impl Iterator<Item = PyResult<(&'py PyString, &'py PyAny)>>,
+        expected_len: usize,
+        serializer: S,
+        include: Option<&'py PyAny>,
+        exclude: Option<&'py PyAny>,
+        extra: Extra,
+    ) -> Result<S::SerializeMap, S::Error> {
+        // NOTE! As above, we maintain the order of the input dict assuming that's right
+        // we don't both with `used_fields` here because on unions, `to_python(..., mode='json')` is used
+        let mut map = serializer.serialize_map(Some(expected_len))?;
+
+        for result in main_iter {
+            let (key, value) = result.map_err(py_err_se_err)?;
+            if extra.exclude_none && value.is_none() {
+                continue;
+            }
+            let key_str = key_str(key).map_err(py_err_se_err)?;
+            let field_extra = Extra {
+                field_name: Some(key_str),
+                ..extra
+            };
+
+            let filter = self.filter.key_filter(key, include, exclude).map_err(py_err_se_err)?;
+            if let Some((next_include, next_exclude)) = filter {
+                if let Some(field) = self.fields.get(key_str) {
+                    if let Some(ref serializer) = field.serializer {
+                        if !exclude_default(value, &field_extra, serializer).map_err(py_err_se_err)? {
+                            let s =
+                                PydanticSerializer::new(value, serializer, next_include, next_exclude, &field_extra);
+                            let output_key = field.get_key_json(key_str, &field_extra);
+                            map.serialize_entry(&output_key, &s)?;
+                        }
+                    }
+                } else if self.mode == FieldsMode::TypedDictAllow {
+                    let output_key = infer_json_key(key, &field_extra).map_err(py_err_se_err)?;
+                    let s = SerializeInfer::new(value, next_include, next_exclude, &field_extra);
+                    map.serialize_entry(&output_key, &s)?;
+                }
+                // no error case here since unions (which need the error case) use `to_python(..., mode='json')`
+            }
+        }
+        Ok(map)
+    }
+
+    pub fn add_computed_fields_python(
+        &self,
+        model: Option<&PyAny>,
+        output_dict: &PyDict,
+        include: Option<&PyAny>,
+        exclude: Option<&PyAny>,
+        extra: &Extra,
+    ) -> PyResult<()> {
+        if let Some(ref computed_fields) = self.computed_fields {
+            if let Some(model_value) = model {
+                let cf_extra = Extra { model, ..*extra };
+                computed_fields.to_python(model_value, output_dict, &self.filter, include, exclude, &cf_extra)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add_computed_fields_json<S: serde::ser::Serializer>(
+        &self,
+        model: Option<&PyAny>,
+        map: &mut S::SerializeMap,
+        include: Option<&PyAny>,
+        exclude: Option<&PyAny>,
+        extra: &Extra,
+    ) -> Result<(), S::Error> {
+        if let Some(ref computed_fields) = self.computed_fields {
+            if let Some(model) = model {
+                computed_fields.serde_serialize::<S>(model, map, &self.filter, include, exclude, extra)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn computed_field_count(&self) -> usize {
+        option_length!(self.computed_fields)
+    }
 }
 
 impl_py_gc_traverse!(GeneralFieldsSerializer {
@@ -164,10 +313,8 @@ impl TypeSerializer for GeneralFieldsSerializer {
         // If there is already a model registered (from a dataclass, BaseModel)
         // then do not touch it
         // If there is no model, we (a TypedDict) are the model
-        let td_extra = Extra {
-            model: extra.model.map_or_else(|| Some(value), Some),
-            ..*extra
-        };
+        let model = extra.model.map_or_else(|| Some(value), Some);
+        let td_extra = Extra { model, ..*extra };
         let (main_dict, extra_dict) = if let Some(main_extra_dict) = self.extract_dicts(value) {
             main_extra_dict
         } else {
@@ -175,57 +322,8 @@ impl TypeSerializer for GeneralFieldsSerializer {
             return infer_to_python(value, include, exclude, &td_extra);
         };
 
-        let output_dict = PyDict::new(py);
-        let mut used_req_fields: usize = 0;
+        let output_dict = self.main_to_python(py, DictResultIterator::new(main_dict), include, exclude, td_extra)?;
 
-        // NOTE! we maintain the order of the input dict assuming that's right
-        for (key, value) in main_dict {
-            let key_str = key_str(key)?;
-            let op_field = self.fields.get(key_str);
-            if extra.exclude_none && value.is_none() {
-                if let Some(field) = op_field {
-                    if field.required {
-                        used_req_fields += 1;
-                    }
-                }
-                continue;
-            }
-            let extra = Extra {
-                field_name: Some(key_str),
-                ..td_extra
-            };
-            if let Some((next_include, next_exclude)) = self.filter.key_filter(key, include, exclude)? {
-                if let Some(field) = op_field {
-                    if let Some(ref serializer) = field.serializer {
-                        if !exclude_default(value, &extra, serializer)? {
-                            let value = serializer.to_python(value, next_include, next_exclude, &extra)?;
-                            let output_key = field.get_key_py(output_dict.py(), &extra);
-                            output_dict.set_item(output_key, value)?;
-                        }
-                    }
-
-                    if field.required {
-                        used_req_fields += 1;
-                    }
-                } else if self.mode == FieldsMode::TypedDictAllow {
-                    let value = match &self.extra_serializer {
-                        Some(serializer) => serializer.to_python(value, next_include, next_exclude, &extra)?,
-                        None => infer_to_python(value, next_include, next_exclude, &extra)?,
-                    };
-                    output_dict.set_item(key, value)?;
-                } else if extra.check == SerCheck::Strict {
-                    return Err(PydanticSerializationUnexpectedValue::new_err(None));
-                }
-            }
-        }
-        if td_extra.check.enabled()
-            // If any of these are true we can't count fields
-            && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none)
-            // Check for missing fields, we can't have extra fields here
-            && self.required_fields > used_req_fields
-        {
-            return Err(PydanticSerializationUnexpectedValue::new_err(None));
-        }
         // this is used to include `__pydantic_extra__` in serialization on models
         if let Some(extra_dict) = extra_dict {
             for (key, value) in extra_dict {
@@ -241,11 +339,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
                 }
             }
         }
-        if let Some(ref computed_fields) = self.computed_fields {
-            if let Some(model) = td_extra.model {
-                computed_fields.to_python(model, output_dict, &self.filter, include, exclude, &td_extra)?;
-            }
-        }
+        self.add_computed_fields_python(model, output_dict, include, exclude, extra)?;
         Ok(output_dict.into_py(py))
     }
 
@@ -271,46 +365,23 @@ impl TypeSerializer for GeneralFieldsSerializer {
         // If there is already a model registered (from a dataclass, BaseModel)
         // then do not touch it
         // If there is no model, we (a TypedDict) are the model
-        let td_extra = Extra {
-            model: extra.model.map_or_else(|| Some(value), Some),
-            ..*extra
-        };
+        let model = extra.model.map_or_else(|| Some(value), Some);
+        let td_extra = Extra { model, ..*extra };
         let expected_len = match self.mode {
-            FieldsMode::TypedDictAllow => main_dict.len() + option_length!(self.computed_fields),
-            _ => self.fields.len() + option_length!(extra_dict) + option_length!(self.computed_fields),
+            FieldsMode::TypedDictAllow => main_dict.len() + self.computed_field_count(),
+            _ => self.fields.len() + option_length!(extra_dict) + self.computed_field_count(),
         };
         // NOTE! As above, we maintain the order of the input dict assuming that's right
         // we don't both with `used_fields` here because on unions, `to_python(..., mode='json')` is used
-        let mut map = serializer.serialize_map(Some(expected_len))?;
+        let mut map = self.main_serde_serialize(
+            DictResultIterator::new(main_dict),
+            expected_len,
+            serializer,
+            include,
+            exclude,
+            td_extra,
+        )?;
 
-        for (key, value) in main_dict {
-            if extra.exclude_none && value.is_none() {
-                continue;
-            }
-            let key_str = key_str(key).map_err(py_err_se_err)?;
-            let extra = Extra {
-                field_name: Some(key_str),
-                ..td_extra
-            };
-
-            let filter = self.filter.key_filter(key, include, exclude).map_err(py_err_se_err)?;
-            if let Some((next_include, next_exclude)) = filter {
-                if let Some(field) = self.fields.get(key_str) {
-                    if let Some(ref serializer) = field.serializer {
-                        if !exclude_default(value, &extra, serializer).map_err(py_err_se_err)? {
-                            let s = PydanticSerializer::new(value, serializer, next_include, next_exclude, &extra);
-                            let output_key = field.get_key_json(key_str, &extra);
-                            map.serialize_entry(&output_key, &s)?;
-                        }
-                    }
-                } else if self.mode == FieldsMode::TypedDictAllow {
-                    let output_key = infer_json_key(key, &extra).map_err(py_err_se_err)?;
-                    let s = SerializeInfer::new(value, next_include, next_exclude, &extra);
-                    map.serialize_entry(&output_key, &s)?;
-                }
-                // no error case here since unions (which need the error case) use `to_python(..., mode='json')`
-            }
-        }
         // this is used to include `__pydantic_extra__` in serialization on models
         if let Some(extra_dict) = extra_dict {
             for (key, value) in extra_dict {
@@ -319,17 +390,14 @@ impl TypeSerializer for GeneralFieldsSerializer {
                 }
                 let filter = self.filter.key_filter(key, include, exclude).map_err(py_err_se_err)?;
                 if let Some((next_include, next_exclude)) = filter {
-                    let output_key = infer_json_key(key, &td_extra).map_err(py_err_se_err)?;
-                    let s = SerializeInfer::new(value, next_include, next_exclude, &td_extra);
+                    let output_key = infer_json_key(key, extra).map_err(py_err_se_err)?;
+                    let s = SerializeInfer::new(value, next_include, next_exclude, extra);
                     map.serialize_entry(&output_key, &s)?;
                 }
             }
         }
-        if let Some(ref computed_fields) = self.computed_fields {
-            if let Some(model) = td_extra.model {
-                computed_fields.serde_serialize::<S>(model, &mut map, &self.filter, include, exclude, &td_extra)?;
-            }
-        }
+
+        self.add_computed_fields_json::<S>(model, &mut map, include, exclude, extra)?;
         map.end()
     }
 
@@ -340,4 +408,29 @@ impl TypeSerializer for GeneralFieldsSerializer {
 
 fn key_str(key: &PyAny) -> PyResult<&str> {
     key.downcast::<PyString>()?.to_str()
+}
+
+pub struct DictResultIterator<'py> {
+    dict_iter: PyDictIterator<'py>,
+}
+
+impl<'py> DictResultIterator<'py> {
+    pub fn new(dict: &'py PyDict) -> Self {
+        Self { dict_iter: dict.iter() }
+    }
+}
+
+impl<'py> Iterator for DictResultIterator<'py> {
+    type Item = PyResult<(&'py PyString, &'py PyAny)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((key, value)) = self.dict_iter.next() {
+            match key.downcast::<PyString>() {
+                Ok(key_str) => Some(Ok((key_str, value))),
+                Err(e) => Some(Err(e.into())),
+            }
+        } else {
+            None
+        }
+    }
 }

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -15,7 +15,7 @@ use super::extra::Extra;
 use super::filter::SchemaFilter;
 use super::infer::{infer_json_key, infer_serialize, infer_to_python, SerializeInfer};
 use super::shared::PydanticSerializer;
-use super::shared::{CombinedSerializer, DictResultIterator, TypeSerializer};
+use super::shared::{CombinedSerializer, DictIterator, TypeSerializer};
 
 /// representation of a field for serialization
 #[derive(Debug, Clone)]
@@ -321,7 +321,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
             return infer_to_python(value, include, exclude, &td_extra);
         };
 
-        let output_dict = self.main_to_python(py, DictResultIterator::new(main_dict), include, exclude, td_extra)?;
+        let output_dict = self.main_to_python(py, DictIterator::new(main_dict), include, exclude, td_extra)?;
 
         // this is used to include `__pydantic_extra__` in serialization on models
         if let Some(extra_dict) = extra_dict {
@@ -373,7 +373,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
         // NOTE! As above, we maintain the order of the input dict assuming that's right
         // we don't both with `used_fields` here because on unions, `to_python(..., mode='json')` is used
         let mut map = self.main_serde_serialize(
-            DictResultIterator::new(main_dict),
+            DictIterator::new(main_dict),
             expected_len,
             serializer,
             include,

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -10,19 +10,17 @@ use pyo3::types::{
 use serde::ser::{Error, Serialize, SerializeMap, SerializeSeq, Serializer};
 
 use crate::input::{EitherTimedelta, Int};
-use crate::serializers::config::InfNanMode;
-use crate::serializers::errors::SERIALIZATION_ERR_MARKER;
-use crate::serializers::filter::SchemaFilter;
-use crate::serializers::shared::{PydanticSerializer, TypeSerializer};
-use crate::serializers::SchemaSerializer;
 use crate::tools::{extract_i64, py_err, safe_repr};
 use crate::url::{PyMultiHostUrl, PyUrl};
 
+use super::config::InfNanMode;
+use super::errors::SERIALIZATION_ERR_MARKER;
 use super::errors::{py_err_se_err, PydanticSerializationError};
 use super::extra::{Extra, SerMode};
-use super::filter::AnyFilter;
+use super::filter::{AnyFilter, SchemaFilter};
 use super::ob_type::ObType;
-use super::shared::dataclass_to_dict;
+use super::shared::{DataclassSerializer, DictResultIterator, PydanticSerializer, TypeSerializer};
+use super::SchemaSerializer;
 
 pub(crate) fn infer_to_python(
     value: &PyAny,
@@ -82,22 +80,6 @@ pub(crate) fn infer_to_python_known(
             items
         }};
     }
-
-    let serialize_dict = |dict: &PyDict| {
-        let new_dict = PyDict::new(py);
-        let filter = AnyFilter::new();
-
-        for (k, v) in dict {
-            let op_next = filter.key_filter(k, include, exclude)?;
-            if let Some((next_include, next_exclude)) = op_next {
-                let k_str = infer_json_key(k, extra)?;
-                let k = PyString::new(py, &k_str);
-                let v = infer_to_python(v, next_include, next_exclude, extra)?;
-                new_dict.set_item(k, v)?;
-            }
-        }
-        Ok::<PyObject, PyErr>(new_dict.into_py(py))
-    };
 
     let serialize_with_serializer = || {
         let py_serializer = value.getattr(intern!(py, "__pydantic_serializer__"))?;
@@ -168,7 +150,13 @@ pub(crate) fn infer_to_python_known(
                 let elements = serialize_seq!(PyFrozenSet);
                 PyList::new(py, elements).into_py(py)
             }
-            ObType::Dict => serialize_dict(value.downcast()?)?,
+            ObType::Dict => serialize_pairs_python_mode_json(
+                py,
+                DictResultIterator::new(value.downcast()?),
+                include,
+                exclude,
+                extra,
+            )?,
             ObType::Datetime => {
                 let py_dt: &PyDateTime = value.downcast()?;
                 let iso_dt = super::type_serializers::datetime_etc::datetime_to_string(py_dt)?;
@@ -205,7 +193,9 @@ pub(crate) fn infer_to_python_known(
                 uuid.into_py(py)
             }
             ObType::PydanticSerializable => serialize_with_serializer()?,
-            ObType::Dataclass => serialize_dict(dataclass_to_dict(value)?)?,
+            ObType::Dataclass => {
+                serialize_pairs_python_mode_json(py, DataclassSerializer::new(value)?, include, exclude, extra)?
+            }
             ObType::Enum => {
                 let v = value.getattr(intern!(py, "value"))?;
                 infer_to_python(v, include, exclude, extra)?.into_py(py)
@@ -256,22 +246,10 @@ pub(crate) fn infer_to_python_known(
                 PyFrozenSet::new(py, &elements)?.into_py(py)
             }
             ObType::Dict => {
-                // different logic for keys from above
-                let dict: &PyDict = value.downcast()?;
-                let new_dict = PyDict::new(py);
-                let filter = AnyFilter::new();
-
-                for (k, v) in dict {
-                    let op_next = filter.key_filter(k, include, exclude)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let v = infer_to_python(v, next_include, next_exclude, extra)?;
-                        new_dict.set_item(k, v)?;
-                    }
-                }
-                new_dict.into_py(py)
+                serialize_pairs_python(py, DictResultIterator::new(value.downcast()?), include, exclude, extra)?
             }
             ObType::PydanticSerializable => serialize_with_serializer()?,
-            ObType::Dataclass => serialize_dict(dataclass_to_dict(value)?)?,
+            ObType::Dataclass => serialize_pairs_python(py, DataclassSerializer::new(value)?, include, exclude, extra)?,
             ObType::Generator => {
                 let iter = super::type_serializers::generator::SerializationIterator::new(
                     value.downcast()?,
@@ -405,23 +383,6 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
         }};
     }
 
-    macro_rules! serialize_dict {
-        ($py_dict:expr) => {{
-            let mut map = serializer.serialize_map(Some($py_dict.len()))?;
-            let filter = AnyFilter::new();
-
-            for (key, value) in $py_dict {
-                let op_next = filter.key_filter(key, include, exclude).map_err(py_err_se_err)?;
-                if let Some((next_include, next_exclude)) = op_next {
-                    let key = infer_json_key(key, extra).map_err(py_err_se_err)?;
-                    let value_serializer = SerializeInfer::new(value, next_include, next_exclude, extra);
-                    map.serialize_entry(&key, &value_serializer)?;
-                }
-            }
-            map.end()
-        }};
-    }
-
     let ser_result = match ob_type {
         ObType::None => serializer.serialize_none(),
         ObType::Int | ObType::IntSubclass => serialize!(Int),
@@ -445,7 +406,10 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
                 .bytes_mode
                 .serialize_bytes(unsafe { py_byte_array.as_bytes() }, serializer)
         }
-        ObType::Dict => serialize_dict!(value.downcast::<PyDict>().map_err(py_err_se_err)?),
+        ObType::Dict => {
+            let dict = value.downcast::<PyDict>().map_err(py_err_se_err)?;
+            serialize_pairs_json(DictResultIterator::new(dict), serializer, include, exclude, extra)
+        }
         ObType::List => serialize_seq_filter!(PyList),
         ObType::Tuple => serialize_seq_filter!(PyTuple),
         ObType::Set => serialize_seq!(PySet),
@@ -503,7 +467,13 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
                 PydanticSerializer::new(value, &extracted_serializer.serializer, include, exclude, &extra);
             pydantic_serializer.serialize(serializer)
         }
-        ObType::Dataclass => serialize_dict!(dataclass_to_dict(value).map_err(py_err_se_err)?),
+        ObType::Dataclass => serialize_pairs_json(
+            DataclassSerializer::new(value).map_err(py_err_se_err)?,
+            serializer,
+            include,
+            exclude,
+            extra,
+        ),
         ObType::Uuid => {
             let py_uuid: &PyAny = value.downcast().map_err(py_err_se_err)?;
             let uuid = super::type_serializers::uuid::uuid_to_string(py_uuid).map_err(py_err_se_err)?;
@@ -671,4 +641,72 @@ pub(crate) fn infer_json_key_known<'py>(ob_type: ObType, key: &'py PyAny, extra:
             }
         }
     }
+}
+
+fn serialize_pairs_python<'py>(
+    py: Python,
+    pairs_iter: impl Iterator<Item = PyResult<(&'py PyAny, &'py PyAny)>>,
+    include: Option<&PyAny>,
+    exclude: Option<&PyAny>,
+    extra: &Extra,
+) -> PyResult<PyObject> {
+    let new_dict = PyDict::new(py);
+    let filter = AnyFilter::new();
+
+    for result in pairs_iter {
+        let (k, v) = result?;
+        let op_next = filter.key_filter(k, include, exclude)?;
+        if let Some((next_include, next_exclude)) = op_next {
+            let v = infer_to_python(v, next_include, next_exclude, extra)?;
+            new_dict.set_item(k, v)?;
+        }
+    }
+    Ok(new_dict.into_py(py))
+}
+
+fn serialize_pairs_python_mode_json<'py>(
+    py: Python,
+    pairs_iter: impl Iterator<Item = PyResult<(&'py PyAny, &'py PyAny)>>,
+    include: Option<&PyAny>,
+    exclude: Option<&PyAny>,
+    extra: &Extra,
+) -> PyResult<PyObject> {
+    let new_dict = PyDict::new(py);
+    let filter = AnyFilter::new();
+
+    for result in pairs_iter {
+        let (k, v) = result?;
+        let op_next = filter.key_filter(k, include, exclude)?;
+        if let Some((next_include, next_exclude)) = op_next {
+            let k_str = infer_json_key(k, extra)?;
+            let k = PyString::new(py, &k_str);
+            let v = infer_to_python(v, next_include, next_exclude, extra)?;
+            new_dict.set_item(k, v)?;
+        }
+    }
+    Ok(new_dict.into_py(py))
+}
+
+fn serialize_pairs_json<'py, S: Serializer>(
+    pairs_iter: impl Iterator<Item = PyResult<(&'py PyAny, &'py PyAny)>>,
+    serializer: S,
+    include: Option<&PyAny>,
+    exclude: Option<&PyAny>,
+    extra: &Extra,
+) -> Result<S::Ok, S::Error> {
+    let (_, expected) = pairs_iter.size_hint();
+    let mut map = serializer.serialize_map(expected)?;
+    let filter = AnyFilter::new();
+
+    for result in pairs_iter {
+        let (key, value) = result.map_err(py_err_se_err)?;
+
+        let op_next = filter.key_filter(key, include, exclude).map_err(py_err_se_err)?;
+        if let Some((next_include, next_exclude)) = op_next {
+            let key = infer_json_key(key, extra).map_err(py_err_se_err)?;
+            let value_serializer = SerializeInfer::new(value, next_include, next_exclude, extra);
+            map.serialize_entry(&key, &value_serializer)?;
+        }
+    }
+    map.end()
 }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -365,17 +365,17 @@ pub(crate) fn to_json_bytes(
     Ok(bytes)
 }
 
-pub(super) struct DictResultIterator<'py> {
+pub(super) struct DictIterator<'py> {
     dict_iter: PyDictIterator<'py>,
 }
 
-impl<'py> DictResultIterator<'py> {
+impl<'py> DictIterator<'py> {
     pub fn new(dict: &'py PyDict) -> Self {
         Self { dict_iter: dict.iter() }
     }
 }
 
-impl<'py> Iterator for DictResultIterator<'py> {
+impl<'py> Iterator for DictIterator<'py> {
     type Item = PyResult<(&'py PyAny, &'py PyAny)>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -387,13 +387,13 @@ impl<'py> Iterator for DictResultIterator<'py> {
     }
 }
 
-pub(super) struct DataclassSerializer<'py> {
+pub(super) struct AnyDataclassIterator<'py> {
     dataclass: &'py PyAny,
     fields_iter: PyDictIterator<'py>,
     field_type_marker: &'py PyAny,
 }
 
-impl<'py> DataclassSerializer<'py> {
+impl<'py> AnyDataclassIterator<'py> {
     pub fn new(dc: &'py PyAny) -> PyResult<Self> {
         let py = dc.py();
         let fields: &PyDict = dc.getattr(intern!(py, "__dataclass_fields__"))?.downcast()?;
@@ -420,7 +420,7 @@ impl<'py> DataclassSerializer<'py> {
     }
 }
 
-impl<'py> Iterator for DataclassSerializer<'py> {
+impl<'py> Iterator for AnyDataclassIterator<'py> {
     type Item = PyResult<(&'py PyAny, &'py PyAny)>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -141,7 +141,7 @@ impl TypeSerializer for DataclassSerializer {
             if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
                 let output_dict = fields_serializer.main_to_python(
                     py,
-                    DataclassResultIterator::new(&self.fields, value),
+                    KnownDataclassIterator::new(&self.fields, value),
                     include,
                     exclude,
                     dc_extra,
@@ -182,7 +182,7 @@ impl TypeSerializer for DataclassSerializer {
             if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
                 let expected_len = self.fields.len() + fields_serializer.computed_field_count();
                 let mut map = fields_serializer.main_serde_serialize(
-                    DataclassResultIterator::new(&self.fields, value),
+                    KnownDataclassIterator::new(&self.fields, value),
                     expected_len,
                     serializer,
                     include,
@@ -211,13 +211,13 @@ impl TypeSerializer for DataclassSerializer {
     }
 }
 
-pub struct DataclassResultIterator<'a, 'py> {
+pub struct KnownDataclassIterator<'a, 'py> {
     index: usize,
     fields: &'a [Py<PyString>],
     dataclass: &'py PyAny,
 }
 
-impl<'a, 'py> DataclassResultIterator<'a, 'py> {
+impl<'a, 'py> KnownDataclassIterator<'a, 'py> {
     pub fn new(fields: &'a [Py<PyString>], dataclass: &'py PyAny) -> Self {
         Self {
             index: 0,
@@ -227,7 +227,7 @@ impl<'a, 'py> DataclassResultIterator<'a, 'py> {
     }
 }
 
-impl<'a, 'py> Iterator for DataclassResultIterator<'a, 'py> {
+impl<'a, 'py> Iterator for KnownDataclassIterator<'a, 'py> {
     type Item = PyResult<(&'py PyAny, &'py PyAny)>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -228,7 +228,7 @@ impl<'a, 'py> DataclassResultIterator<'a, 'py> {
 }
 
 impl<'a, 'py> Iterator for DataclassResultIterator<'a, 'py> {
-    type Item = PyResult<(&'py PyString, &'py PyAny)>;
+    type Item = PyResult<(&'py PyAny, &'py PyAny)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(field) = self.fields.get(self.index) {

--- a/tests/benchmarks/test_serialization_micro.py
+++ b/tests/benchmarks/test_serialization_micro.py
@@ -449,3 +449,9 @@ def test_dataclass_serialization_json(benchmark):
     dc = Foo(a='hello', b=b'more', c=123, d=1.23)
     assert s.to_python(dc) == {'a': 'hello', 'b': b'more', 'c': 123, 'd': 1.23}
     benchmark(s.to_json, dc)
+
+
+@pytest.mark.benchmark(group='dataclass-ser')
+def test_dataclass_to_json(benchmark):
+    dc = Foo(a='hello', b=b'more', c=123, d=1.23)
+    benchmark(to_json, dc)

--- a/tests/benchmarks/test_serialization_micro.py
+++ b/tests/benchmarks/test_serialization_micro.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from datetime import date, datetime
 from uuid import UUID
 
@@ -409,3 +410,42 @@ def test_ser_list_of_lists(benchmark):
     data = [[i + j for j in range(10)] for i in range(1000)]
 
     benchmark(s.to_json, data)
+
+
+@dataclass
+class Foo:
+    a: str
+    b: bytes
+    c: int
+    d: float
+
+
+dataclass_schema = core_schema.dataclass_schema(
+    Foo,
+    core_schema.dataclass_args_schema(
+        'Foo',
+        [
+            core_schema.dataclass_field(name='a', schema=core_schema.str_schema()),
+            core_schema.dataclass_field(name='b', schema=core_schema.bytes_schema()),
+            core_schema.dataclass_field(name='c', schema=core_schema.int_schema()),
+            core_schema.dataclass_field(name='d', schema=core_schema.float_schema()),
+        ],
+    ),
+    ['a', 'b', 'c', 'd'],
+)
+
+
+@pytest.mark.benchmark(group='dataclass-ser')
+def test_dataclass_serialization_python(benchmark):
+    s = SchemaSerializer(dataclass_schema)
+    dc = Foo(a='hello', b=b'more', c=123, d=1.23)
+    assert s.to_python(dc) == {'a': 'hello', 'b': b'more', 'c': 123, 'd': 1.23}
+    benchmark(s.to_python, dc)
+
+
+@pytest.mark.benchmark(group='dataclass-ser')
+def test_dataclass_serialization_json(benchmark):
+    s = SchemaSerializer(dataclass_schema)
+    dc = Foo(a='hello', b=b'more', c=123, d=1.23)
+    assert s.to_python(dc) == {'a': 'hello', 'b': b'more', 'c': 123, 'd': 1.23}
+    benchmark(s.to_json, dc)


### PR DESCRIPTION
Previously we created an intermediate dict from dataclass fields, then iterated over that doing serialization, this avoids the intermediate dict.

From local testing it gives a nice 15% speedup.

```
┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃  Group          ┃  Benchmark                       ┃  Before (ns/iter)  ┃  After (ns/iter)  ┃   Change  ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│  dataclass-ser  │  dataclass_serialization_python  │             637.9  │            510.4  │  -19.99%  │
│                 │  dataclass_serialization_json    │             679.2  │            565.0  │  -16.83%  │
│                 │  dataclass_to_json               │           1_586.8  │          1_030.9  │  -35.03%  │
└─────────────────┴──────────────────────────────────┴────────────────────┴───────────────────┴───────────┘
```