### PR TITLE
update to PyO3 0.21 beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,30 +148,17 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jiter"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87db066a99f69382be06d02313f8ce989996b53a04a8a70cfd1a6483a56227f7"
+checksum = "c2a1b6e316923afd3087ec73829f646a67c18f3a5bd61624247b05e652e4a99d"
 dependencies = [
  "ahash",
  "hashbrown",
- "lexical-core",
+ "lexical-parse-float",
  "num-bigint",
  "num-traits",
  "pyo3",
  "smallvec",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
 ]
 
 [[package]]
@@ -201,27 +188,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
 dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
  "static_assertions",
 ]
 
@@ -363,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "5d0c41d899f822e5f39186d6da130a822a0a43edb19992b51bf4ef6cd0b4cfd1"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -382,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "5509c2aa78c7e770077e41ba86f806e60dcee812e924ccb2d6fe78c0a0128ce2"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -393,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "e6bb234a86ed619a661f3bb3c2493aaff9cb937e33e198d17f5f20a15881e155"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -403,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "f0b787de2c6832eb1eb393c9f82f976a5a87bda979780d9b853878846a8d2e4b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -415,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "5e3b7beed357786d2afe845871964e824ad8af0df38a403f7d01cdc81aadb211"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 rust-version = "1.70"
 
 [dependencies]
-pyo3 = { version = "0.20.3", features = ["generate-import-lib", "num-bigint"] }
+pyo3 = { version = "0.21.0-beta.0", features = ["generate-import-lib", "num-bigint", "gil-refs"] }
 regex = "1.10.3"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.26.1"
@@ -44,7 +44,7 @@ base64 = "0.21.7"
 num-bigint = "0.4.4"
 python3-dll-a = "0.2.7"
 uuid = "1.7.0"
-jiter = {version = "0.0.6", features = ["python"]}
+jiter = {version = "0.0.7", features = ["python"]}
 
 [lib]
 name = "_pydantic_core"
@@ -71,12 +71,12 @@ debug = true
 strip = false
 
 [dev-dependencies]
-pyo3 = { version = "0.20.3", features = ["auto-initialize"] }
+pyo3 = { version = "0.21.0-beta.0", features = ["auto-initialize"] }
 
 [build-dependencies]
 version_check = "0.9.4"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = { version = "0.20.2" }
+pyo3-build-config = { version = "0.21.0-beta.0" }
 
 [lints.clippy]
 dbg_macro = "warn"

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -14,8 +14,8 @@ use crate::ValidationError;
 pub fn schema_or_config<'py, T>(
     schema: &'py PyDict,
     config: Option<&'py PyDict>,
-    schema_key: &PyString,
-    config_key: &PyString,
+    schema_key: &Bound<'py, PyString>,
+    config_key: &Bound<'py, PyString>,
 ) -> PyResult<Option<T>>
 where
     T: FromPyObject<'py>,
@@ -32,7 +32,7 @@ where
 pub fn schema_or_config_same<'py, T>(
     schema: &'py PyDict,
     config: Option<&'py PyDict>,
-    key: &PyString,
+    key: &Bound<'py, PyString>,
 ) -> PyResult<Option<T>>
 where
     T: FromPyObject<'py>,

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -1,5 +1,5 @@
 use pyo3::exceptions::PyTypeError;
-use pyo3::once_cell::GILOnceCell;
+use pyo3::sync::GILOnceCell;
 use std::fmt;
 
 use pyo3::prelude::*;

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -14,7 +14,7 @@ pub use self::value_exception::{PydanticCustomError, PydanticKnownError, Pydanti
 
 pub fn py_err_string(py: Python, err: PyErr) -> String {
     let value = err.value(py);
-    match value.get_type().name() {
+    match value.get_type().qualname() {
         Ok(type_name) => match value.str() {
             Ok(py_str) => {
                 let str_cow = py_str.to_string_lossy();

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use std::fmt;
 
 use pyo3::exceptions::{PyKeyError, PyTypeError};
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyList};
 
 use ahash::AHashMap;

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -5,8 +5,8 @@ use std::str::from_utf8;
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
 use pyo3::ffi;
 use pyo3::intern;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyList, PyString};
 use serde::ser::{Error, SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
@@ -559,7 +559,7 @@ impl PyLineError {
             let input_str = safe_repr(input_value);
             truncate_input_value!(output, &input_str);
 
-            if let Ok(type_) = input_value.get_type().name() {
+            if let Ok(type_) = input_value.get_type().qualname() {
                 write!(output, ", input_type={type_}")?;
             }
         }

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -114,7 +114,7 @@ impl<'a> TryFrom<&'a PyAny> for EitherTimedelta<'a> {
     type Error = PyErr;
 
     fn try_from(value: &'a PyAny) -> PyResult<Self> {
-        if let Ok(dt) = <PyDelta as PyTryFrom>::try_from_exact(value) {
+        if let Ok(dt) = value.downcast_exact::<PyDelta>() {
             Ok(EitherTimedelta::PyExact(dt))
         } else {
             let dt = value.downcast::<PyDelta>()?;

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -22,9 +22,9 @@ pub enum InputType {
 impl IntoPy<PyObject> for InputType {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
-            Self::Json => intern!(py, "json").into(),
-            Self::Python => intern!(py, "python").into(),
-            Self::String => intern!(py, "string").into(),
+            Self::Json => intern!(py, "json").into_py(py),
+            Self::Python => intern!(py, "python").into_py(py),
+            Self::String => intern!(py, "string").into_py(py),
         }
     }
 }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -340,7 +340,7 @@ impl<'a> Input<'a> for PyAny {
     }
 
     fn exact_str(&'a self) -> ValResult<EitherString<'a>> {
-        if let Ok(py_str) = <PyString as PyTryFrom>::try_from_exact(self) {
+        if let Ok(py_str) = self.downcast_exact() {
             Ok(EitherString::Py(py_str))
         } else {
             Err(ValError::new(ErrorTypeDefaults::IntType, self))
@@ -389,7 +389,7 @@ impl<'a> Input<'a> for PyAny {
 
         Err(ValError::new(
             ErrorType::IsInstanceOf {
-                class: decimal_type.name().unwrap_or("Decimal").to_string(),
+                class: decimal_type.qualname().unwrap_or_else(|_| "Decimal".to_owned()),
                 context: None,
             },
             self,
@@ -773,7 +773,7 @@ fn maybe_as_enum(v: &PyAny) -> Option<&PyAny> {
 }
 
 #[cfg(PyPy)]
-static DICT_KEYS_TYPE: pyo3::once_cell::GILOnceCell<Py<PyType>> = pyo3::once_cell::GILOnceCell::new();
+static DICT_KEYS_TYPE: pyo3::sync::GILOnceCell<Py<PyType>> = pyo3::sync::GILOnceCell::new();
 
 #[cfg(PyPy)]
 fn is_dict_keys_type(v: &PyAny) -> bool {
@@ -791,7 +791,7 @@ fn is_dict_keys_type(v: &PyAny) -> bool {
 }
 
 #[cfg(PyPy)]
-static DICT_VALUES_TYPE: pyo3::once_cell::GILOnceCell<Py<PyType>> = pyo3::once_cell::GILOnceCell::new();
+static DICT_VALUES_TYPE: pyo3::sync::GILOnceCell<Py<PyType>> = pyo3::sync::GILOnceCell::new();
 
 #[cfg(PyPy)]
 fn is_dict_values_type(v: &PyAny) -> bool {
@@ -809,7 +809,7 @@ fn is_dict_values_type(v: &PyAny) -> bool {
 }
 
 #[cfg(PyPy)]
-static DICT_ITEMS_TYPE: pyo3::once_cell::GILOnceCell<Py<PyType>> = pyo3::once_cell::GILOnceCell::new();
+static DICT_ITEMS_TYPE: pyo3::sync::GILOnceCell<Py<PyType>> = pyo3::sync::GILOnceCell::new();
 
 #[cfg(PyPy)]
 fn is_dict_items_type(v: &PyAny) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,12 @@ pub use validators::{validate_core_schema, PySome, SchemaValidator};
 use crate::input::Input;
 
 #[pyfunction(signature = (data, *, allow_inf_nan=true, cache_strings=true))]
-pub fn from_json(py: Python, data: &PyAny, allow_inf_nan: bool, cache_strings: bool) -> PyResult<PyObject> {
+pub fn from_json<'py>(
+    py: Python<'py>,
+    data: &PyAny,
+    allow_inf_nan: bool,
+    cache_strings: bool,
+) -> PyResult<Bound<'py, PyAny>> {
     let v_match = data
         .validate_bytes(false)
         .map_err(|_| PyTypeError::new_err("Expected bytes, bytearray or str"))?;

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -333,7 +333,10 @@ impl CollectWarnings {
 
     fn fallback_warning(&self, field_type: &str, value: &PyAny) {
         if self.active {
-            let type_name = value.get_type().name().unwrap_or("<unknown python object>");
+            let type_name = value
+                .get_type()
+                .qualname()
+                .unwrap_or_else(|_| "<unknown python object>".to_owned());
             self.add_warning(format!(
                 "Expected `{field_type}` but got `{type_name}` - serialized value may not be as expected"
             ));

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -23,7 +23,7 @@ fn map_negative_index(value: &PyAny, len: Option<usize>) -> PyResult<&PyAny> {
             .map_or_else(|_| value, |v| v)),
         None => {
             // check that it's not negative
-            let negative = value.call_method1(intern!(py, "__lt__"), (0,))?.is_true()?;
+            let negative = value.call_method1(intern!(py, "__lt__"), (0,))?.is_truthy()?;
             if negative {
                 Err(PyValueError::new_err(
                     "Negative indices cannot be used to exclude items on unsized iterables",
@@ -291,7 +291,7 @@ fn check_contains(obj: &PyAny, py_key: impl ToPyObject + Copy) -> PyResult<Optio
         Ok(contains_method) => {
             if let Ok(result) = contains_method.call1((py_key.to_object(py),)) {
                 Ok(Some(
-                    result.is_true()? || contains_method.call1((intern!(py, "__all__"),))?.is_true()?,
+                    result.is_truthy()? || contains_method.call1((intern!(py, "__all__"),))?.is_truthy()?,
                 ))
             } else {
                 Ok(None)
@@ -316,7 +316,7 @@ where
 
 /// detect both ellipsis and `True` to be compatible with pydantic V1
 fn is_ellipsis_like(v: &PyAny) -> bool {
-    v.is_ellipsis()
+    v.is(&v.py().Ellipsis())
         || match v.downcast::<PyBool>() {
             Ok(b) => b.is_true(),
             Err(_) => false,

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -548,7 +548,7 @@ fn unknown_type_error(value: &PyAny) -> PyErr {
 fn serialize_unknown(value: &PyAny) -> Cow<str> {
     if let Ok(s) = value.str() {
         s.to_string_lossy()
-    } else if let Ok(name) = value.get_type().name() {
+    } else if let Ok(name) = value.get_type().qualname() {
         format!("<Unserializable {name} object>").into()
     } else {
         "<Unserializable object>".into()

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -1,5 +1,5 @@
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{
     PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFloat, PyFrozenSet, PyInt, PyIterator, PyList,
     PySet, PyString, PyTime, PyTuple, PyType,

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 
 use pyo3::exceptions::PyTypeError;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyString};
 use pyo3::{intern, PyTraverseError, PyVisit};
 

--- a/src/serializers/type_serializers/format.rs
+++ b/src/serializers/type_serializers/format.rs
@@ -95,9 +95,9 @@ impl FormatSerializer {
                 format!(
                     "Error calling `format(value, {})`: {}",
                     self.formatting_string
-                        .as_ref(py)
+                        .bind(py)
                         .repr()
-                        .unwrap_or_else(|_| intern!(py, "???")),
+                        .unwrap_or_else(|_| intern!(py, "???").clone()),
                     e
                 )
             })

--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -179,7 +179,7 @@ pub(crate) fn to_str_json_key(key: &PyAny) -> PyResult<Cow<str>> {
 build_simple_serializer!(IntSerializer, "int", Int, ObType::Int, to_str_json_key, true);
 
 pub(crate) fn bool_json_key(key: &PyAny) -> PyResult<Cow<str>> {
-    let v = if key.is_true().unwrap_or(false) {
+    let v = if key.is_truthy().unwrap_or(false) {
         "true"
     } else {
         "false"

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -6,17 +6,17 @@ use pyo3::types::{PyDict, PyString};
 use pyo3::{ffi, intern, FromPyObject};
 
 pub trait SchemaDict<'py> {
-    fn get_as<T>(&'py self, key: &PyString) -> PyResult<Option<T>>
+    fn get_as<T>(&'py self, key: &Bound<PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>;
 
-    fn get_as_req<T>(&'py self, key: &PyString) -> PyResult<T>
+    fn get_as_req<T>(&'py self, key: &Bound<PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>;
 }
 
 impl<'py> SchemaDict<'py> for PyDict {
-    fn get_as<T>(&'py self, key: &PyString) -> PyResult<Option<T>>
+    fn get_as<T>(&'py self, key: &Bound<PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>,
     {
@@ -26,7 +26,7 @@ impl<'py> SchemaDict<'py> for PyDict {
         }
     }
 
-    fn get_as_req<T>(&'py self, key: &PyString) -> PyResult<T>
+    fn get_as_req<T>(&'py self, key: &Bound<PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>,
     {
@@ -38,7 +38,7 @@ impl<'py> SchemaDict<'py> for PyDict {
 }
 
 impl<'py> SchemaDict<'py> for Option<&PyDict> {
-    fn get_as<T>(&'py self, key: &PyString) -> PyResult<Option<T>>
+    fn get_as<T>(&'py self, key: &Bound<PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>,
     {
@@ -49,7 +49,7 @@ impl<'py> SchemaDict<'py> for Option<&PyDict> {
     }
 
     #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn get_as_req<T>(&'py self, key: &PyString) -> PyResult<T>
+    fn get_as_req<T>(&'py self, key: &Bound<PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>,
     {
@@ -92,7 +92,7 @@ pub fn function_name(f: &PyAny) -> PyResult<String> {
 pub fn safe_repr(v: &PyAny) -> Cow<str> {
     if let Ok(s) = v.repr() {
         s.to_string_lossy()
-    } else if let Ok(name) = v.get_type().name() {
+    } else if let Ok(name) = v.get_type().qualname() {
         format!("<unprintable {name} object>").into()
     } else {
         "<unprintable object>".into()

--- a/src/url.rs
+++ b/src/url.rs
@@ -5,8 +5,8 @@ use std::hash::{Hash, Hasher};
 
 use idna::punycode::decode_to_string;
 use pyo3::exceptions::PyValueError;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::pyclass::CompareOp;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyType};
 use pyo3::{intern, prelude::*};
 use url::Url;

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -175,7 +175,7 @@ impl DateConstraints {
     }
 }
 
-fn convert_pydate(schema: &PyDict, field: &PyString) -> PyResult<Option<Date>> {
+fn convert_pydate(schema: &PyDict, field: &Bound<'_, PyString>) -> PyResult<Option<Date>> {
     match schema.get_as::<&PyDate>(field)? {
         Some(date) => Ok(Some(EitherDate::Py(date).as_raw()?)),
         None => Ok(None),

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -1,6 +1,6 @@
 use pyo3::intern;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDateTime, PyDict, PyString};
 use speedate::{DateTime, Time};
 use std::cmp::Ordering;
@@ -209,7 +209,7 @@ impl DateTimeConstraints {
     }
 }
 
-fn py_datetime_as_datetime(schema: &PyDict, field: &PyString) -> PyResult<Option<DateTime>> {
+fn py_datetime_as_datetime(schema: &PyDict, field: &Bound<'_, PyString>) -> PyResult<Option<DateTime>> {
     match schema.get_as::<&PyDateTime>(field)? {
         Some(dt) => Ok(Some(EitherDateTime::Py(dt).as_raw()?)),
         None => Ok(None),

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -27,19 +27,18 @@ impl BuildValidator for IsInstanceValidator {
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
         let cls_key = intern!(py, "cls");
-        let class: &PyAny = schema.get_as_req(cls_key)?;
+        let class: Bound<'_, PyAny> = schema.get_as_req(cls_key)?;
 
         // test that class works with isinstance to avoid errors at call time, reuse cls_key since it doesn't
         // matter what object is being checked
-        let test_value: &PyAny = cls_key.as_ref();
-        if test_value.is_instance(class).is_err() {
+        if cls_key.is_instance(&class).is_err() {
             return py_schema_err!("'cls' must be valid as the first argument to 'isinstance'");
         }
 
         let class_repr = match schema.get_as(intern!(py, "cls_repr"))? {
             Some(s) => s,
             None => match class.extract::<&PyType>() {
-                Ok(t) => t.name()?.to_string(),
+                Ok(t) => t.qualname()?.to_string(),
                 Err(_) => class.repr()?.extract()?,
             },
         };

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -28,7 +28,7 @@ impl BuildValidator for IsSubclassValidator {
 
         let class_repr = match schema.get_as(intern!(py, "cls_repr"))? {
             Some(s) => s,
-            None => class.name()?.to_string(),
+            None => class.qualname()?.to_string(),
         };
         let name = format!("{}[{class_repr}]", Self::EXPECTED_TYPE);
         Ok(Self {

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -66,7 +66,7 @@ impl Validator for JsonValidator {
             None => {
                 let obj =
                     jiter::python_parse(py, json_bytes, true, true).map_err(|e| map_json_err(input, e, json_bytes))?;
-                Ok(obj)
+                Ok(obj.unbind())
             }
         }
     }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use enum_dispatch::enum_dispatch;
 
 use pyo3::exceptions::PyTypeError;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyAny, PyDict, PyTuple, PyType};
 use pyo3::{intern, PyTraverseError, PyVisit};
 

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -95,8 +95,7 @@ impl BuildValidator for ModelValidator {
             custom_init: schema.get_as(intern!(py, "custom_init"))?.unwrap_or(false),
             root_model: schema.get_as(intern!(py, "root_model"))?.unwrap_or(false),
             undefined: PydanticUndefinedType::new(py).to_object(py),
-            // Get the class's `__name__`, not using `class.name()` since it uses `__qualname__`
-            // which is not what we want here
+            // Get the class's `__name__`, not using `class.qualname()`
             name: class.getattr(intern!(py, "__name__"))?.extract()?,
         }
         .into())

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -177,7 +177,9 @@ impl StrConstrainedValidator {
             schema_or_config(schema, config, intern!(py, "to_upper"), intern!(py, "str_to_upper"))?.unwrap_or(false);
 
         let coerce_numbers_to_str = match config {
-            Some(c) => c.get_item("coerce_numbers_to_str")?.map_or(Ok(false), PyAny::is_true)?,
+            Some(c) => c
+                .get_item("coerce_numbers_to_str")?
+                .map_or(Ok(false), PyAny::is_truthy)?,
             None => false,
         };
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -85,7 +85,7 @@ impl Validator for TimeValidator {
     }
 }
 
-fn convert_pytime(schema: &PyDict, field: &PyString) -> PyResult<Option<Time>> {
+fn convert_pytime(schema: &PyDict, field: &Bound<'_, PyString>) -> PyResult<Option<Time>> {
     match schema.get_as::<&PyTime>(field)? {
         Some(date) => Ok(Some(EitherTime::Py(date).as_raw()?)),
         None => Ok(None),

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -113,7 +113,7 @@ impl Validator for UuidValidator {
         } else if state.strict_or(self.strict) && state.extra().input_type == InputType::Python {
             Err(ValError::new(
                 ErrorType::IsInstanceOf {
-                    class: class.name().unwrap_or("UUID").to_string(),
+                    class: class.qualname().unwrap_or_else(|_| "UUID".to_owned()),
                     context: None,
                 },
                 input,

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -1,6 +1,6 @@
 use pyo3::intern;
-use pyo3::once_cell::GILOnceCell;
 use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::PyDict;
 use pyo3::PyTraverseError;
 use pyo3::PyVisit;


### PR DESCRIPTION
## Change Summary

This PR updates to PyO3 0.21 beta (and `jiter` 0.0.7).

It does just the first step of the PyO3 migration which advises to switch on the "gil-refs" feature and solve the rest of the updating. Hence, I've done that here, and I'll use #1085 to merge the follow up which should unlock the real performance boosts.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
