### PR TITLE
use Bound instead of PyObject where possible

### DIFF
--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -53,12 +53,12 @@ impl<'a> EitherDate<'a> {
         }
     }
 
-    pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn try_into_py(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         let date = match self {
             Self::Py(date) => Ok(date),
             Self::Raw(date) => PyDate::new_bound(py, date.year.into(), date.month, date.day),
         }?;
-        Ok(date.into_py(py))
+        Ok(date.unbind().into_bound(py).into_any())
     }
 }
 
@@ -208,7 +208,7 @@ impl<'a> EitherTime<'a> {
         }
     }
 
-    pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn try_into_py(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         let time = match self {
             Self::Py(time) => Ok(time),
             Self::Raw(time) => PyTime::new_bound(
@@ -220,7 +220,7 @@ impl<'a> EitherTime<'a> {
                 time_as_tzinfo(py, &time)?.as_ref(),
             ),
         }?;
-        Ok(time.into_py(py))
+        Ok(time.unbind().into_bound(py).into_any())
     }
 }
 
@@ -267,7 +267,7 @@ impl<'a> EitherDateTime<'a> {
         }
     }
 
-    pub fn try_into_py(self, py: Python<'a>) -> PyResult<PyObject> {
+    pub fn try_into_py(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         let dt = match self {
             Self::Raw(datetime) => PyDateTime::new_bound(
                 py,
@@ -280,9 +280,9 @@ impl<'a> EitherDateTime<'a> {
                 datetime.time.microsecond,
                 time_as_tzinfo(py, &datetime.time)?.as_ref(),
             )?,
-            Self::Py(dt) => dt.clone(),
+            Self::Py(dt) => dt,
         };
-        Ok(dt.into_py(py))
+        Ok(dt.unbind().into_bound(py).into_any())
     }
 }
 

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -72,6 +72,6 @@ impl TypeSerializer for WithDefaultSerializer {
     }
 
     fn get_default(&self, py: Python) -> PyResult<Option<PyObject>> {
-        self.default.default_value(py)
+        self.default.default_value(py).map(|v| v.map(Bound::unbind))
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::{PyDict, PyString, PyTuple};
 use pyo3::{ffi, intern, FromPyObject};
 
 pub trait SchemaDict<'py> {
@@ -142,4 +142,8 @@ pub fn extract_i64(v: &Bound<'_, PyAny>) -> Option<i64> {
     } else {
         None
     }
+}
+
+pub(crate) fn new_bound_tuple(py: Python<'_>, items: impl IntoPy<Py<PyTuple>>) -> Bound<'_, PyTuple> {
+    items.into_py(py).into_bound(py)
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -46,7 +46,7 @@ impl PyUrl {
         let schema_obj = SCHEMA_DEFINITION_URL
             .get_or_init(py, || build_schema_validator(py, "url"))
             .validate_python(py, url, None, None, None, None)?;
-        schema_obj.extract(py)
+        schema_obj.extract()
     }
 
     #[getter]
@@ -226,7 +226,7 @@ impl PyMultiHostUrl {
         let schema_obj = SCHEMA_DEFINITION_MULTI_HOST_URL
             .get_or_init(py, || build_schema_validator(py, "multi-host-url"))
             .validate_python(py, url, None, None, None, None)?;
-        schema_obj.extract(py)
+        schema_obj.extract()
     }
 
     #[getter]

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -32,10 +32,10 @@ impl Validator for AnyValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         // in a union, Any should be preferred to doing lax coercions
         state.floor_exactness(Exactness::Strict);
-        Ok(input.to_object(py))
+        Ok(input.to_object(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -35,12 +35,12 @@ impl Validator for BoolValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
         input
             .validate_bool(state.strict_or(self.strict))
-            .map(|val_match| val_match.unpack(state).into_py(py))
+            .map(|val_match| val_match.unpack(state).into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -45,10 +45,10 @@ impl Validator for BytesValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         input
             .validate_bytes(state.strict_or(self.strict))
-            .map(|m| m.unpack(state).into_py(py))
+            .map(|m| m.unpack(state).into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {
@@ -71,7 +71,7 @@ impl Validator for BytesConstrainedValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let either_bytes = input.validate_bytes(state.strict_or(self.strict))?.unpack(state);
         let len = either_bytes.len()?;
 
@@ -97,7 +97,7 @@ impl Validator for BytesConstrainedValidator {
                 ));
             }
         }
-        Ok(either_bytes.into_py(py))
+        Ok(either_bytes.into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -30,10 +30,10 @@ impl Validator for CallableValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         state.floor_exactness(Exactness::Lax);
         match input.as_python().is_some_and(PyAnyMethods::is_callable) {
-            true => Ok(input.to_object(py)),
+            true => Ok(input.to_object(py).into_bound(py)),
             false => Err(ValError::new(ErrorTypeDefaults::CallableType, input)),
         }
     }

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -75,12 +75,12 @@ impl Validator for ChainValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let mut steps_iter = self.steps.iter();
         let first_step = steps_iter.next().unwrap();
         let value = first_step.validate(py, input, state)?;
 
-        steps_iter.try_fold(value, |v, step| step.validate(py, v.bind(py), state))
+        steps_iter.try_fold(value, |v, step| step.validate(py, &v, state))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -93,7 +93,7 @@ impl Validator for CustomErrorValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         self.validator
             .validate(py, input, state)
             .map_err(|_| self.custom_error.as_val_error(input))

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -44,7 +44,7 @@ impl Validator for DateValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let strict = state.strict_or(self.strict);
         let date = match input.validate_date(strict) {
             Ok(val_match) => val_match.unpack(state),

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -65,7 +65,7 @@ impl Validator for DateTimeValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let strict = state.strict_or(self.strict);
         let datetime = match input.validate_datetime(strict, self.microseconds_precision) {
             Ok(val_match) => val_match.unpack(state),

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -122,7 +122,7 @@ impl Validator for DecimalValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let decimal = input.validate_decimal(state.strict_or(self.strict), py)?;
 
         if !self.allow_inf_nan || self.check_digits {
@@ -256,7 +256,7 @@ impl Validator for DecimalValidator {
             }
         }
 
-        Ok(decimal.into())
+        Ok(decimal)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -74,7 +74,7 @@ impl Validator for DefinitionRefValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();
             if let Some(id) = input.as_python().map(py_identity) {
@@ -96,7 +96,7 @@ impl Validator for DefinitionRefValidator {
         field_name: &str,
         field_value: &Bound<'py, PyAny>,
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         self.definition.read(|validator| {
             let validator = validator.unwrap();
             let Ok(mut guard) = RecursionGuard::new(state, py_identity(obj), self.definition.id()) else {

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -70,7 +70,7 @@ impl Validator for DictValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;
         dict.iterate(ValidateToDict {
@@ -105,8 +105,8 @@ where
     Key: BorrowInput<'py> + Clone + Into<LocItem>,
     Value: BorrowInput<'py>,
 {
-    type Output = ValResult<PyObject>;
-    fn consume_iterator(self, iterator: impl Iterator<Item = ValResult<(Key, Value)>>) -> ValResult<PyObject> {
+    type Output = ValResult<Bound<'py, PyAny>>;
+    fn consume_iterator(self, iterator: impl Iterator<Item = ValResult<(Key, Value)>>) -> ValResult<Bound<'py, PyAny>> {
         let output = PyDict::new_bound(self.py);
         let mut errors: Vec<ValLineError> = Vec::new();
 
@@ -143,7 +143,7 @@ where
         if errors.is_empty() {
             let input = self.input;
             length_check!(input, "Dictionary", self.min_length, self.max_length, output);
-            Ok(output.into())
+            Ok(output.into_any())
         } else {
             Err(ValError::LineErrors(errors))
         }

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -69,12 +69,12 @@ impl Validator for FloatValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         if !self.allow_inf_nan && !either_float.as_f64().is_finite() {
             return Err(ValError::new(ErrorTypeDefaults::FiniteNumber, input));
         }
-        Ok(either_float.into_py(py))
+        Ok(either_float.into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {
@@ -101,7 +101,7 @@ impl Validator for ConstrainedFloatValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let either_float = input.validate_float(state.strict_or(self.strict))?.unpack(state);
         let float: f64 = either_float.as_f64();
         if !self.allow_inf_nan && !float.is_finite() {
@@ -164,7 +164,7 @@ impl Validator for ConstrainedFloatValidator {
                 ));
             }
         }
-        Ok(either_float.into_py(py))
+        Ok(either_float.into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -32,7 +32,7 @@ impl Validator for FrozenSetValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let collection = input.validate_frozenset(state.strict_or(self.strict))?.unpack(state);
         let f_set = PyFrozenSet::empty_bound(py)?;
         collection.iterate(ValidateToFrozenSet {
@@ -44,7 +44,7 @@ impl Validator for FrozenSetValidator {
             state,
         })??;
         min_length_check!(input, "Frozenset", self.min_length, f_set);
-        Ok(f_set.into_py(py))
+        Ok(f_set.into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -48,10 +48,10 @@ impl Validator for IntValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         input
             .validate_int(state.strict_or(self.strict))
-            .map(|val_match| val_match.unpack(state).into_py(py))
+            .map(|val_match| val_match.unpack(state).into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {
@@ -77,7 +77,7 @@ impl Validator for ConstrainedIntValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let either_int = input.validate_int(state.strict_or(self.strict))?.unpack(state);
         let int_value = either_int.as_int()?;
 
@@ -136,7 +136,7 @@ impl Validator for ConstrainedIntValidator {
                 ));
             }
         }
-        Ok(either_int.into_py(py))
+        Ok(either_int.into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -54,7 +54,7 @@ impl Validator for IsInstanceValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         _state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let Some(obj) = input.as_python() else {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(
                 "Cannot check isinstance when validating from json, \
@@ -62,7 +62,7 @@ impl Validator for IsInstanceValidator {
             )));
         };
         match obj.is_instance(self.class.bind(py))? {
-            true => Ok(obj.clone().unbind()),
+            true => Ok(obj.clone()),
             false => Err(ValError::new(
                 ErrorType::IsInstanceOf {
                     class: self.class_repr.clone(),

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -49,7 +49,7 @@ impl Validator for IsSubclassValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         _state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let Some(obj) = input.as_python() else {
             return Err(ValError::InternalErr(PyNotImplementedError::new_err(
                 "Cannot check issubclass when validating from json, \
@@ -57,7 +57,7 @@ impl Validator for IsSubclassValidator {
             )));
         };
         match obj.downcast::<PyType>() {
-            Ok(py_type) if py_type.is_subclass(self.class.bind(py))? => Ok(obj.clone().unbind()),
+            Ok(py_type) if py_type.is_subclass(self.class.bind(py))? => Ok(obj.clone()),
             _ => Err(ValError::new(
                 ErrorType::IsSubclassOf {
                     class: self.class_repr.clone(),

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -51,7 +51,7 @@ impl Validator for JsonValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let v_match = validate_json_bytes(input)?;
         let json_either_bytes = v_match.unpack(state);
         let json_bytes = json_either_bytes.as_slice();
@@ -66,7 +66,7 @@ impl Validator for JsonValidator {
             None => {
                 let obj =
                     jiter::python_parse(py, json_bytes, true, true).map_err(|e| map_json_err(input, e, json_bytes))?;
-                Ok(obj.unbind())
+                Ok(obj)
             }
         }
     }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -54,7 +54,7 @@ impl Validator for JsonOrPython {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match state.extra().input_type {
             InputType::Python => self.python.validate(py, input, state),
             _ => self.json.validate(py, input, state),

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -61,7 +61,7 @@ impl Validator for LaxOrStrictValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         if state.strict_or(self.strict) {
             self.strict_validator.validate(py, input, state)
         } else {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -266,9 +266,9 @@ impl Validator for LiteralValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         _state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match self.lookup.validate(py, input)? {
-            Some((_, v)) => Ok(v.clone()),
+            Some((_, v)) => Ok(v.bind(py).clone()),
             None => Err(ValError::new(
                 ErrorType::LiteralError {
                     expected: self.expected_repr.clone(),

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -29,9 +29,9 @@ impl Validator for NoneValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         _state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match input.is_none() {
-            true => Ok(py.None()),
+            true => Ok(py.None().into_bound(py)),
             false => Err(ValError::new(ErrorTypeDefaults::NoneRequired, input)),
         }
     }

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -38,9 +38,9 @@ impl Validator for NullableValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match input.is_none() {
-            true => Ok(py.None()),
+            true => Ok(py.None().into_bound(py)),
             false => self.validator.validate(py, input, state),
         }
     }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -62,7 +62,7 @@ impl Validator for SetValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let collection = input.validate_set(state.strict_or(self.strict))?.unpack(state);
         let set = PySet::empty_bound(py)?;
         collection.iterate(ValidateToSet {
@@ -74,7 +74,7 @@ impl Validator for SetValidator {
             state,
         })??;
         min_length_check!(input, "Set", self.min_length, set);
-        Ok(set.into_py(py))
+        Ok(set.into_any())
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -46,10 +46,10 @@ impl Validator for StrValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)
-            .map(|val_match| val_match.unpack(state).into_py(py))
+            .map(|val_match| val_match.unpack(state).into_py(py).into_bound(py))
     }
 
     fn get_name(&self) -> &str {
@@ -78,7 +78,7 @@ impl Validator for StrConstrainedValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let either_str = input
             .validate_str(state.strict_or(self.strict), self.coerce_numbers_to_str)?
             .unpack(state);
@@ -138,7 +138,7 @@ impl Validator for StrConstrainedValidator {
             // we haven't modified the string, return the original as it might be a PyString
             either_str.as_py_string(py)
         };
-        Ok(py_string.into_py(py))
+        Ok(py_string.into_any())
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -45,7 +45,7 @@ impl Validator for TimeValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let time = input
             .validate_time(state.strict_or(self.strict), self.microseconds_precision)?
             .unpack(state);

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -70,7 +70,7 @@ impl Validator for TimeDeltaValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let timedelta = input
             .validate_timedelta(state.strict_or(self.strict), self.microseconds_precision)?
             .unpack(state);
@@ -100,7 +100,7 @@ impl Validator for TimeDeltaValidator {
             check_constraint!(ge, GreaterThanEqual);
             check_constraint!(gt, GreaterThan);
         }
-        Ok(py_timedelta.into())
+        Ok(py_timedelta.into_any())
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -147,7 +147,7 @@ impl Validator for TypedDictValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;
 
@@ -319,7 +319,7 @@ impl Validator for TypedDictValidator {
         if !errors.is_empty() {
             Err(ValError::LineErrors(errors))
         } else {
-            Ok(output_dict.to_object(py))
+            Ok(output_dict.into_any())
         }
     }
 

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -106,7 +106,7 @@ impl UnionValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let old_exactness = state.exactness;
         let strict = state.strict_or(self.strict);
         let mut errors = MaybeErrors::new(self.custom_error.as_ref());
@@ -172,7 +172,7 @@ impl UnionValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let mut errors = MaybeErrors::new(self.custom_error.as_ref());
 
         let mut rebound_state;
@@ -207,7 +207,7 @@ impl Validator for UnionValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match self.mode {
             UnionMode::Smart => self.validate_smart(py, input, state),
             UnionMode::LeftToRight => self.validate_left_to_right(py, input, state),
@@ -395,7 +395,7 @@ impl Validator for TaggedUnionValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         match &self.discriminator {
             Discriminator::LookupKey(lookup_key) => {
                 let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
@@ -462,7 +462,7 @@ impl TaggedUnionValidator {
         tag: &Bound<'py, PyAny>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         if let Ok(Some((tag, validator))) = self.lookup.validate(py, tag) {
             return match validator.validate(py, input, state) {
                 Ok(res) => Ok(res),

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -67,7 +67,7 @@ impl Validator for UrlValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let mut either_url = self.get_url(input, state.strict_or(self.strict))?;
 
         if let Some((ref allowed_schemes, ref expected_schemes_repr)) = self.allowed_schemes {
@@ -93,7 +93,7 @@ impl Validator for UrlValidator {
             Ok(()) => {
                 // Lax rather than strict to preserve V2.4 semantic that str wins over url in union
                 state.floor_exactness(Exactness::Lax);
-                Ok(either_url.into_py(py))
+                Ok(either_url.into_py(py).into_bound(py))
             }
             Err(error_type) => Err(ValError::new(error_type, input)),
         }
@@ -233,7 +233,7 @@ impl Validator for MultiHostUrlValidator {
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
-    ) -> ValResult<PyObject> {
+    ) -> ValResult<Bound<'py, PyAny>> {
         let mut multi_url = self.get_url(input, state.strict_or(self.strict))?;
 
         if let Some((ref allowed_schemes, ref expected_schemes_repr)) = self.allowed_schemes {
@@ -258,7 +258,7 @@ impl Validator for MultiHostUrlValidator {
             Ok(()) => {
                 // Lax rather than strict to preserve V2.4 semantic that str wins over url in union
                 state.floor_exactness(Exactness::Lax);
-                Ok(multi_url.into_py(py))
+                Ok(multi_url.into_py(py).into_bound(py))
             }
             Err(error_type) => Err(ValError::new(error_type, input)),
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -118,7 +118,7 @@ json_input = '{"a": "something"}'
                 .unwrap()
                 .validate_json(py, &json_input, None, None, None)
                 .unwrap();
-            let validation_result: Bound<'_, PyAny> = binding.extract(py).unwrap();
+            let validation_result: Bound<'_, PyAny> = binding.extract().unwrap();
             let repr = format!("{}", validation_result.repr().unwrap());
             assert_eq!(repr, "{'a': 'something'}");
         });


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Micro-optimization which should make Clone / Drop implementations more efficient in function stacks. Hopefully reduces binary size a bit / allows better unwinding on early returns.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
