### PR TITLE
support json cow of jiter 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jiter"
-version = "0.0.7"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a1b6e316923afd3087ec73829f646a67c18f3a5bd61624247b05e652e4a99d"
+checksum = "a9cbc4bba9fee7e90f7ab23d53caa097007c6b870b2ca0a33334e774eb34c1ff"
 dependencies = [
  "ahash",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.21.7"
 num-bigint = "0.4.4"
 python3-dll-a = "0.2.7"
 uuid = "1.7.0"
-jiter = {version = "0.0.7", features = ["python"]}
+jiter = { version = "0.1.0", features = ["python"] }
 
 [lib]
 name = "_pydantic_core"

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -151,7 +151,7 @@ impl ValLineError {
 #[derive(Clone)]
 pub enum InputValue {
     Python(PyObject),
-    Json(JsonValue),
+    Json(JsonValue<'static>),
 }
 
 impl ToPyObject for InputValue {

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -1,5 +1,6 @@
 use pyo3::exceptions::PyTypeError;
 use pyo3::sync::GILOnceCell;
+use std::borrow::Cow;
 use std::fmt;
 
 use pyo3::prelude::*;
@@ -49,6 +50,12 @@ impl From<&String> for LocItem {
 impl From<&str> for LocItem {
     fn from(s: &str) -> Self {
         Self::S(s.to_string())
+    }
+}
+
+impl From<Cow<'_, str>> for LocItem {
+    fn from(s: Cow<'_, str>) -> Self {
+        Self::S(s.into_owned())
     }
 }
 

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -180,7 +180,7 @@ pub trait Input<'py>: fmt::Debug + ToPyObject {
 
     fn validate_frozenset(&self, strict: bool) -> ValMatch<Self::Set<'_>>;
 
-    fn validate_iter(&self) -> ValResult<GenericIterator>;
+    fn validate_iter(&self) -> ValResult<GenericIterator<'static>>;
 
     fn validate_date(&self, strict: bool) -> ValMatch<EitherDate<'py>>;
 

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -475,7 +475,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::FrozenSetType, self))
     }
 
-    fn validate_iter(&self) -> ValResult<GenericIterator> {
+    fn validate_iter(&self) -> ValResult<GenericIterator<'static>> {
         if self.iter().is_ok() {
             Ok(self.into())
         } else {

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -171,7 +171,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         Err(ValError::new(ErrorTypeDefaults::FrozenSetType, self))
     }
 
-    fn validate_iter(&self) -> ValResult<GenericIterator> {
+    fn validate_iter(&self) -> ValResult<GenericIterator<'static>> {
         Err(ValError::new(ErrorTypeDefaults::IterableType, self))
     }
 

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -260,12 +260,12 @@ impl LookupKey {
         }
     }
 
-    pub fn json_get<'data, 's>(
+    pub fn json_get<'a, 'data, 's>(
         &'s self,
-        dict: &'data JsonObject,
-    ) -> ValResult<Option<(&'s LookupPath, &'data JsonValue)>> {
+        dict: &'a JsonObject<'data>,
+    ) -> ValResult<Option<(&'s LookupPath, &'a JsonValue<'data>)>> {
         match self {
-            Self::Simple { key, path, .. } => match dict.get(key) {
+            Self::Simple { key, path, .. } => match dict.get(key.as_str()) {
                 Some(value) => Ok(Some((path, value))),
                 None => Ok(None),
             },
@@ -275,9 +275,9 @@ impl LookupKey {
                 key2,
                 path2,
                 ..
-            } => match dict.get(key1) {
+            } => match dict.get(key1.as_str()) {
                 Some(value) => Ok(Some((path1, value))),
-                None => match dict.get(key2) {
+                None => match dict.get(key2.as_str()) {
                     Some(value) => Ok(Some((path2, value))),
                     None => Ok(None),
                 },
@@ -475,7 +475,7 @@ impl PathItem {
         }
     }
 
-    pub fn json_get<'a>(&self, any_json: &'a JsonValue) -> Option<&'a JsonValue> {
+    pub fn json_get<'a, 'data>(&self, any_json: &'a JsonValue<'data>) -> Option<&'a JsonValue<'data>> {
         match any_json {
             JsonValue::Object(v_obj) => self.json_obj_get(v_obj),
             JsonValue::Array(v_array) => match self {
@@ -493,9 +493,9 @@ impl PathItem {
         }
     }
 
-    pub fn json_obj_get<'a>(&self, json_obj: &'a JsonObject) -> Option<&'a JsonValue> {
+    pub fn json_obj_get<'a, 'data>(&self, json_obj: &'a JsonObject<'data>) -> Option<&'a JsonValue<'data>> {
         match self {
-            Self::S(key, _) => json_obj.get(key),
+            Self::S(key, _) => json_obj.get(key.as_str()),
             _ => None,
         }
     }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -65,7 +65,7 @@ impl Validator for GeneratorValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
-        let iterator = input.validate_iter()?;
+        let iterator = input.validate_iter()?.into_static();
         let validator = self.item_validator.as_ref().map(|v| {
             InternalValidator::new(
                 py,
@@ -96,7 +96,7 @@ impl Validator for GeneratorValidator {
 #[pyclass(module = "pydantic_core._pydantic_core")]
 #[derive(Debug)]
 struct ValidatorIterator {
-    iterator: GenericIterator,
+    iterator: GenericIterator<'static>,
     validator: Option<InternalValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,


### PR DESCRIPTION
## Change Summary

Supporting https://github.com/pydantic/jiter/pull/63

This mostly works, apart from a lifetime issue in the `input_json` trait which I think is because the lifetime `'a` in `JsonValue<'a>` needs to be coupled to the `GenericIterable`, but there's no way currently to express this with the `Input` trait.

I think the solution is to unpick `GenericIterable` into associated types such as #1230, I should probably rebase this PR on that and confirm...

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
