### PR TITLE
support Rust 1.70 as MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - id: cache-rust
         name: cache rust
         uses: Swatinem/rust-cache@v2
-        with:
-          key: coverage-v2
 
       - run: cargo install rustfilt coverage-prepare
         if: steps.cache-rust.outputs.cache-hit != 'true'
@@ -120,8 +118,6 @@ jobs:
 
       - name: cache rust
         uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.os }}-v1
 
       - name: set up python
         uses: actions/setup-python@v5
@@ -201,8 +197,6 @@ jobs:
 
       - name: cache rust
         uses: Swatinem/rust-cache@v2
-        with:
-          key: test-debug
 
       - run: pip install -r tests/requirements.txt
       - run: make build-dev
@@ -234,8 +228,6 @@ jobs:
 
       - name: cache rust
         uses: Swatinem/rust-cache@v2
-        with:
-          key: test-pydantic-integration
 
       - name: install deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,43 @@ jobs:
 
       - run: cargo test
 
+  test-msrv:
+    name: test MSRV
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: resolve MSRV
+        id: resolve-msrv
+        run:
+          echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["rust-version"])'` >> $GITHUB_OUTPUT
+
+      - name: install rust MSRV
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.resolve-msrv.outputs.MSRV }}
+
+      - name: cache rust
+        uses: Swatinem/rust-cache@v2
+
+      - run: pip install -r tests/requirements.txt
+
+      - run: pip install -e .
+        env:
+          RUST_BACKTRACE: 1
+
+      - run: pip freeze
+
+      - run: pytest
+
+      - run: cargo test
+
   # test with a debug build as it picks up errors which optimised release builds do not
   test-debug:
     name: test-debug ${{ matrix.python-version }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: cache rust
         uses: Swatinem/rust-cache@v2
-        with:
-          key: v1
 
       - name: Compile pydantic-core for profiling
         run: make build-profiling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ include = [
     "!tests/.pytest_cache",
     "!*.so",
 ]
+rust-version = "1.70"
 
 [dependencies]
 pyo3 = { version = "0.20.2", features = ["generate-import-lib", "num-bigint"] }

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -147,7 +147,7 @@ impl GeneralFieldsSerializer {
         }
     }
 
-    pub fn main_to_python<'py>(
+    pub(crate) fn main_to_python<'py>(
         &self,
         py: Python<'py>,
         main_iter: impl Iterator<Item = PyResult<(&'py PyAny, &'py PyAny)>>,
@@ -212,7 +212,7 @@ impl GeneralFieldsSerializer {
         }
     }
 
-    pub fn main_serde_serialize<'py, S: serde::ser::Serializer>(
+    pub(crate) fn main_serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
         main_iter: impl Iterator<Item = PyResult<(&'py PyAny, &'py PyAny)>>,
         expected_len: usize,
@@ -258,7 +258,7 @@ impl GeneralFieldsSerializer {
         Ok(map)
     }
 
-    pub fn add_computed_fields_python(
+    pub(crate) fn add_computed_fields_python(
         &self,
         model: Option<&PyAny>,
         output_dict: &PyDict,
@@ -275,7 +275,7 @@ impl GeneralFieldsSerializer {
         Ok(())
     }
 
-    pub fn add_computed_fields_json<S: serde::ser::Serializer>(
+    pub(crate) fn add_computed_fields_json<S: serde::ser::Serializer>(
         &self,
         model: Option<&PyAny>,
         map: &mut S::SerializeMap,
@@ -291,7 +291,7 @@ impl GeneralFieldsSerializer {
         Ok(())
     }
 
-    pub fn computed_field_count(&self) -> usize {
+    pub(crate) fn computed_field_count(&self) -> usize {
         option_length!(self.computed_fields)
     }
 }


### PR DESCRIPTION
## Change Summary

This PR sets Rust 1.70 as the minimum supported version. To go lower, we would need to replace use of `OnceLock` with external `once_cell::sync::OnceCell` both here and in `jiter`.

I think going below 1.65 would be hard because we use both GATs and let-else from that release.

## Related issue number

Related to #1176 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin