### PR TITLE
fix: 8699 union with generator

### DIFF
--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -132,6 +132,7 @@ impl UnionValidator {
             if input_ref.is_instance_of::<PyList>()
                 || input_ref.is_instance_of::<PyTuple>()
                 || input_ref.is_instance_of::<PySet>()
+                || input_ref.is_exact_instance_of::<PyDict>()
             {
                 result = choice.validate(py, input, state);
             } else {

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -803,3 +803,23 @@ def test_model_and_literal_union() -> None:
     assert isinstance(m, ModelA)
     assert m.a == 42
     assert validator.validate_python(True) is True
+
+
+def test_model_and_generator_union() -> None:
+    # see https://github.com/pydantic/pydantic/issues/8699
+
+    def gen():
+        for val in range(3):
+            yield val
+
+    validator = SchemaValidator(
+        {
+            'type': 'union',
+            'choices': [
+                {'type': 'list', 'items_schema': {'type': 'str'}},
+                {'type': 'list', 'items_schema': {'type': 'int'}},
+            ],
+        }
+    )
+
+    assert validator.validate_python(gen()) == [0, 1, 2]


### PR DESCRIPTION
## Change Summary
This PR tries to solve this pydantic problem https://github.com/pydantic/pydantic/issues/8699. 

If a generator is given as input and the validation is a union, then after the first check the generator is exhausted. This results in an empty value list if the valid type wasn't on the first position. The idea is to save the generator output between runs of the union validation.

## Related issue number
fix #8699 (pydantic)

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
