### PR TITLE
Fix TzInfo equality check based on offset

### DIFF
--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -569,14 +569,7 @@ impl TzInfo {
             let offset_delta = other.call_method1(intern!(py, "utcoffset"), (py.None().as_ref(py),))?;
             let offset_seconds: f64 = offset_delta.call_method0(intern!(py, "total_seconds"))?.extract()?;
             let offset = offset_seconds.round() as i32;
-            match op {
-                CompareOp::Lt => Ok((self.seconds < offset).into_py(py)),
-                CompareOp::Le => Ok((self.seconds <= offset).into_py(py)),
-                CompareOp::Eq => Ok((self.seconds == offset).into_py(py)),
-                CompareOp::Ne => Ok((self.seconds != offset).into_py(py)),
-                CompareOp::Gt => Ok((self.seconds > offset).into_py(py)),
-                CompareOp::Ge => Ok((self.seconds >= offset).into_py(py)),
-            }
+            Ok(op.matches(self.seconds.cmp(&offset)).into_py(py))
         } else {
             Ok(py.NotImplemented())
         }

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -566,7 +566,10 @@ impl TzInfo {
     fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> PyResult<Py<PyAny>> {
         let py = other.py();
         if other.is_instance_of::<PyTzInfo>() {
-            let offset_delta = other.call_method1(intern!(py, "utcoffset"), (py.None().as_ref(py),))?;
+            let offset_delta = other.call_method1(intern!(py, "utcoffset"), (py.None(),))?;
+            if offset_delta.is_none() {
+                return Ok(py.NotImplemented());
+            }
             let offset_seconds: f64 = offset_delta.call_method0(intern!(py, "total_seconds"))?.extract()?;
             let offset = offset_seconds.round() as i32;
             Ok(op.matches(self.seconds.cmp(&offset)).into_py(py))

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone, tzinfo
 
 from pydantic_core import SchemaValidator, TzInfo, core_schema
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 
 
@@ -174,7 +174,7 @@ class TestTzInfo(unittest.TestCase):
         estdatetime = self.DT.replace(tzinfo=timezone(-timedelta(hours=5)))
         self.assertTrue(self.EST == estdatetime.tzinfo)
         self.assertTrue(tz > estdatetime.tzinfo)
-        if sys.version_info > (3, 8) and sys.platform == 'linux':
+        if sys.version_info >= (3, 9) and sys.platform == 'linux':
             self.assertFalse(tz == ZoneInfo('Europe/London'))
 
     def test_copy(self):

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -175,6 +175,7 @@ class TestTzInfo(unittest.TestCase):
         self.assertTrue(self.EST == estdatetime.tzinfo)
         self.assertTrue(tz > estdatetime.tzinfo)
         if sys.version_info >= (3, 9) and sys.platform == 'linux':
+            self.assertFalse(tz == ZoneInfo('Europe/London'))
             with self.assertRaises(TypeError):
                 tz > ZoneInfo('Europe/London')
 

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -80,6 +80,7 @@ class TestTzInfo(unittest.TestCase):
     def setUp(self):
         self.ACDT = TzInfo(timedelta(hours=9.5).total_seconds())
         self.EST = TzInfo(-timedelta(hours=5).total_seconds())
+        self.UTC = TzInfo(timedelta(0).total_seconds())
         self.DT = datetime(2010, 1, 1)
 
     def test_str(self):
@@ -162,6 +163,13 @@ class TestTzInfo(unittest.TestCase):
         self.assertTrue(tz > SMALLEST)
         self.assertFalse(tz <= SMALLEST)
         self.assertTrue(tz >= SMALLEST)
+
+        # offset based comparion tests for tzinfo derived classes like datetime.timezone.
+        utcdatetime = self.DT.replace(tzinfo=timezone.utc)
+        self.assertTrue(tz == utcdatetime.tzinfo)
+        estdatetime = self.DT.replace(tzinfo=timezone(-timedelta(hours=5)))
+        self.assertTrue(self.EST == estdatetime.tzinfo)
+        self.assertTrue(tz > estdatetime.tzinfo)
 
     def test_copy(self):
         for tz in self.ACDT, self.EST:

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -1,12 +1,14 @@
 import copy
 import functools
 import pickle
+import sys
 import unittest
 from datetime import datetime, timedelta, timezone, tzinfo
 
-from zoneinfo import ZoneInfo
-
 from pydantic_core import SchemaValidator, TzInfo, core_schema
+
+if sys.version_info > (3, 8):
+    from zoneinfo import ZoneInfo
 
 
 class _ALWAYS_EQ:
@@ -172,7 +174,8 @@ class TestTzInfo(unittest.TestCase):
         estdatetime = self.DT.replace(tzinfo=timezone(-timedelta(hours=5)))
         self.assertTrue(self.EST == estdatetime.tzinfo)
         self.assertTrue(tz > estdatetime.tzinfo)
-        self.assertFalse(tz == ZoneInfo('Europe/London'))
+        if sys.version_info > (3, 8) and sys.platform == 'linux':
+            self.assertFalse(tz == ZoneInfo('Europe/London'))
 
     def test_copy(self):
         for tz in self.ACDT, self.EST:

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -4,6 +4,8 @@ import pickle
 import unittest
 from datetime import datetime, timedelta, timezone, tzinfo
 
+from zoneinfo import ZoneInfo
+
 from pydantic_core import SchemaValidator, TzInfo, core_schema
 
 
@@ -170,6 +172,7 @@ class TestTzInfo(unittest.TestCase):
         estdatetime = self.DT.replace(tzinfo=timezone(-timedelta(hours=5)))
         self.assertTrue(self.EST == estdatetime.tzinfo)
         self.assertTrue(tz > estdatetime.tzinfo)
+        self.assertFalse(tz == ZoneInfo('Europe/London'))
 
     def test_copy(self):
         for tz in self.ACDT, self.EST:

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -175,7 +175,8 @@ class TestTzInfo(unittest.TestCase):
         self.assertTrue(self.EST == estdatetime.tzinfo)
         self.assertTrue(tz > estdatetime.tzinfo)
         if sys.version_info >= (3, 9) and sys.platform == 'linux':
-            self.assertFalse(tz == ZoneInfo('Europe/London'))
+            with self.assertRaises(TypeError):
+                tz > ZoneInfo('Europe/London')
 
     def test_copy(self):
         for tz in self.ACDT, self.EST:


### PR DESCRIPTION
## Change Summary
comparison check doesn't works with `datatime.tzinfo` derived class- timezone. In this change, the comparison is based on offset set(in seconds) for tzinfo class.

## Related issue number
fix pydantic/pydantic#8683
Also partially fixes pydantic/pydantic#8195, in this the issue is that comparison check for different tzinfo fails.
- In case of utc there is instancecheck and identity check with `is`. 
- but in case of other timezones it does equality check. [link](https://github.com/pandas-dev/pandas/blob/479b5dcbed643e5356b4a2a45bac6c14ab0a8b36/pandas/_libs/tslibs/timezones.pyx#L413)

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb