### PR TITLE
fix(url): fix host extra trailing slash issue

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -177,15 +177,25 @@ impl PyUrl {
         };
         let mut url = format!("{scheme}://{url_host}");
         if let Some(path) = path {
-            url.push('/');
-            url.push_str(path);
+            if !url.ends_with('/') {
+                url.push('/');
+            }
+            if path.starts_with('/') {
+                url.push_str(path.trim_start_matches('/'));
+            } else {
+                url.push_str(path);
+            }
         }
         if let Some(query) = query {
-            url.push('?');
+            if !query.starts_with('?') {
+                url.push('?');
+            }
             url.push_str(query);
         }
         if let Some(fragment) = fragment {
-            url.push('#');
+            if !fragment.starts_with('#') {
+                url.push('#');
+            }
             url.push_str(fragment);
         }
         cls.call1((url,))
@@ -405,15 +415,25 @@ impl PyMultiHostUrl {
             };
 
         if let Some(path) = path {
-            url.push('/');
-            url.push_str(path);
+            if !url.ends_with('/') {
+                url.push('/');
+            }
+            if path.starts_with('/') {
+                url.push_str(path.trim_start_matches('/'));
+            } else {
+                url.push_str(path);
+            }
         }
         if let Some(query) = query {
-            url.push('?');
+            if !query.starts_with('?') {
+                url.push('?');
+            }
             url.push_str(query);
         }
         if let Some(fragment) = fragment {
-            url.push('#');
+            if !fragment.starts_with('#') {
+                url.push('#');
+            }
             url.push_str(fragment);
         }
         cls.call1((url,))

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -1259,6 +1259,20 @@ def test_multi_url_build() -> None:
     assert url == MultiHostUrl('postgresql://testuser:testpassword@127.0.0.1:5432/database?sslmode=require#test')
     assert str(url) == 'postgresql://testuser:testpassword@127.0.0.1:5432/database?sslmode=require#test'
 
+    # assert that `build` builds correctly with leading slash in path, leading question mark in query and leading hash in fragment
+    url = MultiHostUrl.build(
+        scheme='postgresql',
+        username='testuser',
+        password='testpassword',
+        host='127.0.0.1',
+        port=5432,
+        path='/database',
+        query='?sslmode=require',
+        fragment='#test',
+    )
+    assert url == MultiHostUrl('postgresql://testuser:testpassword@127.0.0.1:5432/database?sslmode=require#test')
+    assert str(url) == 'postgresql://testuser:testpassword@127.0.0.1:5432/database?sslmode=require#test'
+
 
 @pytest.mark.parametrize('field', ['host', 'password', 'username', 'port'])
 def test_multi_url_build_hosts_set_with_single_value(field) -> None:


### PR DESCRIPTION
## Change Summary

Currently `Url.build` and `MultiHostUrl.build` methods both have a bug, where there is an extra slash always added after `host` before `path`, regardless of whether any of them already have trailing/leading slash. This PR adds checks to make sure that there will only single slash in the resulting URL. Additionally, added similar checks to `query` and `fragment` appends, so jsut in case any of the contain leading `?`/`#`.

## Related issue number

I haven't found any related issue in this repo, but there were related issues in `pydantic/pydantic` repo.

## Checklist

* [+] Unit tests for the changes exist
* [+] Documentation reflects the changes where applicable
* [+] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [+] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt