### PR TITLE
implement omit_trailing_slash feature for PyUrl [7186]

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -454,12 +454,13 @@ class Url(SupportsAllComparisons):
     by Mozilla.
     """
 
-    def __new__(cls, url: str) -> Self:
+    def __new__(cls, url: str, omit_trailing_slash: bool = False) -> Self:
         """
         Create a new `Url` instance.
 
         Args:
             url: String representation of a URL.
+            omit_trailing_slash: Whether to omit trailing slash (only if path == "/")
 
         Returns:
             A new `Url` instance.
@@ -590,12 +591,13 @@ class MultiHostUrl(SupportsAllComparisons):
     by Mozilla.
     """
 
-    def __new__(cls, url: str) -> Self:
+    def __new__(cls, url: str, omit_trailing_slash: bool = False) -> Self:
         """
         Create a new `MultiHostUrl` instance.
 
         Args:
             url: String representation of a URL.
+            omit_trailing_slash: Whether to omit trailing slash (only if path == "/")
 
         Returns:
             A new `MultiHostUrl` instance.

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3454,6 +3454,7 @@ class UrlSchema(TypedDict, total=False):
     default_host: str
     default_port: int
     default_path: str
+    omit_trailing_slash: bool  # default False
     strict: bool
     ref: str
     metadata: Any
@@ -3468,6 +3469,7 @@ def url_schema(
     default_host: str | None = None,
     default_port: int | None = None,
     default_path: str | None = None,
+    omit_trailing_slash: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -3492,6 +3494,7 @@ def url_schema(
         default_host: The default host to use if the URL does not have a host
         default_port: The default port to use if the URL does not have a port
         default_path: The default path to use if the URL does not have a path
+        omit_trailing_slash: Whether to omit trailing slash (only if path == "/")
         strict: Whether to use strict URL parsing
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -3506,6 +3509,7 @@ def url_schema(
         default_port=default_port,
         default_path=default_path,
         strict=strict,
+        omit_trailing_slash=omit_trailing_slash,
         ref=ref,
         metadata=metadata,
         serialization=serialization,
@@ -3520,6 +3524,7 @@ class MultiHostUrlSchema(TypedDict, total=False):
     default_host: str
     default_port: int
     default_path: str
+    omit_trailing_slash: bool
     strict: bool
     ref: str
     metadata: Any
@@ -3534,6 +3539,7 @@ def multi_host_url_schema(
     default_host: str | None = None,
     default_port: int | None = None,
     default_path: str | None = None,
+    omit_trailing_slash: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Any = None,
@@ -3558,6 +3564,7 @@ def multi_host_url_schema(
         default_host: The default host to use if the URL does not have a host
         default_port: The default port to use if the URL does not have a port
         default_path: The default path to use if the URL does not have a path
+        omit_trailing_slash: Whether to omit trailing slash (only if path == "/")
         strict: Whether to use strict URL parsing
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -3571,6 +3578,7 @@ def multi_host_url_schema(
         default_host=default_host,
         default_port=default_port,
         default_path=default_path,
+        omit_trailing_slash=omit_trailing_slash,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -444,7 +444,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
         }
         ObType::Url => {
             let py_url: PyUrl = value.extract().map_err(py_err_se_err)?;
-            serializer.serialize_str(py_url.__str__())
+            serializer.serialize_str(py_url.__str__().as_str())
         }
         ObType::MultiHostUrl => {
             let py_url: PyMultiHostUrl = value.extract().map_err(py_err_se_err)?;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Based on comment https://github.com/pydantic/pydantic/issues/7186#issuecomment-1912192517 implemented `omit_trailing_slash` feature for PyUrl crate.

## Related issue number

https://github.com/pydantic/pydantic/issues/7186

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu