### PR TITLE
implement `Input` for `str`

### DIFF
--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -5,6 +5,7 @@ use pyo3::DowncastIntoError;
 
 use jiter::JsonValue;
 
+use crate::input::BorrowInput;
 use crate::input::Input;
 
 use super::location::{LocItem, Location};
@@ -12,13 +13,13 @@ use super::types::ErrorType;
 
 pub type ValResult<T> = Result<T, ValError>;
 
-pub trait AsErrorValue {
-    fn as_error_value(&self) -> InputValue;
+pub trait ToErrorValue {
+    fn to_error_value(&self) -> InputValue;
 }
 
-impl<'a, T: Input<'a>> AsErrorValue for T {
-    fn as_error_value(&self) -> InputValue {
-        Input::as_error_value(self)
+impl<'a, T: BorrowInput<'a>> ToErrorValue for T {
+    fn to_error_value(&self) -> InputValue {
+        Input::as_error_value(self.borrow_input())
     }
 }
 
@@ -55,11 +56,11 @@ impl From<Vec<ValLineError>> for ValError {
 }
 
 impl ValError {
-    pub fn new(error_type: ErrorType, input: &impl AsErrorValue) -> ValError {
+    pub fn new(error_type: ErrorType, input: impl ToErrorValue) -> ValError {
         Self::LineErrors(vec![ValLineError::new(error_type, input)])
     }
 
-    pub fn new_with_loc(error_type: ErrorType, input: &impl AsErrorValue, loc: impl Into<LocItem>) -> ValError {
+    pub fn new_with_loc(error_type: ErrorType, input: impl ToErrorValue, loc: impl Into<LocItem>) -> ValError {
         Self::LineErrors(vec![ValLineError::new_with_loc(error_type, input, loc)])
     }
 
@@ -94,26 +95,26 @@ pub struct ValLineError {
 }
 
 impl ValLineError {
-    pub fn new(error_type: ErrorType, input: &impl AsErrorValue) -> ValLineError {
+    pub fn new(error_type: ErrorType, input: impl ToErrorValue) -> ValLineError {
         Self {
             error_type,
-            input_value: input.as_error_value(),
+            input_value: input.to_error_value(),
             location: Location::default(),
         }
     }
 
-    pub fn new_with_loc(error_type: ErrorType, input: &impl AsErrorValue, loc: impl Into<LocItem>) -> ValLineError {
+    pub fn new_with_loc(error_type: ErrorType, input: impl ToErrorValue, loc: impl Into<LocItem>) -> ValLineError {
         Self {
             error_type,
-            input_value: input.as_error_value(),
+            input_value: input.to_error_value(),
             location: Location::new_some(loc.into()),
         }
     }
 
-    pub fn new_with_full_loc(error_type: ErrorType, input: &impl AsErrorValue, location: Location) -> ValLineError {
+    pub fn new_with_full_loc(error_type: ErrorType, input: impl ToErrorValue, location: Location) -> ValLineError {
         Self {
             error_type,
-            input_value: input.as_error_value(),
+            input_value: input.to_error_value(),
             location,
         }
     }

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -23,6 +23,12 @@ impl<'a, T: BorrowInput<'a>> ToErrorValue for T {
     }
 }
 
+impl ToErrorValue for &'_ dyn ToErrorValue {
+    fn to_error_value(&self) -> InputValue {
+        (**self).to_error_value()
+    }
+}
+
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum ValError {
     LineErrors(Vec<ValLineError>),

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,7 +6,7 @@ mod types;
 mod validation_exception;
 mod value_exception;
 
-pub use self::line_error::{AsErrorValue, InputValue, ValError, ValLineError, ValResult};
+pub use self::line_error::{InputValue, ToErrorValue, ValError, ValLineError, ValResult};
 pub use self::location::LocItem;
 pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
 pub use self::validation_exception::ValidationError;

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -5,7 +5,7 @@ use pyo3::types::{PyDict, PyString};
 use crate::input::InputType;
 use crate::tools::extract_i64;
 
-use super::line_error::AsErrorValue;
+use super::line_error::ToErrorValue;
 use super::{ErrorType, ValError};
 
 #[pyclass(extends=PyException, module="pydantic_core._pydantic_core")]
@@ -106,7 +106,7 @@ impl PydanticCustomError {
 }
 
 impl PydanticCustomError {
-    pub fn into_val_error(self, input: &impl AsErrorValue) -> ValError {
+    pub fn into_val_error(self, input: impl ToErrorValue) -> ValError {
         let error_type = ErrorType::CustomError {
             error_type: self.error_type,
             message_template: self.message_template,
@@ -181,7 +181,7 @@ impl PydanticKnownError {
 }
 
 impl PydanticKnownError {
-    pub fn into_val_error(self, input: &impl AsErrorValue) -> ValError {
+    pub fn into_val_error(self, input: impl ToErrorValue) -> ValError {
         ValError::new(self.error_type, input)
     }
 }

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -4,7 +4,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyDict, PyType};
 use pyo3::{intern, prelude::*};
 
-use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
+use crate::errors::{ErrorTypeDefaults, InputValue, ValError, ValResult};
 use crate::tools::py_err;
 use crate::{PyMultiHostUrl, PyUrl};
 
@@ -46,7 +46,7 @@ impl TryFrom<&str> for InputType {
 /// the convention is to either implement:
 /// * `strict_*` & `lax_*` if they have different behavior
 /// * or, `validate_*` and `strict_*` to just call `validate_*` if the behavior for strict and lax is the same
-pub trait Input<'py>: fmt::Debug + ToPyObject + Into<LocItem> + Sized {
+pub trait Input<'py>: fmt::Debug + ToPyObject {
     fn as_error_value(&self) -> InputValue;
 
     fn identity(&self) -> Option<usize> {
@@ -83,9 +83,9 @@ pub trait Input<'py>: fmt::Debug + ToPyObject + Into<LocItem> + Sized {
         false
     }
 
-    fn validate_args(&self) -> ValResult<GenericArguments<'_>>;
+    fn validate_args(&self) -> ValResult<GenericArguments<'_, 'py>>;
 
-    fn validate_dataclass_args<'a>(&'a self, dataclass_name: &str) -> ValResult<GenericArguments<'a>>;
+    fn validate_dataclass_args<'a>(&'a self, dataclass_name: &str) -> ValResult<GenericArguments<'a, 'py>>;
 
     fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValResult<ValidationMatch<EitherString<'_>>>;
 
@@ -201,25 +201,25 @@ pub trait Input<'py>: fmt::Debug + ToPyObject + Into<LocItem> + Sized {
 
     fn validate_iter(&self) -> ValResult<GenericIterator>;
 
-    fn validate_date(&self, strict: bool) -> ValResult<ValidationMatch<EitherDate>>;
+    fn validate_date(&self, strict: bool) -> ValResult<ValidationMatch<EitherDate<'py>>>;
 
     fn validate_time(
         &self,
         strict: bool,
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTime>>;
+    ) -> ValResult<ValidationMatch<EitherTime<'py>>>;
 
     fn validate_datetime(
         &self,
         strict: bool,
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherDateTime>>;
+    ) -> ValResult<ValidationMatch<EitherDateTime<'py>>>;
 
     fn validate_timedelta(
         &self,
         strict: bool,
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTimedelta>>;
+    ) -> ValResult<ValidationMatch<EitherTimedelta<'py>>>;
 }
 
 /// The problem to solve here is that iterating collections often returns owned
@@ -228,11 +228,11 @@ pub trait Input<'py>: fmt::Debug + ToPyObject + Into<LocItem> + Sized {
 /// or borrowed; all we care about is that we can borrow it again with `borrow_input`
 /// for some lifetime 'a.
 pub trait BorrowInput<'py> {
-    type Input: Input<'py>;
+    type Input: Input<'py> + ?Sized;
     fn borrow_input(&self) -> &Self::Input;
 }
 
-impl<'py, T: Input<'py>> BorrowInput<'py> for &'_ T {
+impl<'py, T: Input<'py> + ?Sized> BorrowInput<'py> for &'_ T {
     type Input = T;
     fn borrow_input(&self) -> &Self::Input {
         self

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -231,3 +231,10 @@ pub trait BorrowInput<'py> {
     type Input: Input<'py>;
     fn borrow_input(&self) -> &Self::Input;
 }
+
+impl<'py, T: Input<'py>> BorrowInput<'py> for &'_ T {
+    type Input = T;
+    fn borrow_input(&self) -> &Self::Input {
+        self
+    }
+}

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -308,13 +308,6 @@ impl<'py> Input<'py> for JsonValue {
     }
 }
 
-impl BorrowInput<'_> for &'_ JsonValue {
-    type Input = JsonValue;
-    fn borrow_input(&self) -> &Self::Input {
-        self
-    }
-}
-
 /// Required for JSON Object keys so the string can behave like an Input
 impl<'py> Input<'py> for String {
     fn as_error_value(&self) -> InputValue {
@@ -436,13 +429,6 @@ impl<'py> Input<'py> for String {
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
     ) -> ValResult<ValidationMatch<EitherTimedelta>> {
         bytes_as_timedelta(self, self.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::lax)
-    }
-}
-
-impl BorrowInput<'_> for &'_ String {
-    type Input = String;
-    fn borrow_input(&self) -> &Self::Input {
-        self
     }
 }
 

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -60,7 +60,7 @@ impl<'py> Input<'py> for JsonValue {
         }
     }
 
-    fn validate_args(&self) -> ValResult<GenericArguments<'_>> {
+    fn validate_args(&self) -> ValResult<GenericArguments<'_, 'py>> {
         match self {
             JsonValue::Object(object) => Ok(JsonArgs::new(None, Some(object)).into()),
             JsonValue::Array(array) => Ok(JsonArgs::new(Some(array), None).into()),
@@ -68,7 +68,7 @@ impl<'py> Input<'py> for JsonValue {
         }
     }
 
-    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a>> {
+    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a, 'py>> {
         match self {
             JsonValue::Object(object) => Ok(JsonArgs::new(None, Some(object)).into()),
             _ => {
@@ -241,7 +241,7 @@ impl<'py> Input<'py> for JsonValue {
         }
     }
 
-    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate>> {
+    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate<'py>>> {
         match self {
             JsonValue::Str(v) => bytes_as_date(self, v.as_bytes()).map(ValidationMatch::strict),
             _ => Err(ValError::new(ErrorTypeDefaults::DateType, self)),
@@ -251,7 +251,7 @@ impl<'py> Input<'py> for JsonValue {
         &self,
         strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTime>> {
+    ) -> ValResult<ValidationMatch<EitherTime<'py>>> {
         match self {
             JsonValue::Str(v) => {
                 bytes_as_time(self, v.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::strict)
@@ -277,7 +277,7 @@ impl<'py> Input<'py> for JsonValue {
         &self,
         strict: bool,
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherDateTime>> {
+    ) -> ValResult<ValidationMatch<EitherDateTime<'py>>> {
         match self {
             JsonValue::Str(v) => {
                 bytes_as_datetime(self, v.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::strict)
@@ -292,7 +292,7 @@ impl<'py> Input<'py> for JsonValue {
         &self,
         strict: bool,
         microseconds_overflow_behavior: speedate::MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTimedelta>> {
+    ) -> ValResult<ValidationMatch<EitherTimedelta<'py>>> {
         match self {
             JsonValue::Str(v) => {
                 bytes_as_timedelta(self, v.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::strict)
@@ -309,11 +309,11 @@ impl<'py> Input<'py> for JsonValue {
 }
 
 /// Required for JSON Object keys so the string can behave like an Input
-impl<'py> Input<'py> for String {
+impl<'py> Input<'py> for str {
     fn as_error_value(&self) -> InputValue {
         // Justification for the clone: this is on the error pathway and we are generally ok
         // with errors having a performance penalty
-        InputValue::Json(JsonValue::Str(self.clone()))
+        InputValue::Json(JsonValue::Str(self.to_owned()))
     }
 
     fn as_kwargs(&self, _py: Python<'py>) -> Option<Bound<'py, PyDict>> {
@@ -321,12 +321,12 @@ impl<'py> Input<'py> for String {
     }
 
     #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn validate_args(&self) -> ValResult<GenericArguments<'_>> {
+    fn validate_args(&self) -> ValResult<GenericArguments<'_, 'py>> {
         Err(ValError::new(ErrorTypeDefaults::ArgumentsType, self))
     }
 
     #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a>> {
+    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a, 'py>> {
         let class_name = class_name.to_string();
         Err(ValError::new(
             ErrorType::DataclassType {
@@ -347,7 +347,7 @@ impl<'py> Input<'py> for String {
         // converting input
         // TODO: in V3 we may want to make JSON str always win if in union, for consistency,
         // see https://github.com/pydantic/pydantic-core/pull/867#discussion_r1386582501
-        Ok(ValidationMatch::strict(self.as_str().into()))
+        Ok(ValidationMatch::strict(self.into()))
     }
 
     fn validate_bytes<'a>(&'a self, _strict: bool) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
@@ -403,7 +403,7 @@ impl<'py> Input<'py> for String {
         Ok(string_to_vec(self).into())
     }
 
-    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate>> {
+    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate<'py>>> {
         bytes_as_date(self, self.as_bytes()).map(ValidationMatch::lax)
     }
 
@@ -411,7 +411,7 @@ impl<'py> Input<'py> for String {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTime>> {
+    ) -> ValResult<ValidationMatch<EitherTime<'py>>> {
         bytes_as_time(self, self.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::lax)
     }
 
@@ -419,7 +419,7 @@ impl<'py> Input<'py> for String {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherDateTime>> {
+    ) -> ValResult<ValidationMatch<EitherDateTime<'py>>> {
         bytes_as_datetime(self, self.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::lax)
     }
 
@@ -427,13 +427,20 @@ impl<'py> Input<'py> for String {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTimedelta>> {
+    ) -> ValResult<ValidationMatch<EitherTimedelta<'py>>> {
         bytes_as_timedelta(self, self.as_bytes(), microseconds_overflow_behavior).map(ValidationMatch::lax)
     }
 }
 
+impl BorrowInput<'_> for &'_ String {
+    type Input = str;
+    fn borrow_input(&self) -> &Self::Input {
+        self
+    }
+}
+
 impl BorrowInput<'_> for String {
-    type Input = String;
+    type Input = str;
     fn borrow_input(&self) -> &Self::Input {
         self
     }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -160,7 +160,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         self.is_callable()
     }
 
-    fn validate_args(&self) -> ValResult<GenericArguments<'_>> {
+    fn validate_args(&self) -> ValResult<GenericArguments<'_, 'py>> {
         if let Ok(dict) = self.downcast::<PyDict>() {
             Ok(PyArgs::new(None, Some(dict.clone())).into())
         } else if let Ok(args_kwargs) = self.extract::<ArgsKwargs>() {
@@ -176,7 +176,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
     }
 
-    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a>> {
+    fn validate_dataclass_args<'a>(&'a self, class_name: &str) -> ValResult<GenericArguments<'a, 'py>> {
         if let Ok(dict) = self.downcast::<PyDict>() {
             Ok(PyArgs::new(None, Some(dict.clone())).into())
         } else if let Ok(args_kwargs) = self.extract::<ArgsKwargs>() {
@@ -584,7 +584,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
     }
 
-    fn validate_date(&self, strict: bool) -> ValResult<ValidationMatch<EitherDate>> {
+    fn validate_date(&self, strict: bool) -> ValResult<ValidationMatch<EitherDate<'py>>> {
         if let Ok(date) = self.downcast_exact::<PyDate>() {
             Ok(ValidationMatch::exact(date.clone().into()))
         } else if self.is_instance_of::<PyDateTime>() {
@@ -615,7 +615,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         &self,
         strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTime>> {
+    ) -> ValResult<ValidationMatch<EitherTime<'py>>> {
         if let Ok(time) = self.downcast_exact::<PyTime>() {
             return Ok(ValidationMatch::exact(time.clone().into()));
         } else if let Ok(time) = self.downcast::<PyTime>() {
@@ -649,7 +649,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         &self,
         strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherDateTime>> {
+    ) -> ValResult<ValidationMatch<EitherDateTime<'py>>> {
         if let Ok(dt) = self.downcast_exact::<PyDateTime>() {
             return Ok(ValidationMatch::exact(dt.clone().into()));
         } else if let Ok(dt) = self.downcast::<PyDateTime>() {
@@ -685,7 +685,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         &self,
         strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTimedelta>> {
+    ) -> ValResult<ValidationMatch<EitherTimedelta<'py>>> {
         if let Ok(either_dt) = EitherTimedelta::try_from(self) {
             let exactness = if matches!(either_dt, EitherTimedelta::PyExact(_)) {
                 Exactness::Exact

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -73,12 +73,12 @@ impl<'py> Input<'py> for StringMapping<'py> {
         None
     }
 
-    fn validate_args(&self) -> ValResult<GenericArguments<'_>> {
+    fn validate_args(&self) -> ValResult<GenericArguments<'_, 'py>> {
         // do we want to support this?
         Err(ValError::new(ErrorTypeDefaults::ArgumentsType, self))
     }
 
-    fn validate_dataclass_args<'a>(&'a self, _dataclass_name: &str) -> ValResult<GenericArguments<'a>> {
+    fn validate_dataclass_args<'a>(&'a self, _dataclass_name: &str) -> ValResult<GenericArguments<'a, 'py>> {
         match self {
             StringMapping::String(_) => Err(ValError::new(ErrorTypeDefaults::ArgumentsType, self)),
             StringMapping::Mapping(m) => Ok(GenericArguments::StringMapping(m.clone())),
@@ -162,7 +162,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         Err(ValError::new(ErrorTypeDefaults::IterableType, self))
     }
 
-    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate>> {
+    fn validate_date(&self, _strict: bool) -> ValResult<ValidationMatch<EitherDate<'py>>> {
         match self {
             Self::String(s) => bytes_as_date(self, py_string_str(s)?.as_bytes()).map(ValidationMatch::strict),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DateType, self)),
@@ -173,7 +173,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTime>> {
+    ) -> ValResult<ValidationMatch<EitherTime<'py>>> {
         match self {
             Self::String(s) => bytes_as_time(self, py_string_str(s)?.as_bytes(), microseconds_overflow_behavior)
                 .map(ValidationMatch::strict),
@@ -185,7 +185,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherDateTime>> {
+    ) -> ValResult<ValidationMatch<EitherDateTime<'py>>> {
         match self {
             Self::String(s) => bytes_as_datetime(self, py_string_str(s)?.as_bytes(), microseconds_overflow_behavior)
                 .map(ValidationMatch::strict),
@@ -197,7 +197,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         &self,
         _strict: bool,
         microseconds_overflow_behavior: MicrosecondsPrecisionOverflowBehavior,
-    ) -> ValResult<ValidationMatch<EitherTimedelta>> {
+    ) -> ValResult<ValidationMatch<EitherTimedelta<'py>>> {
         match self {
             Self::String(s) => bytes_as_timedelta(self, py_string_str(s)?.as_bytes(), microseconds_overflow_behavior)
                 .map(ValidationMatch::strict),

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -8,8 +8,8 @@ use pyo3::types::{PyDict, PyList, PyMapping, PyString};
 use jiter::{JsonObject, JsonValue};
 
 use crate::build_tools::py_schema_err;
-use crate::errors::{py_err_string, ErrorType, ValError, ValLineError, ValResult};
-use crate::input::{Input, StringMapping};
+use crate::errors::{py_err_string, ErrorType, ToErrorValue, ValError, ValLineError, ValResult};
+use crate::input::StringMapping;
 use crate::tools::{extract_i64, py_err};
 
 /// Used for getting items from python dicts, python objects, or JSON objects, in different ways
@@ -307,10 +307,10 @@ impl LookupKey {
         }
     }
 
-    pub fn error<'d>(
+    pub fn error(
         &self,
         error_type: ErrorType,
-        input: &impl Input<'d>,
+        input: impl ToErrorValue,
         loc_by_alias: bool,
         field_name: &str,
     ) -> ValLineError {

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -30,8 +30,8 @@ impl Validator for AnyValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         // in a union, Any should be preferred to doing lax coercions
         state.floor_exactness(Exactness::Strict);

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -169,8 +169,8 @@ impl Validator for ArgumentsValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let args = input.validate_args()?;
 

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -33,8 +33,8 @@ impl Validator for BoolValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -43,8 +43,8 @@ impl Validator for BytesValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         input
             .validate_bytes(state.strict_or(self.strict))
@@ -69,8 +69,8 @@ impl Validator for BytesConstrainedValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let either_bytes = input.validate_bytes(state.strict_or(self.strict))?.unpack(state);
         let len = either_bytes.len()?;

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -78,8 +78,8 @@ impl Validator for CallValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let args = self.arguments_validator.validate(py, input, state)?.into_bound(py);
 

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -28,8 +28,8 @@ impl Validator for CallableValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         state.floor_exactness(Exactness::Lax);
         match input.callable() {

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -73,8 +73,8 @@ impl Validator for ChainValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let mut steps_iter = self.steps.iter();
         let first_step = steps_iter.next().unwrap();

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::py_schema_err;
-use crate::errors::AsErrorValue;
+use crate::errors::ToErrorValue;
 use crate::errors::{ErrorType, PydanticCustomError, PydanticKnownError, ValError, ValResult};
 use crate::input::Input;
 use crate::tools::SchemaDict;
@@ -49,7 +49,7 @@ impl CustomError {
         }
     }
 
-    pub fn as_val_error(&self, input: &impl AsErrorValue) -> ValError {
+    pub fn as_val_error(&self, input: impl ToErrorValue) -> ValError {
         match self {
             CustomError::KnownError(ref known_error) => known_error.clone().into_val_error(input),
             CustomError::Custom(ref custom_error) => custom_error.clone().into_val_error(input),

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -91,8 +91,8 @@ impl Validator for CustomErrorValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         self.validator
             .validate(py, input, state)

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -42,8 +42,8 @@ impl Validator for DateValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let date = match input.validate_date(strict) {
@@ -109,7 +109,7 @@ impl Validator for DateValidator {
 /// "exact date", e.g. has a zero time component.
 ///
 /// Ok(None) means that this is not relevant to dates (the input was not a datetime nor a string)
-fn date_from_datetime<'data>(input: &impl Input<'data>) -> Result<Option<EitherDate<'data>>, ValError> {
+fn date_from_datetime<'py>(input: &(impl Input<'py> + ?Sized)) -> Result<Option<EitherDate<'py>>, ValError> {
     let either_dt = match input.validate_datetime(false, speedate::MicrosecondsPrecisionOverflowBehavior::Truncate) {
         Ok(val_match) => val_match.into_inner(),
         // if the error was a parsing error, update the error type from DatetimeParsing to DateFromDatetimeParsing

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -72,8 +72,8 @@ impl Validator for DefinitionRefValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();
@@ -88,13 +88,13 @@ impl Validator for DefinitionRefValidator {
         })
     }
 
-    fn validate_assignment<'data>(
+    fn validate_assignment<'py>(
         &self,
-        py: Python<'data>,
-        obj: &Bound<'data, PyAny>,
+        py: Python<'py>,
+        obj: &Bound<'py, PyAny>,
         field_name: &str,
-        field_value: &Bound<'data, PyAny>,
-        state: &mut ValidationState,
+        field_value: &Bound<'py, PyAny>,
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -70,8 +70,8 @@ impl Validator for DictValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;
@@ -99,14 +99,14 @@ impl Validator for DictValidator {
 }
 
 impl DictValidator {
-    fn validate_generic_mapping<'data>(
+    fn validate_generic_mapping<'py>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
         mapping_iter: impl Iterator<
-            Item = ValResult<(impl BorrowInput<'data> + Clone + Into<LocItem>, impl BorrowInput<'data>)>,
+            Item = ValResult<(impl BorrowInput<'py> + Clone + Into<LocItem>, impl BorrowInput<'py>)>,
         >,
-        state: &mut ValidationState,
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let output = PyDict::new_bound(py);
         let mut errors: Vec<ValLineError> = Vec::new();

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -67,8 +67,8 @@ impl Validator for FloatValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         if !self.allow_inf_nan && !either_float.as_f64().is_finite() {
@@ -99,8 +99,8 @@ impl Validator for ConstrainedFloatValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         let float: f64 = either_float.as_f64();

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -31,8 +31,8 @@ impl Validator for FrozenSetValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let collection = input.validate_frozenset(state.strict_or(self.strict))?;
         let exactness = match &collection {

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -62,8 +62,8 @@ impl Validator for GeneratorValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let iterator = input.validate_iter()?;
         let validator = self.item_validator.as_ref().map(|v| {
@@ -253,12 +253,12 @@ impl InternalValidator {
         }
     }
 
-    pub fn validate_assignment<'data>(
+    pub fn validate_assignment<'py>(
         &mut self,
-        py: Python<'data>,
-        model: &Bound<'data, PyAny>,
+        py: Python<'py>,
+        model: &Bound<'py, PyAny>,
         field_name: &str,
-        field_value: &Bound<'data, PyAny>,
+        field_value: &Bound<'py, PyAny>,
         outer_location: Option<LocItem>,
     ) -> PyResult<PyObject> {
         let extra = Extra {
@@ -289,10 +289,10 @@ impl InternalValidator {
         result
     }
 
-    pub fn validate<'data>(
+    pub fn validate<'py>(
         &mut self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
         outer_location: Option<LocItem>,
     ) -> PyResult<PyObject> {
         let extra = Extra {

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -46,8 +46,8 @@ impl Validator for IntValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         input
             .validate_int(state.strict_or(self.strict))
@@ -75,8 +75,8 @@ impl Validator for ConstrainedIntValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let either_int = input.validate_int(state.strict_or(self.strict))?.unpack(state);
         let int_value = either_int.as_int()?;

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -55,11 +55,11 @@ impl BuildValidator for IsInstanceValidator {
 impl_py_gc_traverse!(IsInstanceValidator { class });
 
 impl Validator for IsInstanceValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
-        _state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         if !input.is_python() {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -43,11 +43,11 @@ impl BuildValidator for IsSubclassValidator {
 impl_py_gc_traverse!(IsSubclassValidator { class });
 
 impl Validator for IsSubclassValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
-        _state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         match input.input_is_subclass(self.class.bind(py))? {
             true => Ok(input.to_object(py)),

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -49,8 +49,8 @@ impl Validator for JsonValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let v_match = validate_json_bytes(input)?;
         let json_either_bytes = v_match.unpack(state);
@@ -76,7 +76,9 @@ impl Validator for JsonValidator {
     }
 }
 
-pub fn validate_json_bytes<'a, 'py>(input: &'a impl Input<'py>) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
+pub fn validate_json_bytes<'a, 'py>(
+    input: &'a (impl Input<'py> + ?Sized),
+) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
     match input.validate_bytes(false) {
         Ok(v_match) => Ok(v_match),
         Err(ValError::LineErrors(e)) => Err(ValError::LineErrors(
@@ -95,7 +97,7 @@ fn map_bytes_error(line_error: ValLineError) -> ValLineError {
     }
 }
 
-pub fn map_json_err<'py>(input: &impl Input<'py>, error: jiter::JsonError, json_bytes: &[u8]) -> ValError {
+pub fn map_json_err<'py>(input: &(impl Input<'py> + ?Sized), error: jiter::JsonError, json_bytes: &[u8]) -> ValError {
     ValError::new(
         ErrorType::JsonInvalid {
             error: error.description(json_bytes),

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -52,8 +52,8 @@ impl Validator for JsonOrPython {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         match state.extra().input_type {
             InputType::Python => self.python.validate(py, input, state),

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -59,8 +59,8 @@ impl Validator for LaxOrStrictValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         if state.strict_or(self.strict) {
             self.strict_validator.validate(py, input, state)

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -119,8 +119,8 @@ impl Validator for ListValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let seq = input.validate_list(state.strict_or(self.strict))?;
         let exactness = match &seq {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -91,7 +91,11 @@ impl<T: Debug> LiteralLookup<T> {
         })
     }
 
-    pub fn validate<'a, 'py, I: Input<'py>>(&self, py: Python<'py>, input: &'a I) -> ValResult<Option<(&'a I, &T)>> {
+    pub fn validate<'a, 'py, I: Input<'py> + ?Sized>(
+        &self,
+        py: Python<'py>,
+        input: &'a I,
+    ) -> ValResult<Option<(&'a I, &T)>> {
         if let Some(expected_bool) = &self.expected_bool {
             if let Ok(bool_value) = input.validate_bool(true) {
                 if bool_value.into_inner() {
@@ -189,11 +193,11 @@ impl BuildValidator for LiteralValidator {
 impl_py_gc_traverse!(LiteralValidator { lookup });
 
 impl Validator for LiteralValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
-        _state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         match self.lookup.validate(py, input)? {
             Some((_, v)) => Ok(v.clone()),

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -122,8 +122,8 @@ impl Validator for ModelFieldsValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
@@ -340,13 +340,13 @@ impl Validator for ModelFieldsValidator {
         }
     }
 
-    fn validate_assignment<'data>(
+    fn validate_assignment<'py>(
         &self,
-        py: Python<'data>,
-        obj: &Bound<'data, PyAny>,
+        py: Python<'py>,
+        obj: &Bound<'py, PyAny>,
         field_name: &str,
-        field_value: &Bound<'data, PyAny>,
-        state: &mut ValidationState,
+        field_value: &Bound<'py, PyAny>,
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let dict = obj.downcast::<PyDict>()?;
 

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -24,11 +24,11 @@ impl BuildValidator for NoneValidator {
 impl_py_gc_traverse!(NoneValidator {});
 
 impl Validator for NoneValidator {
-    fn validate<'data>(
+    fn validate<'py>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
-        _state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         match input.is_none() {
             true => Ok(py.None()),

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -36,8 +36,8 @@ impl Validator for NullableValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         match input.is_none() {
             true => Ok(py.None()),

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -61,8 +61,8 @@ impl Validator for SetValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let collection = input.validate_set(state.strict_or(self.strict))?;
         let exactness = match &collection {

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -44,8 +44,8 @@ impl Validator for StrValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)
@@ -76,8 +76,8 @@ impl Validator for StrConstrainedValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let either_str = input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)?

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -43,8 +43,8 @@ impl Validator for TimeValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let time = input
             .validate_time(state.strict_or(self.strict), self.microseconds_precision)?

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -68,8 +68,8 @@ impl Validator for TimeDeltaValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let timedelta = input
             .validate_timedelta(state.strict_or(self.strict), self.microseconds_precision)?

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -60,11 +60,11 @@ impl_py_gc_traverse!(TupleValidator { validators });
 
 impl TupleValidator {
     #[allow(clippy::too_many_arguments)]
-    fn validate_tuple_items<'data, I: BorrowInput<'data>>(
+    fn validate_tuple_items<'py, I: BorrowInput<'py>>(
         &self,
-        py: Python<'data>,
-        input: &impl Input<'data>,
-        state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
         output: &mut Vec<PyObject>,
         errors: &mut Vec<ValLineError>,
         item_validators: &[CombinedValidator],
@@ -97,11 +97,11 @@ impl TupleValidator {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn validate_tuple_variable<'data, I: BorrowInput<'data>, InputT: Input<'data>>(
+    fn validate_tuple_variable<'py, I: BorrowInput<'py>>(
         &self,
-        py: Python<'data>,
-        input: &InputT,
-        state: &mut ValidationState,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
         errors: &mut Vec<ValLineError>,
         collection_iter: &mut NextCountingIterator<impl Iterator<Item = I>>,
         actual_length: Option<usize>,
@@ -216,9 +216,9 @@ impl TupleValidator {
         Ok(output)
     }
 
-    fn push_output_item<'data>(
+    fn push_output_item<'py>(
         &self,
-        input: &impl Input<'data>,
+        input: &(impl Input<'py> + ?Sized),
         output: &mut Vec<PyObject>,
         item: PyObject,
         actual_length: Option<usize>,
@@ -245,8 +245,8 @@ impl Validator for TupleValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let collection = input.validate_tuple(state.strict_or(self.strict))?;
         let exactness = match &collection {

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -148,8 +148,8 @@ impl Validator for TypedDictValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -89,8 +89,8 @@ impl Validator for UuidValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let class = get_uuid_type(py)?;
         if let Some(py_input) = input.input_is_instance(class) {
@@ -150,7 +150,7 @@ impl Validator for UuidValidator {
 }
 
 impl UuidValidator {
-    fn get_uuid<'s, 'data>(&'s self, input: &impl Input<'data>) -> ValResult<Uuid> {
+    fn get_uuid<'py>(&self, input: &(impl Input<'py> + ?Sized)) -> ValResult<Uuid> {
         let uuid = match input.exact_str().ok() {
             Some(either_string) => {
                 let cow = either_string.as_cow()?;

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -137,8 +137,8 @@ impl Validator for WithDefaultValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
-        input: &impl Input<'py>,
-        state: &mut ValidationState,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         if input.to_object(py).is(&self.undefined) {
             Ok(self.default_value(py, None::<usize>, state)?.unwrap())
@@ -157,11 +157,11 @@ impl Validator for WithDefaultValidator {
         }
     }
 
-    fn default_value(
+    fn default_value<'py>(
         &self,
-        py: Python<'_>,
+        py: Python<'py>,
         outer_loc: Option<impl Into<LocItem>>,
-        state: &mut ValidationState,
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Option<PyObject>> {
         match self.default.default_value(py)? {
             Some(stored_dft) => {


### PR DESCRIPTION
## Change Summary

This is on the way to supporting https://github.com/pydantic/jiter/pull/63/files

Because that PR changes the input type for the JSON data to `Cow<'_, str>`, we run into trouble with the existing implementation of `Input for String` not being sufficient to cover the `Borrowed` (i.e. `str`) variant of the `Cow`.

After lots of wrestling with options I decided this is the right implementation, as it makes this as reusable as possible and helps to push further with the ideas in #1227 to unpick the two lifetimes. 

I want to get this reviewed & merged before the final `Cow` support PR because it changes a lot about how the lifetimes are written without any of the other logical changes related to the `Cow`, which will be more interesting to review on their own.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
