### PR TITLE
`date` string coerced to `datetime` shouldn't infer timezone

### DIFF
--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -140,7 +140,6 @@ impl Validator for DateTimeValidator {
 }
 
 /// In lax mode, if the input is not a datetime, we try parsing the input as a date and add the "00:00:00" time.
-///
 /// Ok(None) means that this is not relevant to datetimes (the input was not a date nor a string)
 fn datetime_from_date<'data>(input: &'data impl Input<'data>) -> Result<Option<EitherDateTime<'data>>, ValError> {
     let either_date = match input.validate_date(false) {
@@ -171,7 +170,7 @@ fn datetime_from_date<'data>(input: &'data impl Input<'data>) -> Result<Option<E
         minute: 0,
         second: 0,
         microsecond: 0,
-        tz_offset: Some(0),
+        tz_offset: None,
     };
 
     let datetime = DateTime {

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -19,7 +19,7 @@ from ..conftest import Err, PyAndJson
     [
         (datetime(2022, 6, 8, 12, 13, 14), datetime(2022, 6, 8, 12, 13, 14)),
         (date(2022, 6, 8), datetime(2022, 6, 8)),
-        ('2022-01-01', datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc)),
+        ('2022-01-01', datetime(2022, 1, 1, 0, 0, 0)),
         ('2022-06-08T12:13:14', datetime(2022, 6, 8, 12, 13, 14)),
         ('1000000000000', datetime(2001, 9, 9, 1, 46, 40, tzinfo=timezone.utc)),
         (b'2022-06-08T12:13:14', datetime(2022, 6, 8, 12, 13, 14)),


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8762