### PR TITLE
uprev to jiter v0.0.6, uprev pydantic-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,9 +100,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -138,11 +148,12 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jiter"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184598fea113663dd78e33a24ad3a1e7ba8ceedf71effb7406b3f2eccb63ed1"
+checksum = "87db066a99f69382be06d02313f8ce989996b53a04a8a70cfd1a6483a56227f7"
 dependencies = [
  "ahash",
+ "hashbrown",
  "lexical-core",
  "num-bigint",
  "num-traits",
@@ -321,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "ahash",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.15.0"
+version = "2.16.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"
@@ -43,7 +43,7 @@ base64 = "0.21.7"
 num-bigint = "0.4.4"
 python3-dll-a = "0.2.7"
 uuid = "1.6.1"
-jiter = {version = "0.0.5", features = ["python"]}
+jiter = {version = "0.0.6", features = ["python"]}
 
 [lib]
 name = "_pydantic_core"


### PR DESCRIPTION
See https://github.com/pydantic/jiter/releases/tag/v0.0.6 for details on jiter release.

Also, preparing for v2.16.0 release.