### PR TITLE
Add support for dataclass fields init

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2985,6 +2985,7 @@ class DataclassField(TypedDict, total=False):
     name: Required[str]
     schema: Required[CoreSchema]
     kw_only: bool  # default: True
+    init: bool  # default: True
     init_only: bool  # default: False
     frozen: bool  # default: False
     validation_alias: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
@@ -2998,6 +2999,7 @@ def dataclass_field(
     schema: CoreSchema,
     *,
     kw_only: bool | None = None,
+    init: bool | None = None,
     init_only: bool | None = None,
     validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
     serialization_alias: str | None = None,
@@ -3023,6 +3025,7 @@ def dataclass_field(
         name: The name to use for the argument parameter
         schema: The schema to use for the argument parameter
         kw_only: Whether the field can be set with a positional argument as well as a keyword argument
+        init: Whether the field should be validated during initialization
         init_only: Whether the field should be omitted  from `__dict__` and passed to `__post_init__`
         validation_alias: The alias(es) to use to find the field in the validation data
         serialization_alias: The alias to use as a key when serializing
@@ -3035,6 +3038,7 @@ def dataclass_field(
         name=name,
         schema=schema,
         kw_only=kw_only,
+        init=init,
         init_only=init_only,
         validation_alias=validation_alias,
         serialization_alias=serialization_alias,

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -185,7 +185,17 @@ impl Validator for DataclassArgsValidator {
                                         set_item!(field, value);
                                     },
                                     Ok(None) => continue,
-                                    Err(_) => continue
+                                    Err(ValError::Omit) => continue,
+                                    Err(ValError::LineErrors(line_errors)) => {
+                                        for err in line_errors {
+                                            // Note: this will always use the field name even if there is an alias
+                                            // However, we don't mind so much because this error can only happen if the
+                                            // default value fails validation, which is arguably a developer error.
+                                            // We could try to "fix" this in the future if desired.
+                                            errors.push(err);
+                                        }
+                                    }
+                                    Err(err) => return Err(err),
                                 };
                             };
 

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -186,15 +186,11 @@ impl Validator for DataclassArgsValidator {
                                     },
                                     Ok(None) => continue,
                                     Err(ValError::Omit) => continue,
-                                    Err(ValError::LineErrors(line_errors)) => {
-                                        for err in line_errors {
-                                            // Note: this will always use the field name even if there is an alias
-                                            // However, we don't mind so much because this error can only happen if the
-                                            // default value fails validation, which is arguably a developer error.
-                                            // We could try to "fix" this in the future if desired.
-                                            errors.push(err);
-                                        }
-                                    }
+                                    // Note: this will always use the field name even if there is an alias
+                                    // However, we don't mind so much because this error can only happen if the
+                                    // default value fails validation, which is arguably a developer error.
+                                    // We could try to "fix" this in the future if desired.
+                                    Err(ValError::LineErrors(line_errors)) => errors.extend(line_errors),
                                     Err(err) => return Err(err),
                                 };
                                 continue;

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -26,6 +26,7 @@ struct Field {
     kw_only: bool,
     name: String,
     py_name: Py<PyString>,
+    init: bool,
     init_only: bool,
     lookup_key: LookupKey,
     validator: CombinedValidator,
@@ -107,6 +108,7 @@ impl BuildValidator for DataclassArgsValidator {
                 py_name: py_name.into(),
                 lookup_key,
                 validator,
+                init: field.get_as(intern!(py, "init"))?.unwrap_or(true),
                 init_only: field.get_as(intern!(py, "init_only"))?.unwrap_or(false),
                 frozen: field.get_as::<bool>(intern!(py, "frozen"))?.unwrap_or(false),
             });
@@ -176,6 +178,8 @@ impl Validator for DataclassArgsValidator {
                     ($args:ident, $get_method:ident, $get_macro:ident, $slice_macro:ident) => {{
                         // go through fields getting the value from args or kwargs and validating it
                         for (index, field) in self.fields.iter().enumerate() {
+                            if (!field.init) { continue };
+
                             let mut pos_value = None;
                             if let Some(args) = $args.args {
                                 if !field.kw_only {

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -184,8 +184,7 @@ impl Validator for DataclassArgsValidator {
                                         // Default value exists, and passed validation if required
                                         set_item!(field, value);
                                     },
-                                    Ok(None) => continue,
-                                    Err(ValError::Omit) => continue,
+                                    Ok(None) | Err(ValError::Omit) => continue,
                                     // Note: this will always use the field name even if there is an alias
                                     // However, we don't mind so much because this error can only happen if the
                                     // default value fails validation, which is arguably a developer error.

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -197,6 +197,7 @@ impl Validator for DataclassArgsValidator {
                                     }
                                     Err(err) => return Err(err),
                                 };
+                                continue;
                             };
 
                             let mut pos_value = None;

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -178,7 +178,16 @@ impl Validator for DataclassArgsValidator {
                     ($args:ident, $get_method:ident, $get_macro:ident, $slice_macro:ident) => {{
                         // go through fields getting the value from args or kwargs and validating it
                         for (index, field) in self.fields.iter().enumerate() {
-                            if (!field.init) { continue };
+                            if (!field.init) {
+                                match field.validator.default_value(py, Some(field.name.as_str()), state) {
+                                    Ok(Some(value)) => {
+                                        // Default value exists, and passed validation if required
+                                        set_item!(field, value);
+                                    },
+                                    Ok(None) => continue,
+                                    Err(_) => continue
+                                };
+                            };
 
                             let mut pos_value = None;
                             if let Some(args) = $args.args {

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -1597,6 +1597,11 @@ def test_leak_dataclass(validator):
 init_test_cases = [
     ({'a': 'hello', 'b': 'bye'}, 'ignore', {'a': 'hello', 'b': 'HELLO'}),
     ({'a': 'hello'}, 'ignore', {'a': 'hello', 'b': 'HELLO'}),
+    # note, for the case below, we don't actually support this case in Pydantic
+    # it's disallowed in Pydantic to have a model with extra='allow' and a field
+    # with init=False, so this case isn't really possible at the momment
+    # however, no conflict arises here because we don't pass in the value for b
+    # to __init__
     ({'a': 'hello'}, 'allow', {'a': 'hello', 'b': 'HELLO'}),
     (
         {'a': 'hello', 'b': 'bye'},
@@ -1621,6 +1626,11 @@ init_test_cases = [
     'input_value,extra_behavior,expected',
     [
         *init_test_cases,
+        # special case - when init=False, extra='allow', and the value is provided
+        # currently, it's disallowed in Pydantic to have a model with extra='allow'
+        # and a field with init=False, so this case isn't really possible at the momment
+        # TODO: open to changing this behavior, and changes won't be significantly breaking
+        # because we currently don't support this case
         ({'a': 'hello', 'b': 'bye'}, 'allow', {'a': 'hello', 'b': 'HELLO'}),
     ],
 )

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -1597,7 +1597,6 @@ def test_leak_dataclass(validator):
 init_test_cases = [
     ({'a': 'hello', 'b': 'bye'}, 'ignore', {'a': 'hello', 'b': 'HELLO'}),
     ({'a': 'hello'}, 'ignore', {'a': 'hello', 'b': 'HELLO'}),
-    ({'a': 'hello', 'b': 'bye'}, 'allow', {'a': 'hello', 'b': 'HELLO'}),
     ({'a': 'hello'}, 'allow', {'a': 'hello', 'b': 'HELLO'}),
     (
         {'a': 'hello', 'b': 'bye'},
@@ -1620,7 +1619,10 @@ init_test_cases = [
 
 @pytest.mark.parametrize(
     'input_value,extra_behavior,expected',
-    init_test_cases,
+    [
+        *init_test_cases,
+        ({'a': 'hello', 'b': 'bye'}, 'allow', {'a': 'hello', 'b': 'HELLO'}),
+    ],
 )
 def test_dataclass_args_init(input_value, extra_behavior, expected):
     @dataclasses.dataclass
@@ -1659,7 +1661,11 @@ def test_dataclass_args_init(input_value, extra_behavior, expected):
 
 @pytest.mark.parametrize(
     'input_value,extra_behavior,expected',
-    init_test_cases,
+    [
+        *init_test_cases,
+        # special case - allow override of default, even when init=False, if extra='allow'
+        ({'a': 'hello', 'b': 'bye'}, 'allow', {'a': 'hello', 'b': 'bye'}),
+    ],
 )
 def test_dataclass_args_init_with_default(input_value, extra_behavior, expected):
     @dataclasses.dataclass
@@ -1675,7 +1681,7 @@ def test_dataclass_args_init_with_default(input_value, extra_behavior, expected)
                 core_schema.dataclass_field(name='a', schema=core_schema.str_schema()),
                 core_schema.dataclass_field(
                     name='b',
-                    schema=core_schema.with_default_schema(core_schema.str_schema(), default='HELLO'),
+                    schema=core_schema.with_default_schema(schema=core_schema.str_schema(), default='HELLO'),
                     init=False,
                 ),
             ],

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -1664,6 +1664,9 @@ def test_dataclass_args_init(input_value, extra_behavior, expected):
     [
         *init_test_cases,
         # special case - allow override of default, even when init=False, if extra='allow'
+        # TODO: we haven't really decided if this should be allowed or not
+        # currently, it's disallowed in Pydantic to have a model with extra='allow'
+        # and a field with init=False, so this case isn't really possible at the momment
         ({'a': 'hello', 'b': 'bye'}, 'allow', {'a': 'hello', 'b': 'bye'}),
     ],
 )


### PR DESCRIPTION
We might want more careful error handling in certain circumstances. In particular, the default behavior of pydantic dataclasses of ignoring extra could end up being confusing for people who don't realize what `init=False` is supposed to do, as this implementation results in it being ignored the same as any other attribute. I do think this is the most "consistent" behavior with other functionality, and that if you want it to be an _error_ to pass the value it should probably have the `extra='forbid'` set in the config. Open to disagreement though.

Also, needs tests added.