### PR TITLE
fix: 8699 union with generator

### DIFF
--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -22,7 +22,7 @@ mod extra;
 mod fields;
 mod filter;
 mod infer;
-mod ob_type;
+pub mod ob_type;
 pub mod ser;
 mod shared;
 mod type_serializers;

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -10,7 +10,6 @@ use strum::Display;
 use strum_macros::EnumString;
 
 use crate::url::{PyMultiHostUrl, PyUrl};
-
 #[derive(Debug, Clone)]
 pub struct ObTypeLookup {
     // valid JSON types

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -10,6 +10,7 @@ use strum::Display;
 use strum_macros::EnumString;
 
 use crate::url::{PyMultiHostUrl, PyUrl};
+
 #[derive(Debug, Clone)]
 pub struct ObTypeLookup {
     // valid JSON types

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -125,6 +125,7 @@ impl UnionValidator {
 
         let mut gen_values: Vec<&PyAny> = Vec::new();
         let is_gen = input_ref.get_type().is(generator_object.as_ref(py));
+        // Save generator values in vector, as they will be lost on another union choice check.
         if is_gen {
             let values = input.lax_list()?;
             let seq = values.as_sequence_iterator(py)?;

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -150,10 +150,12 @@ impl UnionValidator {
 
             state.exactness = Some(Exactness::Exact);
 
-            let saved_ref = gen_values.clone().into_py(py);
-            let saved_input = saved_ref.as_ref(py);
             let result = match is_gen {
-                true => choice.validate(py, saved_input, state),
+                true => {
+                    let saved_ref = gen_values.clone().into_py(py);
+                    let saved_input = saved_ref.as_ref(py);
+                    choice.validate(py, saved_input, state)
+                }
                 false => choice.validate(py, input, state),
             };
             match result {

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -803,3 +803,22 @@ def test_model_and_literal_union() -> None:
     assert isinstance(m, ModelA)
     assert m.a == 42
     assert validator.validate_python(True) is True
+
+def test_model_and_generator_union() -> None:
+    # see https://github.com/pydantic/pydantic/issues/8699
+
+    def gen():
+        for val in range(3):
+            yield val
+
+    validator = SchemaValidator(
+        {
+            'type': 'union',
+            'choices': [
+                {'type': 'list', 'items_schema': {'type': 'str'}},
+                {'type': 'list', 'items_schema': {'type': 'int'}},
+            ],
+        }
+    )
+
+    assert validator.validate_python(gen()) == [0, 1, 2]

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -804,6 +804,7 @@ def test_model_and_literal_union() -> None:
     assert m.a == 42
     assert validator.validate_python(True) is True
 
+
 def test_model_and_generator_union() -> None:
     # see https://github.com/pydantic/pydantic/issues/8699
 


### PR DESCRIPTION
## Change Summary
This PR tries to solve this pydantic problem https://github.com/pydantic/pydantic/issues/8699. 

If a generator is given as input and the validation is a union, then after the first check the generator is exhausted. This results in an empty value list if the valid type wasn't on the first position. The idea is to save the generator output between runs of the union validation.

## Related issue number
fix #8699 (pydantic)

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin