### PR TITLE
move list validation to produce an associated type

### DIFF
--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -11,6 +11,7 @@ use crate::validators::decimal::create_decimal;
 use super::datetime::{
     bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, EitherDate, EitherDateTime, EitherTime,
 };
+use super::input_abstract::{Never, ValMatch};
 use super::shared::{str_as_bool, str_as_float, str_as_int};
 use super::{
     BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericArguments, GenericIterable,
@@ -138,7 +139,9 @@ impl<'py> Input<'py> for StringMapping<'py> {
         }
     }
 
-    fn strict_list<'a>(&'a self) -> ValResult<GenericIterable<'a, 'py>> {
+    type List<'a> = Never where Self: 'a;
+
+    fn validate_list(&self, _strict: bool) -> ValMatch<Never> {
         Err(ValError::new(ErrorTypeDefaults::ListType, self))
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -15,12 +15,13 @@ pub(crate) use datetime::{
     duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, EitherDate, EitherDateTime,
     EitherTime, EitherTimedelta,
 };
-pub(crate) use input_abstract::{BorrowInput, Input, InputType};
+pub(crate) use input_abstract::{AsPyList, BorrowInput, ConsumeIterator, Input, InputType, Iterable};
 pub(crate) use input_string::StringMapping;
 pub(crate) use return_enums::{
-    py_string_str, AttributesGenericIterator, DictGenericIterator, EitherBytes, EitherFloat, EitherInt, EitherString,
-    GenericArguments, GenericIterable, GenericIterator, GenericMapping, Int, JsonArgs, JsonObjectGenericIterator,
-    MappingGenericIterator, PyArgs, StringMappingGenericIterator, ValidationMatch,
+    no_validator_iter_to_vec, py_string_str, validate_iter_to_vec, AttributesGenericIterator, DictGenericIterator,
+    EitherBytes, EitherFloat, EitherInt, EitherString, GenericArguments, GenericIterable, GenericIterator,
+    GenericMapping, Int, JsonArgs, JsonObjectGenericIterator, MappingGenericIterator, MaxLengthCheck, PyArgs,
+    StringMappingGenericIterator, ValidationMatch,
 };
 
 // Defined here as it's not exported by pyo3


### PR DESCRIPTION
## Change Summary

Heading towards https://github.com/pydantic/jiter/pull/63 still...

The goal here is to be able to split coupling between the `Input` trait definition and the actual types which can get produced by certain "validate" operations. This gives more flexibility in the lifetimes, because we can completely separate the Python and JSON types. I hope it might also give perf boosts by allowing code to optimize solely for the relevant types at hand.

The experiment is to do this just for `validate_list` first; if this works I'll do it for all uses of `GenericIterable` and `GenericArgs`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
