### PR TITLE
separate `Input` trait `'a` and `'py` lifetimes

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -277,11 +277,11 @@ fn dict_value_error(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let validator = build_schema_validator(
             py,
-            r#"{
+            r"{
                 'type': 'dict',
                 'keys_schema': {'type': 'str'},
                 'values_schema': {'type': 'int', 'lt': 0},
-            }"#,
+            }",
         );
 
         let code = format!(
@@ -322,7 +322,7 @@ fn typed_dict_json(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let validator = build_schema_validator(
             py,
-            r#"{
+            r"{
           'type': 'typed-dict',
           'extra_behavior': 'ignore',
           'fields': {
@@ -337,7 +337,7 @@ fn typed_dict_json(bench: &mut Bencher) {
             'i': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
             'j': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
           },
-        }"#,
+        }",
         );
 
         let code = r#"{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 0}"#.to_string();
@@ -351,7 +351,7 @@ fn typed_dict_python(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let validator = build_schema_validator(
             py,
-            r#"{
+            r"{
           'type': 'typed-dict',
           'extra_behavior': 'ignore',
           'fields': {
@@ -366,7 +366,7 @@ fn typed_dict_python(bench: &mut Bencher) {
             'i': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
             'j': {'type': 'typed-dict-field', 'schema': {'type': 'int'}},
           },
-        }"#,
+        }",
         );
 
         let code = r#"{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 0}"#.to_string();
@@ -384,7 +384,7 @@ fn typed_dict_deep_error(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let validator = build_schema_validator(
             py,
-            r#"{
+            r"{
             'type': 'typed-dict',
             'fields': {
                 'field_a': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
@@ -405,7 +405,7 @@ fn typed_dict_deep_error(bench: &mut Bencher) {
                     }
                 },
             },
-        }"#,
+        }",
         );
 
         let code = "{'field_a': '1', 'field_b': {'field_c': '2', 'field_d': {'field_e': '4', 'field_f': 'xx'}}}";
@@ -557,7 +557,7 @@ fn literal_enums_few_python(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let globals = PyDict::new_bound(py);
         py.run_bound(
-            r#"
+            r"
 from enum import Enum
 
 class Foo(Enum):
@@ -565,7 +565,7 @@ class Foo(Enum):
     v2 = object()
     v3 = object()
     v4 = object()
-"#,
+",
             Some(&globals),
             None,
         )
@@ -682,7 +682,7 @@ fn literal_mixed_few_python(bench: &mut Bencher) {
     Python::with_gil(|py| {
         let globals = PyDict::new_bound(py);
         py.run_bound(
-            r#"
+            r"
 from enum import Enum
 
 class Foo(Enum):
@@ -690,7 +690,7 @@ class Foo(Enum):
     v2 = object()
     v3 = object()
     v4 = object()
-"#,
+",
             Some(&globals),
             None,
         )

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -20,7 +20,7 @@ pub fn get_enum_meta_object(py: Python) -> &Bound<'_, PyAny> {
         .bind(py)
 }
 
-pub fn str_as_bool<'a>(input: &'a impl Input<'a>, str: &str) -> ValResult<bool> {
+pub fn str_as_bool<'py>(input: &impl Input<'py>, str: &str) -> ValResult<bool> {
     if str == "0"
         || str.eq_ignore_ascii_case("f")
         || str.eq_ignore_ascii_case("n")
@@ -42,7 +42,7 @@ pub fn str_as_bool<'a>(input: &'a impl Input<'a>, str: &str) -> ValResult<bool> 
     }
 }
 
-pub fn int_as_bool<'a>(input: &'a impl Input<'a>, int: i64) -> ValResult<bool> {
+pub fn int_as_bool<'py>(input: &impl Input<'py>, int: i64) -> ValResult<bool> {
     if int == 0 {
         Ok(false)
     } else if int == 1 {
@@ -72,7 +72,7 @@ fn strip_underscores(s: &str) -> Option<String> {
 /// max length of the input is 4300, see
 /// https://docs.python.org/3/whatsnew/3.11.html#other-cpython-implementation-changes and
 /// https://github.com/python/cpython/issues/95778 for more info in that length bound
-pub fn str_as_int<'s, 'l>(input: &'s impl Input<'s>, str: &'l str) -> ValResult<EitherInt<'s>> {
+pub fn str_as_int<'s>(input: &'s impl Input<'s>, str: &str) -> ValResult<EitherInt<'s>> {
     let str = str.trim();
     let len = str.len();
     if len > 4300 {
@@ -97,7 +97,7 @@ pub fn str_as_int<'s, 'l>(input: &'s impl Input<'s>, str: &'l str) -> ValResult<
 }
 
 /// parse a float as a float
-pub fn str_as_float<'s, 'l>(input: &'s impl Input<'s>, str: &'l str) -> ValResult<EitherFloat<'s>> {
+pub fn str_as_float<'s>(input: &'s impl Input<'s>, str: &str) -> ValResult<EitherFloat<'s>> {
     match str.trim().parse() {
         Ok(float) => Ok(EitherFloat::F64(float)),
         Err(_) => match strip_underscores(str).and_then(|stripped| stripped.parse().ok()) {
@@ -109,7 +109,7 @@ pub fn str_as_float<'s, 'l>(input: &'s impl Input<'s>, str: &'l str) -> ValResul
 
 /// parse a string as an int, `input` is required here to get lifetimes to match up
 ///
-fn _parse_str<'s, 'l>(_input: &'s impl Input<'s>, str: &'l str, len: usize) -> Option<EitherInt<'s>> {
+fn _parse_str<'s>(_input: &'s impl Input<'s>, str: &str, len: usize) -> Option<EitherInt<'s>> {
     if len < 19 {
         if let Ok(i) = str.parse::<i64>() {
             return Some(EitherInt::I64(i));

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -310,7 +310,7 @@ impl LookupKey {
     pub fn error<'d>(
         &self,
         error_type: ErrorType,
-        input: &'d impl Input<'d>,
+        input: &impl Input<'d>,
         loc_by_alias: bool,
         field_name: &str,
     ) -> ValLineError {

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -27,10 +27,10 @@ impl BuildValidator for AnyValidator {
 impl_py_gc_traverse!(AnyValidator {});
 
 impl Validator for AnyValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         // in a union, Any should be preferred to doing lax coercions

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -166,10 +166,10 @@ impl_py_gc_traverse!(ArgumentsValidator {
 });
 
 impl Validator for ArgumentsValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let args = input.validate_args()?;

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -30,10 +30,10 @@ impl BuildValidator for BoolValidator {
 impl_py_gc_traverse!(BoolValidator {});
 
 impl Validator for BoolValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -40,10 +40,10 @@ impl BuildValidator for BytesValidator {
 impl_py_gc_traverse!(BytesValidator {});
 
 impl Validator for BytesValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         input
@@ -66,10 +66,10 @@ pub struct BytesConstrainedValidator {
 impl_py_gc_traverse!(BytesConstrainedValidator {});
 
 impl Validator for BytesConstrainedValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let either_bytes = input.validate_bytes(state.strict_or(self.strict))?.unpack(state);

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -75,10 +75,10 @@ impl_py_gc_traverse!(CallValidator {
 });
 
 impl Validator for CallValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let args = self.arguments_validator.validate(py, input, state)?.into_bound(py);

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -25,10 +25,10 @@ impl BuildValidator for CallableValidator {
 impl_py_gc_traverse!(CallableValidator {});
 
 impl Validator for CallableValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         state.floor_exactness(Exactness::Lax);

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -70,10 +70,10 @@ fn build_validator_steps(
 impl_py_gc_traverse!(ChainValidator { steps });
 
 impl Validator for ChainValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let mut steps_iter = self.steps.iter();

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -88,10 +88,10 @@ impl BuildValidator for CustomErrorValidator {
 impl_py_gc_traverse!(CustomErrorValidator { validator });
 
 impl Validator for CustomErrorValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         self.validator

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -141,10 +141,10 @@ impl_py_gc_traverse!(Field { validator });
 impl_py_gc_traverse!(DataclassArgsValidator { fields });
 
 impl Validator for DataclassArgsValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let args = input.validate_dataclass_args(&self.dataclass_name)?;
@@ -529,10 +529,10 @@ impl BuildValidator for DataclassValidator {
 impl_py_gc_traverse!(DataclassValidator { class, validator });
 
 impl Validator for DataclassValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if let Some(self_instance) = state.extra().self_instance {
@@ -614,7 +614,7 @@ impl DataclassValidator {
         &'s self,
         py: Python<'data>,
         self_instance: &Bound<'_, PyAny>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on the self_instance
@@ -642,7 +642,7 @@ impl DataclassValidator {
         py: Python<'data>,
         dc: &Bound<'_, PyAny>,
         val_output: PyObject,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
     ) -> ValResult<()> {
         let (dc_dict, post_init_kwargs): (Bound<'_, PyAny>, Bound<'_, PyAny>) = val_output.extract(py)?;
         if self.slots {

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -39,10 +39,10 @@ impl BuildValidator for DateValidator {
 impl_py_gc_traverse!(DateValidator {});
 
 impl Validator for DateValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
@@ -109,7 +109,7 @@ impl Validator for DateValidator {
 /// "exact date", e.g. has a zero time component.
 ///
 /// Ok(None) means that this is not relevant to dates (the input was not a datetime nor a string)
-fn date_from_datetime<'data>(input: &'data impl Input<'data>) -> Result<Option<EitherDate<'data>>, ValError> {
+fn date_from_datetime<'data>(input: &impl Input<'data>) -> Result<Option<EitherDate<'data>>, ValError> {
     let either_dt = match input.validate_datetime(false, speedate::MicrosecondsPrecisionOverflowBehavior::Truncate) {
         Ok(val_match) => val_match.into_inner(),
         // if the error was a parsing error, update the error type from DatetimeParsing to DateFromDatetimeParsing

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -59,10 +59,10 @@ impl BuildValidator for DateTimeValidator {
 impl_py_gc_traverse!(DateTimeValidator {});
 
 impl Validator for DateTimeValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
@@ -141,7 +141,7 @@ impl Validator for DateTimeValidator {
 
 /// In lax mode, if the input is not a datetime, we try parsing the input as a date and add the "00:00:00" time.
 /// Ok(None) means that this is not relevant to datetimes (the input was not a date nor a string)
-fn datetime_from_date<'data>(input: &'data impl Input<'data>) -> Result<Option<EitherDateTime<'data>>, ValError> {
+fn datetime_from_date<'data>(input: &impl Input<'data>) -> Result<Option<EitherDateTime<'data>>, ValError> {
     let either_date = match input.validate_date(false) {
         Ok(val_match) => val_match.into_inner(),
         // if the error was a parsing error, update the error type from DateParsing to DatetimeFromDateParsing
@@ -307,7 +307,7 @@ impl TZConstraint {
         }
     }
 
-    pub(super) fn tz_check<'d>(&self, tz_offset: Option<i32>, input: &'d impl Input<'d>) -> ValResult<()> {
+    pub(super) fn tz_check<'d>(&self, tz_offset: Option<i32>, input: &impl Input<'d>) -> ValResult<()> {
         match (self, tz_offset) {
             (TZConstraint::Aware(_), None) => return Err(ValError::new(ErrorTypeDefaults::TimezoneAware, input)),
             (TZConstraint::Aware(Some(tz_expected)), Some(tz_actual)) => {

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -117,10 +117,10 @@ fn extract_decimal_digits_info(decimal: &Bound<'_, PyAny>, normalized: bool) -> 
 }
 
 impl Validator for DecimalValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let decimal = input.validate_decimal(state.strict_or(self.strict), py)?;
@@ -264,7 +264,7 @@ impl Validator for DecimalValidator {
     }
 }
 
-pub(crate) fn create_decimal<'a>(arg: &Bound<'a, PyAny>, input: &'a impl Input<'a>) -> ValResult<Bound<'a, PyAny>> {
+pub(crate) fn create_decimal<'a>(arg: &Bound<'a, PyAny>, input: &impl Input<'a>) -> ValResult<Bound<'a, PyAny>> {
     let py = arg.py();
     get_decimal_type(py).call1((arg,)).map_err(|e| {
         let decimal_exception = match py

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -69,10 +69,10 @@ impl BuildValidator for DefinitionRefValidator {
 impl_py_gc_traverse!(DefinitionRefValidator {});
 
 impl Validator for DefinitionRefValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         self.definition.read(|validator| {

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -64,10 +64,10 @@ impl BuildValidator for FloatValidator {
 impl_py_gc_traverse!(FloatValidator {});
 
 impl Validator for FloatValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
@@ -96,10 +96,10 @@ pub struct ConstrainedFloatValidator {
 impl_py_gc_traverse!(ConstrainedFloatValidator {});
 
 impl Validator for ConstrainedFloatValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -28,10 +28,10 @@ impl BuildValidator for FrozenSetValidator {
 impl_py_gc_traverse!(FrozenSetValidator { item_validator });
 
 impl Validator for FrozenSetValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let collection = input.validate_frozenset(state.strict_or(self.strict))?;

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -59,10 +59,10 @@ impl BuildValidator for GeneratorValidator {
 impl_py_gc_traverse!(GeneratorValidator { item_validator });
 
 impl Validator for GeneratorValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let iterator = input.validate_iter()?;
@@ -292,7 +292,7 @@ impl InternalValidator {
     pub fn validate<'data>(
         &mut self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         outer_location: Option<LocItem>,
     ) -> PyResult<PyObject> {
         let extra = Extra {

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -43,10 +43,10 @@ impl BuildValidator for IntValidator {
 impl_py_gc_traverse!(IntValidator {});
 
 impl Validator for IntValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         input
@@ -72,10 +72,10 @@ pub struct ConstrainedIntValidator {
 impl_py_gc_traverse!(ConstrainedIntValidator {});
 
 impl Validator for ConstrainedIntValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let either_int = input.validate_int(state.strict_or(self.strict))?.unpack(state);

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -58,7 +58,7 @@ impl Validator for IsInstanceValidator {
     fn validate<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         _state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if !input.is_python() {

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -46,7 +46,7 @@ impl Validator for IsSubclassValidator {
     fn validate<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         _state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match input.input_is_subclass(self.class.bind(py))? {

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -46,10 +46,10 @@ impl BuildValidator for JsonValidator {
 impl_py_gc_traverse!(JsonValidator { validator });
 
 impl Validator for JsonValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let v_match = validate_json_bytes(input)?;
@@ -76,7 +76,7 @@ impl Validator for JsonValidator {
     }
 }
 
-pub fn validate_json_bytes<'data>(input: &'data impl Input<'data>) -> ValResult<ValidationMatch<EitherBytes<'data>>> {
+pub fn validate_json_bytes<'a, 'py>(input: &'a impl Input<'py>) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
     match input.validate_bytes(false) {
         Ok(v_match) => Ok(v_match),
         Err(ValError::LineErrors(e)) => Err(ValError::LineErrors(
@@ -95,7 +95,7 @@ fn map_bytes_error(line_error: ValLineError) -> ValLineError {
     }
 }
 
-pub fn map_json_err<'a>(input: &'a impl Input<'a>, error: jiter::JsonError, json_bytes: &[u8]) -> ValError {
+pub fn map_json_err<'py>(input: &impl Input<'py>, error: jiter::JsonError, json_bytes: &[u8]) -> ValError {
     ValError::new(
         ErrorType::JsonInvalid {
             error: error.description(json_bytes),

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -49,10 +49,10 @@ impl BuildValidator for JsonOrPython {
 impl_py_gc_traverse!(JsonOrPython { json, python });
 
 impl Validator for JsonOrPython {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match state.extra().input_type {

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -56,10 +56,10 @@ impl_py_gc_traverse!(LaxOrStrictValidator {
 });
 
 impl Validator for LaxOrStrictValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if state.strict_or(self.strict) {

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -116,10 +116,10 @@ impl BuildValidator for ListValidator {
 impl_py_gc_traverse!(ListValidator { item_validator });
 
 impl Validator for ListValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let seq = input.validate_list(state.strict_or(self.strict))?;

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -91,11 +91,7 @@ impl<T: Debug> LiteralLookup<T> {
         })
     }
 
-    pub fn validate<'data, I: Input<'data>>(
-        &self,
-        py: Python<'data>,
-        input: &'data I,
-    ) -> ValResult<Option<(&'data I, &T)>> {
+    pub fn validate<'a, 'py, I: Input<'py>>(&self, py: Python<'py>, input: &'a I) -> ValResult<Option<(&'a I, &T)>> {
         if let Some(expected_bool) = &self.expected_bool {
             if let Ok(bool_value) = input.validate_bool(true) {
                 if bool_value.into_inner() {
@@ -196,7 +192,7 @@ impl Validator for LiteralValidator {
     fn validate<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         _state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match self.lookup.validate(py, input)? {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -321,7 +321,7 @@ impl SchemaValidator {
     fn _validate<'s, 'data>(
         &'data self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         input_type: InputType,
         strict: Option<bool>,
         from_attributes: Option<bool>,
@@ -708,10 +708,10 @@ pub enum CombinedValidator {
 #[enum_dispatch(CombinedValidator)]
 pub trait Validator: Send + Sync + Debug {
     /// Do the actual validation for this schema/type
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject>;
 

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -108,10 +108,10 @@ impl BuildValidator for ModelValidator {
 impl_py_gc_traverse!(ModelValidator { class, validator });
 
 impl Validator for ModelValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if let Some(self_instance) = state.extra().self_instance {
@@ -227,7 +227,7 @@ impl ModelValidator {
         &'s self,
         py: Python<'data>,
         self_instance: &Bound<'s, PyAny>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         // we need to set `self_instance` to None for nested validators as we don't want to operate on self_instance
@@ -253,7 +253,7 @@ impl ModelValidator {
     fn validate_construct<'s, 'data>(
         &'s self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         existing_fields_set: Option<&Bound<'_, PyAny>>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
@@ -295,7 +295,7 @@ impl ModelValidator {
         &'s self,
         py: Python<'data>,
         instance: Bound<'_, PyAny>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         extra: &Extra,
     ) -> ValResult<PyObject> {
         if let Some(ref post_init) = self.post_init {

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -119,10 +119,10 @@ impl_py_gc_traverse!(ModelFieldsValidator {
 });
 
 impl Validator for ModelFieldsValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -27,7 +27,7 @@ impl Validator for NoneValidator {
     fn validate<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         _state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match input.is_none() {

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -33,10 +33,10 @@ impl BuildValidator for NullableValidator {
 impl_py_gc_traverse!(NullableValidator { validator });
 
 impl Validator for NullableValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match input.is_none() {

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -58,10 +58,10 @@ impl BuildValidator for SetValidator {
 impl_py_gc_traverse!(SetValidator { item_validator });
 
 impl Validator for SetValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let collection = input.validate_set(state.strict_or(self.strict))?;

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -41,10 +41,10 @@ impl BuildValidator for StrValidator {
 impl_py_gc_traverse!(StrValidator {});
 
 impl Validator for StrValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         input
@@ -73,10 +73,10 @@ pub struct StrConstrainedValidator {
 impl_py_gc_traverse!(StrConstrainedValidator {});
 
 impl Validator for StrConstrainedValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let either_str = input

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -40,10 +40,10 @@ impl BuildValidator for TimeValidator {
 impl_py_gc_traverse!(TimeValidator {});
 
 impl Validator for TimeValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let time = input

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -65,10 +65,10 @@ impl BuildValidator for TimeDeltaValidator {
 impl_py_gc_traverse!(TimeDeltaValidator {});
 
 impl Validator for TimeDeltaValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let timedelta = input

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -60,10 +60,10 @@ impl_py_gc_traverse!(TupleValidator { validators });
 
 impl TupleValidator {
     #[allow(clippy::too_many_arguments)]
-    fn validate_tuple_items<'s, 'data, I: BorrowInput + 'data>(
+    fn validate_tuple_items<'data, I: BorrowInput<'data>>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
         output: &mut Vec<PyObject>,
         errors: &mut Vec<ValLineError>,
@@ -97,10 +97,10 @@ impl TupleValidator {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn validate_tuple_variable<'data, I: BorrowInput + 'data, InputT: Input<'data> + 'data>(
+    fn validate_tuple_variable<'data, I: BorrowInput<'data>, InputT: Input<'data>>(
         &self,
         py: Python<'data>,
-        input: &'data InputT,
+        input: &InputT,
         state: &mut ValidationState,
         errors: &mut Vec<ValLineError>,
         collection_iter: &mut NextCountingIterator<impl Iterator<Item = I>>,
@@ -218,7 +218,7 @@ impl TupleValidator {
 
     fn push_output_item<'data>(
         &self,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         output: &mut Vec<PyObject>,
         item: PyObject,
         actual_length: Option<usize>,
@@ -242,13 +242,13 @@ impl TupleValidator {
 }
 
 impl Validator for TupleValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
-        let collection: GenericIterable<'_> = input.validate_tuple(state.strict_or(self.strict))?;
+        let collection = input.validate_tuple(state.strict_or(self.strict))?;
         let exactness = match &collection {
             GenericIterable::Tuple(_) | GenericIterable::JsonArray(_) => Exactness::Exact,
             GenericIterable::List(_) => Exactness::Strict,

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -145,10 +145,10 @@ impl_py_gc_traverse!(TypedDictValidator {
 });
 
 impl Validator for TypedDictValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -104,7 +104,7 @@ impl UnionValidator {
     fn validate_smart<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let old_exactness = state.exactness;
@@ -170,7 +170,7 @@ impl UnionValidator {
     fn validate_left_to_right<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let mut errors = MaybeErrors::new(self.custom_error.as_ref());
@@ -202,10 +202,10 @@ impl PyGcTraverse for UnionValidator {
 }
 
 impl Validator for UnionValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match self.mode {
@@ -390,10 +390,10 @@ impl BuildValidator for TaggedUnionValidator {
 impl_py_gc_traverse!(TaggedUnionValidator { discriminator, lookup });
 
 impl Validator for TaggedUnionValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         match self.discriminator {
@@ -450,7 +450,7 @@ impl TaggedUnionValidator {
     fn self_schema_tag<'data>(
         &self,
         py: Python<'data>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
     ) -> ValResult<Bound<'data, PyString>> {
         let dict = input.strict_dict()?;
         let tag = match &dict {
@@ -484,7 +484,7 @@ impl TaggedUnionValidator {
         &'s self,
         py: Python<'data>,
         tag: &Bound<'data, PyAny>,
-        input: &'data impl Input<'data>,
+        input: &impl Input<'data>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if let Ok(Some((tag, validator))) = self.lookup.validate(py, tag) {
@@ -507,7 +507,7 @@ impl TaggedUnionValidator {
         }
     }
 
-    fn tag_not_found<'s, 'data>(&'s self, input: &'data impl Input<'data>) -> ValError {
+    fn tag_not_found<'s, 'data>(&'s self, input: &impl Input<'data>) -> ValError {
         match self.custom_error {
             Some(ref custom_error) => custom_error.as_val_error(input),
             None => ValError::new(

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -60,10 +60,10 @@ impl BuildValidator for UrlValidator {
 impl_py_gc_traverse!(UrlValidator {});
 
 impl Validator for UrlValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let mut lib_url = self.get_url(input, state.strict_or(self.strict))?;
@@ -103,7 +103,7 @@ impl Validator for UrlValidator {
 }
 
 impl UrlValidator {
-    fn get_url<'s, 'data>(&'s self, input: &'data impl Input<'data>, strict: bool) -> ValResult<Url> {
+    fn get_url<'s, 'data>(&'s self, input: &impl Input<'data>, strict: bool) -> ValResult<Url> {
         match input.validate_str(strict, false) {
             Ok(val_match) => {
                 let either_str = val_match.into_inner();
@@ -133,7 +133,7 @@ impl UrlValidator {
         }
     }
 
-    fn check_length<'s, 'data>(&self, input: &'data impl Input<'data>, url_str: &str) -> ValResult<()> {
+    fn check_length<'s, 'data>(&self, input: &impl Input<'data>, url_str: &str) -> ValResult<()> {
         if let Some(max_length) = self.max_length {
             if url_str.len() > max_length {
                 return Err(ValError::new(
@@ -194,10 +194,10 @@ impl BuildValidator for MultiHostUrlValidator {
 impl_py_gc_traverse!(MultiHostUrlValidator {});
 
 impl Validator for MultiHostUrlValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let mut multi_url = self.get_url(input, state.strict_or(self.strict))?;
@@ -236,7 +236,7 @@ impl Validator for MultiHostUrlValidator {
 }
 
 impl MultiHostUrlValidator {
-    fn get_url<'s, 'data>(&'s self, input: &'data impl Input<'data>, strict: bool) -> ValResult<PyMultiHostUrl> {
+    fn get_url<'s, 'data>(&'s self, input: &impl Input<'data>, strict: bool) -> ValResult<PyMultiHostUrl> {
         match input.validate_str(strict, false) {
             Ok(val_match) => {
                 let either_str = val_match.into_inner();
@@ -264,7 +264,7 @@ impl MultiHostUrlValidator {
         }
     }
 
-    fn check_length<'s, 'data, F>(&self, input: &'data impl Input<'data>, func: F) -> ValResult<()>
+    fn check_length<'s, 'data, F>(&self, input: &impl Input<'data>, func: F) -> ValResult<()>
     where
         F: FnOnce() -> usize,
     {
@@ -285,7 +285,7 @@ impl MultiHostUrlValidator {
 
 fn parse_multihost_url<'url, 'input>(
     url_str: &'url str,
-    input: &'input impl Input<'input>,
+    input: &impl Input<'input>,
     strict: bool,
 ) -> ValResult<PyMultiHostUrl> {
     macro_rules! parsing_err {
@@ -402,7 +402,7 @@ fn parse_multihost_url<'url, 'input>(
     }
 }
 
-fn parse_url<'url, 'input>(url_str: &'url str, input: &'input impl Input<'input>, strict: bool) -> ValResult<Url> {
+fn parse_url<'url, 'input>(url_str: &'url str, input: &impl Input<'input>, strict: bool) -> ValResult<Url> {
     if url_str.is_empty() {
         return Err(ValError::new(
             ErrorType::UrlParsing {

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -86,10 +86,10 @@ impl BuildValidator for UuidValidator {
 impl_py_gc_traverse!(UuidValidator {});
 
 impl Validator for UuidValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         let class = get_uuid_type(py)?;
@@ -150,7 +150,7 @@ impl Validator for UuidValidator {
 }
 
 impl UuidValidator {
-    fn get_uuid<'s, 'data>(&'s self, input: &'data impl Input<'data>) -> ValResult<Uuid> {
+    fn get_uuid<'s, 'data>(&'s self, input: &impl Input<'data>) -> ValResult<Uuid> {
         let uuid = match input.exact_str().ok() {
             Some(either_string) => {
                 let cow = either_string.as_cow()?;

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -134,10 +134,10 @@ impl BuildValidator for WithDefaultValidator {
 impl_py_gc_traverse!(WithDefaultValidator { default, validator });
 
 impl Validator for WithDefaultValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
+        py: Python<'py>,
+        input: &impl Input<'py>,
         state: &mut ValidationState,
     ) -> ValResult<PyObject> {
         if input.to_object(py).is(&self.undefined) {


### PR DESCRIPTION
## Change Summary

This is in advance of supporting https://github.com/pydantic/jiter/pull/63/files

The main complication which I face there is that the `Input<'data>` lifetime is a bit mixed up in what lifetime should be `'py` for the Python interpreter and which should be `'a` for the data borrowed from the `Input`. When we start throwing the cow lifetime into the mix (which is equivalent to `'a`) things get really mixed up if we don't try to untangle concepts first.

This PR separates out those two concepts more cleanly. In general this means that code which previously took `&'data impl Input<'data>` now just takes `&impl Input<'py>` in most places.

I looked at more extreme alternatives like removing the `'py` lifetime from the trait entirely. That might still be still on the cards, but it would require some more extensive refactoring and this would be a precursor anyway.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
