### PR TITLE
Allow case where `__pydantic_extra__` is `None`, even if `extra='allow'`

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -133,8 +133,13 @@ impl GeneralFieldsSerializer {
     fn extract_dicts<'a>(&self, value: &Bound<'a, PyAny>) -> Option<(Bound<'a, PyDict>, Option<Bound<'a, PyDict>>)> {
         match self.mode {
             FieldsMode::ModelExtra => {
-                if let Ok((main_dict, extra_dict)) = value.extract() {
-                    Some((main_dict, Some(extra_dict)))
+                if let Ok((main_dict, extra_dict_option)) = value.extract() {
+                    match extra_dict_option {
+                        Some(extra_dict) => Some((main_dict, Some(extra_dict))),
+                        // if extra dict is None, that's fine, we just don't have any extra fields
+                        // but we still need to return a tuple
+                        None => Some((main_dict.clone(), None)),
+                    }
                 } else {
                     None
                 }


### PR DESCRIPTION
For the following setup:

```py
from pydantic import BaseModel, ConfigDict, Field, TypeAdapter


class Base(BaseModel):
    a: int = Field(default=1)
    
    model_config = ConfigDict(extra='allow')


class Sub(Base):
    b: str = Field(default="2")

    model_config = ConfigDict(extra='forbid')


sub = Sub()
ta = TypeAdapter(Base)
```

Before this fix:

```py
result = ta.dump_python(sub)
"""
/Users/programming/pydantic_work/pydantic/pydantic/type_adapter.py:356: UserWarning: Pydantic serializer warnings:
  Expected `general-fields` but got `tuple` - serialized value may not be as expected
  return self.serializer.to_python(
"""
print(result)
#> ({'a': 1, 'b': '2'}, None)
```

After this fix:

```py
result = ta.dump_python(sub)
print(result)
#> {'a': 1}
```