### PR TITLE
Fix json serialization when computed field is excluded

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -163,7 +163,6 @@ impl ComputedField {
         }
         Ok(())
     }
-
 }
 
 pub(crate) struct ComputedFieldSerializer<'py> {

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -71,16 +71,18 @@ impl ComputedFields {
             // Do not serialize computed fields
             return Ok(());
         }
+
         for computed_field in &self.0 {
             let property_name_py = computed_field.property_name_py.bind(model.py());
-            let value = model.getattr(property_name_py).map_err(py_err_se_err)?;
-            if extra.exclude_none && value.is_none() {
-                continue;
-            }
+
             if let Some((next_include, next_exclude)) = filter
                 .key_filter(property_name_py, include, exclude)
                 .map_err(py_err_se_err)?
             {
+                let value = model.getattr(property_name_py).map_err(py_err_se_err)?;
+                if extra.exclude_none && value.is_none() {
+                    continue;
+                }
                 let cfs = ComputedFieldSerializer {
                     model,
                     computed_field,
@@ -161,6 +163,7 @@ impl ComputedField {
         }
         Ok(())
     }
+
 }
 
 pub(crate) struct ComputedFieldSerializer<'py> {


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9015

Previously, we were getting the value of a computed field before we checked if it was excluded, which could lead to a recursion error in a case like that shown below.

This mirrors the behavior of the `to_python` logic already present, which currently works.

```py
from __future__ import annotations

import hashlib

from pydantic import BaseModel, computed_field


class MediaFileInfo(BaseModel):
    url: str
    duration: float
    bitrate: int
    format: str
    codec: str

    @computed_field(repr=False)
    def id(self) -> str:
        str_obj = self.model_dump_json(exclude={"id"})
        hash_obj = hashlib.sha256()
        hash_obj.update(str_obj.encode("utf-8"))
        return hash_obj.hexdigest()[:12]


class VideoMediaFileInfo(MediaFileInfo):
    width: int
    height: int


class AudioMediaFileInfo(MediaFileInfo):
    language: str


if __name__ == "__main__":
    mf = AudioMediaFileInfo(
        url="https://bla.com",
        duration=123,
        bitrate=123,
        format="mp4",
        codec="mp4",
        language="fr"
    )
    print(mf.id)
```

This case is now fixed, and prints the id as expected! I think it makes sense to add a test case in `pydantic` for this 👍 

Selected Reviewer: @samuelcolvin