### PR TITLE
ensure recursion guard is always used as a stack

### DIFF
--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -10,7 +10,7 @@ use crate::py_gc::PyGcTraverse;
 
 use config::SerializationConfig;
 pub use errors::{PydanticSerializationError, PydanticSerializationUnexpectedValue};
-use extra::{CollectWarnings, SerRecursionGuard};
+use extra::{CollectWarnings, SerRecursionState};
 pub(crate) use extra::{Extra, SerMode, SerializationState};
 pub use shared::CombinedSerializer;
 use shared::{to_json_bytes, BuildSerializer, TypeSerializer};
@@ -52,7 +52,7 @@ impl SchemaSerializer {
         exclude_defaults: bool,
         exclude_none: bool,
         round_trip: bool,
-        rec_guard: &'a SerRecursionGuard,
+        rec_guard: &'a SerRecursionState,
         serialize_unknown: bool,
         fallback: Option<&'a PyAny>,
     ) -> Extra<'b> {
@@ -113,7 +113,7 @@ impl SchemaSerializer {
     ) -> PyResult<PyObject> {
         let mode: SerMode = mode.into();
         let warnings = CollectWarnings::new(warnings);
-        let rec_guard = SerRecursionGuard::default();
+        let rec_guard = SerRecursionState::default();
         let extra = self.build_extra(
             py,
             &mode,
@@ -152,7 +152,7 @@ impl SchemaSerializer {
         fallback: Option<&PyAny>,
     ) -> PyResult<PyObject> {
         let warnings = CollectWarnings::new(warnings);
-        let rec_guard = SerRecursionGuard::default();
+        let rec_guard = SerRecursionState::default();
         let extra = self.build_extra(
             py,
             &SerMode::Json,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -6,7 +6,7 @@ use pyo3::types::PyDict;
 
 use crate::errors::{ErrorType, LocItem, ValError, ValResult};
 use crate::input::{GenericIterator, Input};
-use crate::recursion_guard::RecursionGuard;
+use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
 use crate::ValidationError;
 
@@ -212,7 +212,7 @@ pub struct InternalValidator {
     from_attributes: Option<bool>,
     context: Option<PyObject>,
     self_instance: Option<PyObject>,
-    recursion_guard: RecursionGuard,
+    recursion_guard: RecursionState,
     pub(crate) exactness: Option<Exactness>,
     validation_mode: InputType,
     hide_input_in_errors: bool,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -13,7 +13,7 @@ use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::errors::{LocItem, ValError, ValResult, ValidationError};
 use crate::input::{Input, InputType, StringMapping};
 use crate::py_gc::PyGcTraverse;
-use crate::recursion_guard::RecursionGuard;
+use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
 
 mod any;
@@ -263,7 +263,7 @@ impl SchemaValidator {
             self_instance: None,
         };
 
-        let guard = &mut RecursionGuard::default();
+        let guard = &mut RecursionState::default();
         let mut state = ValidationState::new(extra, guard);
         self.validator
             .validate_assignment(py, obj, field_name, field_value, &mut state)
@@ -280,7 +280,7 @@ impl SchemaValidator {
             context,
             self_instance: None,
         };
-        let recursion_guard = &mut RecursionGuard::default();
+        let recursion_guard = &mut RecursionState::default();
         let mut state = ValidationState::new(extra, recursion_guard);
         let r = self.validator.default_value(py, None::<i64>, &mut state);
         match r {
@@ -326,7 +326,7 @@ impl SchemaValidator {
     where
         's: 'data,
     {
-        let mut recursion_guard = RecursionGuard::default();
+        let mut recursion_guard = RecursionState::default();
         let mut state = ValidationState::new(
             Extra::new(strict, from_attributes, context, self_instance, input_type),
             &mut recursion_guard,
@@ -378,7 +378,7 @@ impl<'py> SelfValidator<'py> {
     }
 
     pub fn validate_schema(&self, py: Python<'py>, schema: &'py PyAny, strict: Option<bool>) -> PyResult<&'py PyAny> {
-        let mut recursion_guard = RecursionGuard::default();
+        let mut recursion_guard = RecursionState::default();
         let mut state = ValidationState::new(
             Extra::new(strict, None, None, None, InputType::Python),
             &mut recursion_guard,

--- a/src/validators/validation_state.rs
+++ b/src/validators/validation_state.rs
@@ -1,4 +1,4 @@
-use crate::recursion_guard::RecursionGuard;
+use crate::recursion_guard::{ContainsRecursionState, RecursionState};
 
 use super::Extra;
 
@@ -10,14 +10,14 @@ pub enum Exactness {
 }
 
 pub struct ValidationState<'a> {
-    pub recursion_guard: &'a mut RecursionGuard,
+    pub recursion_guard: &'a mut RecursionState,
     pub exactness: Option<Exactness>,
     // deliberately make Extra readonly
     extra: Extra<'a>,
 }
 
 impl<'a> ValidationState<'a> {
-    pub fn new(extra: Extra<'a>, recursion_guard: &'a mut RecursionGuard) -> Self {
+    pub fn new(extra: Extra<'a>, recursion_guard: &'a mut RecursionState) -> Self {
         Self {
             recursion_guard, // Don't care about exactness unless doing union validation
             exactness: None,
@@ -81,6 +81,12 @@ impl<'a> ValidationState<'a> {
             }
             Some(Exactness::Exact) => self.exactness = Some(exactness),
         }
+    }
+}
+
+impl ContainsRecursionState for ValidationState<'_> {
+    fn access_recursion_state<R>(&mut self, f: impl FnOnce(&mut RecursionState) -> R) -> R {
+        f(self.recursion_guard)
     }
 }
 


### PR DESCRIPTION
## Change Summary

Introduces `RecursionGuard` as a type which goes in a function frame and releases on drop.

This fixes the issue seen updating to 2.16.0.

Because `RecursionGuard` takes ownership of the state, it guarantees that two guards can't overlap their usage of the state.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
