### PR TITLE
Take a `mode` parameter in `validate_python`

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -42,12 +42,20 @@ fn ints_python(bench: &mut Bencher) {
         let validator = build_schema_validator(py, "{'type': 'int'}");
 
         let input = 123_i64.into_py(py).into_bound(py);
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_int: i64 = result.extract(py).unwrap();
         assert_eq!(result_int, 123);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -81,7 +89,9 @@ fn list_int_python(bench: &mut Bencher) {
         let (validator, input) = list_int_input(py);
         let input = black_box(input.bind(py));
         bench.iter(|| {
-            let v = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let v = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             black_box(v)
         })
     })
@@ -146,7 +156,7 @@ fn list_error_python_input(py: Python<'_>) -> (SchemaValidator, PyObject) {
 
     let input = py.eval(&code, None, None).unwrap().extract().unwrap();
 
-    match validator.validate_python(py, &input, None, None, None, None) {
+    match validator.validate_python(py, &input, None, "python", None, None, None) {
         Ok(_) => panic!("unexpectedly valid"),
         Err(e) => {
             let v = e.value(py);
@@ -166,7 +176,7 @@ fn list_error_python(bench: &mut Bencher) {
 
         let input = black_box(input.bind(py));
         bench.iter(|| {
-            let result = validator.validate_python(py, &input, None, None, None, None);
+            let result = validator.validate_python(py, &input, None, "python", None, None, None);
 
             match result {
                 Ok(_) => panic!("unexpectedly valid"),
@@ -214,7 +224,9 @@ fn list_any_python(bench: &mut Bencher) {
         let input = py.eval(&code, None, None).unwrap().to_object(py);
         let input = black_box(input.bind(py));
         bench.iter(|| {
-            let v = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let v = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             black_box(v)
         })
     })
@@ -266,7 +278,9 @@ fn dict_python(bench: &mut Bencher) {
         let input = py.eval(&code, None, None).unwrap().to_object(py);
         let input = black_box(input.bind(py));
         bench.iter(|| {
-            let v = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let v = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             black_box(v)
         })
     })
@@ -294,7 +308,7 @@ fn dict_value_error(bench: &mut Bencher) {
 
         let input = py.eval(&code, None, None).unwrap().to_object(py).into_bound(py);
 
-        match validator.validate_python(py, &input, None, None, None, None) {
+        match validator.validate_python(py, &input, None, "python", None, None, None) {
             Ok(_) => panic!("unexpectedly valid"),
             Err(e) => {
                 let v = e.value(py);
@@ -307,7 +321,7 @@ fn dict_value_error(bench: &mut Bencher) {
 
         let input = black_box(input);
         bench.iter(|| {
-            let result = validator.validate_python(py, &input, None, None, None, None);
+            let result = validator.validate_python(py, &input, None, "python", None, None, None);
 
             match result {
                 Ok(_) => panic!("unexpectedly valid"),
@@ -373,7 +387,9 @@ fn typed_dict_python(bench: &mut Bencher) {
         let input = py.eval(&code, None, None).unwrap().to_object(py);
         let input = black_box(input.bind(py));
         bench.iter(|| {
-            let v = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let v = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             black_box(v)
         })
     })
@@ -413,7 +429,7 @@ fn typed_dict_deep_error(bench: &mut Bencher) {
         let input = py.eval(code, None, None).unwrap().to_object(py);
         let input = black_box(input.bind(py));
 
-        match validator.validate_python(py, &input, None, None, None, None) {
+        match validator.validate_python(py, &input, None, "python", None, None, None) {
             Ok(_) => panic!("unexpectedly valid"),
             Err(e) => {
                 let v = e.value(py);
@@ -425,7 +441,7 @@ fn typed_dict_deep_error(bench: &mut Bencher) {
         };
 
         bench.iter(|| {
-            let result = validator.validate_python(py, &input, None, None, None, None);
+            let result = validator.validate_python(py, &input, None, "python", None, None, None);
 
             match result {
                 Ok(_) => panic!("unexpectedly valid"),
@@ -450,7 +466,11 @@ fn complete_model(bench: &mut Bencher) {
         let input = black_box(input);
 
         bench.iter(|| {
-            black_box(validator.validate_python(py, &input, None, None, None, None).unwrap());
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            );
         })
     })
 }
@@ -469,10 +489,16 @@ fn nested_model_using_definitions(bench: &mut Bencher) {
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);
 
-        validator.validate_python(py, &input, None, None, None, None).unwrap();
+        validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
 
         bench.iter(|| {
-            black_box(validator.validate_python(py, &input, None, None, None, None).unwrap());
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            );
         })
     })
 }
@@ -491,10 +517,16 @@ fn nested_model_inlined(bench: &mut Bencher) {
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);
 
-        validator.validate_python(py, &input, None, None, None, None).unwrap();
+        validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
 
         bench.iter(|| {
-            black_box(validator.validate_python(py, &input, None, None, None, None).unwrap());
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            );
         })
     })
 }
@@ -506,12 +538,20 @@ fn literal_ints_few_python(bench: &mut Bencher) {
 
         let input = 4_i64.into_py(py);
         let input = input.bind(py);
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_int: i64 = result.extract(py).unwrap();
         assert_eq!(result_int, 4);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -523,12 +563,20 @@ fn literal_strings_few_small_python(bench: &mut Bencher) {
         let input = py.eval("'4'", None, None).unwrap();
         let input = input.to_object(py).into_bound(py);
         let input_str: String = input.extract().unwrap();
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_str: String = result.extract(py).unwrap();
         assert_eq!(result_str, input_str);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -543,12 +591,20 @@ fn literal_strings_few_large_python(bench: &mut Bencher) {
         let input = py.eval("'a' * 25 + '4'", None, None).unwrap();
         let input = input.to_object(py).into_bound(py);
         let input_str: String = input.extract().unwrap();
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_str: String = result.extract(py).unwrap();
         assert_eq!(result_str, input_str);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -579,11 +635,19 @@ class Foo(Enum):
 
         let input = py.eval("Foo.v4", Some(globals.as_gil_ref()), None).unwrap();
         let input = input.to_object(py).into_bound(py);
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         assert!(input.eq(result).unwrap());
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -593,12 +657,20 @@ fn literal_ints_many_python(bench: &mut Bencher) {
         let validator = build_schema_validator(py, "{'type': 'literal', 'expected': list(range(100))}");
 
         let input = 99_i64.into_py(py).into_bound(py);
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_int: i64 = result.extract(py).unwrap();
         assert_eq!(result_int, 99);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -610,12 +682,20 @@ fn literal_strings_many_small_python(bench: &mut Bencher) {
         let input = py.eval("'99'", None, None).unwrap();
         let input = input.to_object(py).into_bound(py);
         let input_str: String = input.extract().unwrap();
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_str: String = result.extract(py).unwrap();
         assert_eq!(result_str, input_str);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -630,12 +710,20 @@ fn literal_strings_many_large_python(bench: &mut Bencher) {
         let input = py.eval("'a' * 25 + '99'", None, None).unwrap();
         let input = input.to_object(py).into_bound(py);
         let input_str: String = input.extract().unwrap();
-        let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+        let result = validator
+            .validate_python(py, &input, None, "python", None, None, None)
+            .unwrap();
         let result_str: String = result.extract(py).unwrap();
         assert_eq!(result_str, input_str);
 
         let input = black_box(input);
-        bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+        bench.iter(|| {
+            black_box(
+                validator
+                    .validate_python(py, &input, None, "python", None, None, None)
+                    .unwrap(),
+            )
+        })
     })
 }
 
@@ -706,12 +794,20 @@ class Foo(Enum):
             let input = py.eval("'null'", None, None).unwrap();
             let input = input.to_object(py).into_bound(py);
             let input_str: String = input.extract().unwrap();
-            let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let result = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             let result_str: String = result.extract(py).unwrap();
             assert_eq!(result_str, input_str);
 
             let input = black_box(input);
-            bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+            bench.iter(|| {
+                black_box(
+                    validator
+                        .validate_python(py, &input, None, "python", None, None, None)
+                        .unwrap(),
+                )
+            })
         }
 
         // Int
@@ -719,34 +815,58 @@ class Foo(Enum):
             let input = py.eval("-1", None, None).unwrap();
             let input = input.to_object(py).into_bound(py);
             let input_int: i64 = input.extract().unwrap();
-            let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let result = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             let result_int: i64 = result.extract(py).unwrap();
             assert_eq!(result_int, input_int);
 
             let input = black_box(input);
-            bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+            bench.iter(|| {
+                black_box(
+                    validator
+                        .validate_python(py, &input, None, "python", None, None, None)
+                        .unwrap(),
+                )
+            })
         }
 
         // None
         {
             let input = py.eval("None", None, None).unwrap();
             let input = input.to_object(py).into_bound(py);
-            let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let result = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             assert!(input.eq(result).unwrap());
 
             let input = black_box(input);
-            bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+            bench.iter(|| {
+                black_box(
+                    validator
+                        .validate_python(py, &input, None, "python", None, None, None)
+                        .unwrap(),
+                )
+            })
         }
 
         // Enum
         {
             let input = py.eval("Foo.v4", Some(globals.as_gil_ref()), None).unwrap();
             let input = input.to_object(py).into_bound(py);
-            let result = validator.validate_python(py, &input, None, None, None, None).unwrap();
+            let result = validator
+                .validate_python(py, &input, None, "python", None, None, None)
+                .unwrap();
             assert!(input.eq(result).unwrap());
 
             let input = black_box(input);
-            bench.iter(|| black_box(validator.validate_python(py, &input, None, None, None, None).unwrap()))
+            bench.iter(|| {
+                black_box(
+                    validator
+                        .validate_python(py, &input, None, "python", None, None, None)
+                        .unwrap(),
+                )
+            })
         }
     })
 }

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -100,7 +100,7 @@ class SchemaValidator:
         input: Any,
         *,
         strict: bool | None = None,
-        mode: Literal['python', 'json'] = 'json'
+        mode: Literal['python', 'json'] = 'python',
         from_attributes: bool | None = None,
         context: dict[str, Any] | None = None,
         self_instance: Any | None = None,

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -100,6 +100,7 @@ class SchemaValidator:
         input: Any,
         *,
         strict: bool | None = None,
+        mode: Literal['python', 'json'] = 'json'
         from_attributes: bool | None = None,
         context: dict[str, Any] | None = None,
         self_instance: Any | None = None,
@@ -111,6 +112,11 @@ class SchemaValidator:
             input: The Python object to validate.
             strict: Whether to validate the object in strict mode.
                 If `None`, the value of [`CoreConfig.strict`][pydantic_core.core_schema.CoreConfig] is used.
+            mode: Specifies the validation mode. Defaults to `'python'`.
+                Under `'json'`, certain coercions are permitted (e.g. `dict` to `dataclass`),
+                even when `strict` is enabled. This can be useful if `input` is is an
+                object that has already undergone parsing (JSON, YAML, etc.), but requires
+                the same validation rules that `validate_json` would apply.
             from_attributes: Whether to validate objects as inputs to models by extracting attributes.
                 If `None`, the value of [`CoreConfig.from_attributes`][pydantic_core.core_schema.CoreConfig] is used.
             context: The context to use for validation, this is passed to functional validators as

--- a/src/url.rs
+++ b/src/url.rs
@@ -45,7 +45,7 @@ impl PyUrl {
     pub fn py_new(py: Python, url: &Bound<'_, PyAny>) -> PyResult<Self> {
         let schema_obj = SCHEMA_DEFINITION_URL
             .get_or_init(py, || build_schema_validator(py, "url"))
-            .validate_python(py, url, None, None, None, None)?;
+            .validate_python(py, url, None, "python", None, None, None)?;
         schema_obj.extract(py)
     }
 
@@ -221,7 +221,7 @@ impl PyMultiHostUrl {
     pub fn py_new(py: Python, url: &Bound<'_, PyAny>) -> PyResult<Self> {
         let schema_obj = SCHEMA_DEFINITION_MULTI_HOST_URL
             .get_or_init(py, || build_schema_validator(py, "multi-host-url"))
-            .validate_python(py, url, None, None, None, None)?;
+            .validate_python(py, url, None, "python", None, None, None)?;
         schema_obj.extract(py)
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -170,7 +170,7 @@ impl SchemaValidator {
             "json" => InputType::Json,
             _ => {
                 return Err(PyValueError::new_err(format!(
-                    "parameter 'mode' can only be 'python' or 'json' but was {mode}",
+                    "parameter 'mode' can only be 'python' or 'json' but was '{mode}'",
                 )))
             }
         };

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -216,8 +216,11 @@ def test_dataclass():
 
     assert dataclasses.asdict(v.validate_python(FooDataclass(a='hello', b=True))) == {'a': 'hello', 'b': True}
 
+    foo = v.validate_python({'a': 'hello', 'b': True}, strict=True, mode='json')
+
     with pytest.raises(ValidationError, match='Input should be an instance of FooDataclass') as exc_info:
         v.validate_python({'a': 'hello', 'b': True}, strict=True)
+        v.validate_python({'a': 'hello', 'b': True}, strict=True, mode='python')
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -222,6 +222,9 @@ def test_dataclass():
         v.validate_python({'a': 'hello', 'b': True}, strict=True)
         v.validate_python({'a': 'hello', 'b': True}, strict=True, mode='python')
 
+    with pytest.raises(ValueError, match="parameter 'mode' can only be 'python' or 'json' but was 'yaml'"):
+        v.validate_python({'a': 'hello', 'b': True}, mode='yaml')
+
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
         {


### PR DESCRIPTION
This PR introduces a `mode` parameter in `validate_python` so that developers can get similar affordances to `validate_json` when `strict=True`.

Currently, validating `dict` objects against other kinds of models fails when `strict` is turned on, since the validation logic expects specific instances of a class. One could instead just lean on `validate_json`; however, if data has already been hydrated into Python dictionary objects (usually because parsing has happened elsewhere, sometimes in a format other than JSON entirely), then you're out of luck with some questionable solutions.

`mode` is meant to be either the string `"python"` or `"json"`, defaulting to `"python"`. Other values are currently rejected.

Fixes #712.