### PR TITLE
refactor `Input` trait to have single `as_python` cast for python inputs

### DIFF
--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -1,13 +1,12 @@
 use std::fmt;
 
 use pyo3::exceptions::PyValueError;
-use pyo3::types::{PyDict, PyList, PyType};
+use pyo3::types::{PyDict, PyList};
 use pyo3::{intern, prelude::*};
 
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
 use crate::tools::py_err;
-use crate::{PyMultiHostUrl, PyUrl};
 
 use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
 use super::return_enums::{EitherBytes, EitherInt, EitherString};
@@ -52,43 +51,15 @@ pub type ValMatch<T> = ValResult<ValidationMatch<T>>;
 pub trait Input<'py>: fmt::Debug + ToPyObject {
     fn as_error_value(&self) -> InputValue;
 
-    fn identity(&self) -> Option<usize> {
-        None
-    }
-
     fn is_none(&self) -> bool {
         false
     }
 
-    fn input_is_instance(&self, _class: &Bound<'py, PyType>) -> Option<&Bound<'py, PyAny>> {
+    fn as_python(&self) -> Option<&Bound<'py, PyAny>> {
         None
-    }
-
-    fn input_is_exact_instance(&self, _class: &Bound<'py, PyType>) -> bool {
-        false
-    }
-
-    fn is_python(&self) -> bool {
-        false
     }
 
     fn as_kwargs(&self, py: Python<'py>) -> Option<Bound<'py, PyDict>>;
-
-    fn input_is_subclass(&self, _class: &Bound<'_, PyType>) -> PyResult<bool> {
-        Ok(false)
-    }
-
-    fn input_as_url(&self) -> Option<PyUrl> {
-        None
-    }
-
-    fn input_as_multi_host_url(&self) -> Option<PyMultiHostUrl> {
-        None
-    }
-
-    fn callable(&self) -> bool {
-        false
-    }
 
     type Arguments<'a>: Arguments<'py>
     where

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use input_abstract::{
     Arguments, BorrowInput, ConsumeIterator, Input, InputType, KeywordArgs, PositionalArgs, ValidatedDict,
     ValidatedList, ValidatedSet, ValidatedTuple,
 };
+pub(crate) use input_python::{downcast_python_input, input_as_python_instance};
 pub(crate) use input_string::StringMapping;
 pub(crate) use return_enums::{
     no_validator_iter_to_vec, py_string_str, validate_iter_to_set, validate_iter_to_vec, EitherBytes, EitherFloat,

--- a/src/url.rs
+++ b/src/url.rs
@@ -16,8 +16,8 @@ use crate::SchemaValidator;
 
 static SCHEMA_DEFINITION_URL: GILOnceCell<SchemaValidator> = GILOnceCell::new();
 
-#[pyclass(name = "Url", module = "pydantic_core._pydantic_core", subclass)]
-#[derive(Clone)]
+#[pyclass(name = "Url", module = "pydantic_core._pydantic_core", subclass, frozen)]
+#[derive(Clone, Hash)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PyUrl {
     lib_url: Url,
@@ -28,8 +28,8 @@ impl PyUrl {
         Self { lib_url }
     }
 
-    pub fn into_url(self) -> Url {
-        self.lib_url
+    pub fn url(&self) -> &Url {
+        &self.lib_url
     }
 }
 
@@ -138,7 +138,7 @@ impl PyUrl {
 
     fn __hash__(&self) -> u64 {
         let mut s = DefaultHasher::new();
-        self.lib_url.to_string().hash(&mut s);
+        self.hash(&mut s);
         s.finish()
     }
 
@@ -192,8 +192,8 @@ impl PyUrl {
     }
 }
 
-#[pyclass(name = "MultiHostUrl", module = "pydantic_core._pydantic_core", subclass)]
-#[derive(Clone)]
+#[pyclass(name = "MultiHostUrl", module = "pydantic_core._pydantic_core", subclass, frozen)]
+#[derive(Clone, Hash)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PyMultiHostUrl {
     ref_url: PyUrl,
@@ -206,6 +206,10 @@ impl PyMultiHostUrl {
             ref_url: PyUrl::new(ref_url),
             extra_urls,
         }
+    }
+
+    pub fn lib_url(&self) -> &Url {
+        &self.ref_url.lib_url
     }
 
     pub fn mut_lib_url(&mut self) -> &mut Url {
@@ -338,8 +342,7 @@ impl PyMultiHostUrl {
 
     fn __hash__(&self) -> u64 {
         let mut s = DefaultHasher::new();
-        self.ref_url.clone().into_url().to_string().hash(&mut s);
-        self.extra_urls.hash(&mut s);
+        self.hash(&mut s);
         s.finish()
     }
 

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -32,7 +32,7 @@ impl Validator for CallableValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         state.floor_exactness(Exactness::Lax);
-        match input.callable() {
+        match input.as_python().is_some_and(PyAnyMethods::is_callable) {
             true => Ok(input.to_object(py)),
             false => Err(ValError::new(ErrorTypeDefaults::CallableType, input)),
         }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -8,8 +8,9 @@ use ahash::AHashSet;
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
-use crate::input::InputType;
-use crate::input::{Arguments, BorrowInput, Input, KeywordArgs, PositionalArgs, ValidationMatch};
+use crate::input::{
+    input_as_python_instance, Arguments, BorrowInput, Input, InputType, KeywordArgs, PositionalArgs, ValidationMatch,
+};
 use crate::lookup_key::LookupKey;
 use crate::tools::SchemaDict;
 use crate::validators::function::convert_err;
@@ -501,7 +502,7 @@ impl Validator for DataclassValidator {
 
         // same logic as on models
         let class = self.class.bind(py);
-        if let Some(py_input) = input.input_is_instance(class) {
+        if let Some(py_input) = input_as_python_instance(input, class) {
             if self.revalidate.should_revalidate(py_input, class) {
                 let input_dict = self.dataclass_to_dict(py_input)?;
                 let val_output = self.validator.validate(py, input_dict.as_any(), state)?;

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -77,7 +77,8 @@ impl Validator for DefinitionRefValidator {
     ) -> ValResult<PyObject> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();
-            if let Some(id) = input.identity() {
+            if let Some(id) = input.as_python().map(py_identity) {
+                // Python objects can be cyclic, so need recursion guard
                 let Ok(mut guard) = RecursionGuard::new(state, id, self.definition.id()) else {
                     return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, input));
                 };
@@ -98,18 +99,18 @@ impl Validator for DefinitionRefValidator {
     ) -> ValResult<PyObject> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();
-            if let Some(id) = obj.identity() {
-                let Ok(mut guard) = RecursionGuard::new(state, id, self.definition.id()) else {
-                    return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, obj));
-                };
-                validator.validate_assignment(py, obj, field_name, field_value, guard.state())
-            } else {
-                validator.validate_assignment(py, obj, field_name, field_value, state)
-            }
+            let Ok(mut guard) = RecursionGuard::new(state, py_identity(obj), self.definition.id()) else {
+                return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, obj));
+            };
+            validator.validate_assignment(py, obj, field_name, field_value, guard.state())
         })
     }
 
     fn get_name(&self) -> &str {
         self.definition.get_or_init_name(|v| v.get_name().into())
     }
+}
+
+fn py_identity(obj: &Bound<'_, PyAny>) -> usize {
+    obj.as_ptr() as usize
 }

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -103,11 +103,11 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let class = self.class.bind(py);
-        if input.input_is_exact_instance(class) {
+        if input.as_python().is_some_and(|any| any.is_exact_instance(class)) {
             return Ok(input.to_object(py));
         }
         let strict = state.strict_or(self.strict);
-        if strict && input.is_python() {
+        if strict && input.as_python().is_some() {
             // TODO what about instances of subclasses?
             return Err(ValError::new(
                 ErrorType::IsInstanceOf {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -123,7 +123,7 @@ impl<T: Debug> LiteralLookup<T> {
             }
         }
         if let Some(expected_strings) = &self.expected_str {
-            let validation_result = if input.is_python() {
+            let validation_result = if input.as_python().is_some() {
                 input.exact_str()
             } else {
                 // Strings coming from JSON are treated as "strict" but not "exact" for reasons

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
-use crate::input::{py_error_on_minusone, Input};
+use crate::input::{input_as_python_instance, py_error_on_minusone, Input};
 use crate::tools::{py_err, SchemaDict};
 use crate::PydanticUndefinedType;
 
@@ -124,7 +124,7 @@ impl Validator for ModelValidator {
         // if the input is an instance of the class, we "revalidate" it - e.g. we extract and reuse `__pydantic_fields_set__`
         // but use from attributes to create a new instance of the model field type
         let class = self.class.bind(py);
-        if let Some(py_input) = input.input_is_instance(class) {
+        if let Some(py_input) = input_as_python_instance(input, class) {
             if self.revalidate.should_revalidate(py_input, class) {
                 let fields_set = py_input.getattr(intern!(py, DUNDER_FIELDS_SET_KEY))?;
                 if self.root_model {

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -9,6 +9,7 @@ use uuid::Variant;
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
+use crate::input::input_as_python_instance;
 use crate::input::Input;
 use crate::input::InputType;
 use crate::tools::SchemaDict;
@@ -93,7 +94,7 @@ impl Validator for UuidValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let class = get_uuid_type(py)?;
-        if let Some(py_input) = input.input_is_instance(class) {
+        if let Some(py_input) = input_as_python_instance(input, class) {
             if let Some(expected_version) = self.version {
                 let py_input_version: Option<usize> = py_input.getattr(intern!(py, "version"))?.extract()?;
                 if !match py_input_version {

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -495,7 +495,7 @@ def test_url_to_url(url_validator, multi_host_url_validator):
     url2 = url_validator.validate_python(url)
     assert isinstance(url2, Url)
     assert str(url2) == 'https://example.com/'
-    assert url is not url2
+    assert url is url2
 
     multi_url = multi_host_url_validator.validate_python('https://example.com')
     assert isinstance(multi_url, MultiHostUrl)
@@ -982,7 +982,7 @@ def test_url_to_multi_url(url_validator, multi_host_url_validator):
     url3 = multi_host_url_validator.validate_python(url2)
     assert isinstance(url3, MultiHostUrl)
     assert str(url3) == 'https://example.com/'
-    assert url2 is not url3
+    assert url2 is url3
 
 
 def test_multi_wrong_type(multi_host_url_validator):


### PR DESCRIPTION
## Change Summary

Looking at performance of new pydantic-core in pydantic's north star benchmark, I noticed that an easy perf win is to avoid copying `Url` and `MultiHostUrl` objects when unnecessary.

At the same time, I refactored the `Input` trait just a little bit so that all the python-specific methods could be replaced by a single `.as_python()` call which validators with targeted optimizations could then use.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
