### PR TITLE
associated types for arguments in Input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
     "!tests/.pytest_cache",
     "!*.so",
 ]
-rust-version = "1.70"
+rust-version = "1.76"
 
 [dependencies]
 pyo3 = { version = "0.21.0-beta.0", features = ["generate-import-lib", "num-bigint"] }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -15,13 +15,14 @@ pub(crate) use datetime::{
     duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, EitherDate, EitherDateTime,
     EitherTime, EitherTimedelta,
 };
-pub(crate) use input_abstract::{AsPyList, BorrowInput, ConsumeIterator, Input, InputType, Iterable};
+pub(crate) use input_abstract::{
+    Arguments, AsPyList, BorrowInput, ConsumeIterator, Input, InputType, Iterable, KeywordArgs, PositionalArgs,
+};
 pub(crate) use input_string::StringMapping;
 pub(crate) use return_enums::{
     no_validator_iter_to_vec, py_string_str, validate_iter_to_vec, AttributesGenericIterator, DictGenericIterator,
-    EitherBytes, EitherFloat, EitherInt, EitherString, GenericArguments, GenericIterable, GenericIterator,
-    GenericMapping, Int, JsonArgs, JsonObjectGenericIterator, MappingGenericIterator, MaxLengthCheck, PyArgs,
-    StringMappingGenericIterator, ValidationMatch,
+    EitherBytes, EitherFloat, EitherInt, EitherString, GenericIterable, GenericIterator, GenericMapping, Int,
+    JsonObjectGenericIterator, MappingGenericIterator, MaxLengthCheck, StringMappingGenericIterator, ValidationMatch,
 };
 
 // Defined here as it's not exported by pyo3

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -784,49 +784,6 @@ impl GenericJsonIterator {
 }
 
 #[cfg_attr(debug_assertions, derive(Debug))]
-pub struct PyArgs<'py> {
-    pub args: Option<Bound<'py, PyTuple>>,
-    pub kwargs: Option<Bound<'py, PyDict>>,
-}
-
-impl<'py> PyArgs<'py> {
-    pub fn new(args: Option<Bound<'py, PyTuple>>, kwargs: Option<Bound<'py, PyDict>>) -> Self {
-        Self { args, kwargs }
-    }
-}
-
-#[cfg_attr(debug_assertions, derive(Debug))]
-pub struct JsonArgs<'a> {
-    pub args: Option<&'a [JsonValue]>,
-    pub kwargs: Option<&'a JsonObject>,
-}
-
-impl<'a> JsonArgs<'a> {
-    pub fn new(args: Option<&'a [JsonValue]>, kwargs: Option<&'a JsonObject>) -> Self {
-        Self { args, kwargs }
-    }
-}
-
-#[cfg_attr(debug_assertions, derive(Debug))]
-pub enum GenericArguments<'a, 'py> {
-    Py(PyArgs<'py>),
-    Json(JsonArgs<'a>),
-    StringMapping(Bound<'py, PyDict>),
-}
-
-impl<'py> From<PyArgs<'py>> for GenericArguments<'_, 'py> {
-    fn from(s: PyArgs<'py>) -> Self {
-        Self::Py(s)
-    }
-}
-
-impl<'a> From<JsonArgs<'a>> for GenericArguments<'a, '_> {
-    fn from(s: JsonArgs<'a>) -> Self {
-        Self::Json(s)
-    }
-}
-
-#[cfg_attr(debug_assertions, derive(Debug))]
 pub enum EitherString<'a> {
     Cow(Cow<'a, str>),
     Py(Bound<'a, PyString>),


### PR DESCRIPTION
## Change Summary

Continuing with https://github.com/pydantic/pydantic-core/pull/1230

This time we move `GenericArguments` to have associated types.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
