### PR TITLE
Fix model computed field serializer (json)

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -75,7 +75,7 @@ impl ComputedFields {
             let property_name_py = computed_field.property_name_py.as_ref(model.py());
             let value = model.getattr(property_name_py).map_err(py_err_se_err)?;
             if extra.exclude_none && value.is_none() {
-                return Ok(());
+                continue;
             }
             if let Some((next_include, next_exclude)) = filter
                 .key_filter(property_name_py, include, exclude)


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8691

Effectively, we were skipping the serialization of some computed fields on accident, now we're not.