### PR TITLE
Update pyodide to 0.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
           # NOTE!: as per https://github.com/pydantic/pydantic-core/pull/149 this version needs to match the version
           # in node_modules/pyodide/repodata.json, to get the version, run:
           # `cat node_modules/pyodide/repodata.json | python -m json.tool | rg platform`
-          version: '3.1.32'
+          version: '3.1.46'
           actions-cache-folder: emsdk-cache
 
       - run: pip install 'maturin>=1,<2' 'ruff==0.1.3' typing_extensions

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "tests/emscripten_runner.js",
   "dependencies": {
     "prettier": "^2.7.1",
-    "pyodide": "^0.23.0"
+    "pyodide": "^0.25.0"
   },
   "scripts": {
     "test": "node tests/emscripten_runner.js",

--- a/wasm-preview/run_tests.py
+++ b/wasm-preview/run_tests.py
@@ -21,7 +21,7 @@ async def main(tests_zip: str, tag_name: str):
     # File saved on the GH release
     pydantic_core_wheel = (
         'https://githubproxy.samuelcolvin.workers.dev/pydantic/pydantic-core/releases/'
-        f'download/{tag_name}/pydantic_core-{tag_name.lstrip("v")}-cp311-cp311-emscripten_3_1_32_wasm32.whl'
+        f'download/{tag_name}/pydantic_core-{tag_name.lstrip("v")}-cp311-cp311-emscripten_3_1_46_wasm32.whl'
     )
     zip_file = ZipFile(BytesIO(base64.b64decode(tests_zip)))
     count = 0

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -89,7 +89,7 @@ async function main() {
       get(`./run_tests.py?v=${Date.now()}`, 'text'),
       // e4cf2e2 commit matches the pydantic-core wheel being used, so tests should pass
       get(zip_url, 'blob'),
-      importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.0/full/pyodide.js'),
+      importScripts('https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js'),
     ]);
 
     const pyodide = await loadPyodide();


### PR DESCRIPTION
I needed a WASM build for the latest stable release of pyodide. Sharing the changes I made to achieve this in case helpful.

[Pyodide v0.25.0 changelog](https://pyodide.org/en/stable/project/changelog.html#version-0-25-0)