### PR TITLE
allow serialization functions to upgrade warnings to exceptions

### DIFF
--- a/.mypy-stubtest-allowlist
+++ b/.mypy-stubtest-allowlist
@@ -2,3 +2,6 @@
 pydantic_core._pydantic_core.PydanticUndefinedType.new
 # As per #1240, from_json has custom logic to coverage the `cache_strings` kwarg
 pydantic_core._pydantic_core.from_json
+# the `warnings` kwarg for SchemaSerializer functions has custom logic
+pydantic_core._pydantic_core.SchemaSerializer.to_python
+pydantic_core._pydantic_core.SchemaSerializer.to_json

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -264,7 +264,7 @@ class SchemaSerializer:
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         round_trip: bool = False,
-        warnings: bool = True,
+        warnings: bool | Literal['none', 'warn', 'error'] = True,
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
         context: dict[str, Any] | None = None,
@@ -284,7 +284,8 @@ class SchemaSerializer:
             exclude_defaults: Whether to exclude fields that are equal to their default value.
             exclude_none: Whether to exclude fields that have a value of `None`.
             round_trip: Whether to enable serialization and validation round-trip support.
-            warnings: Whether to log warnings when invalid fields are encountered.
+            warnings: How to handle invalid fields. False/"none" ignores them, True/"warn" logs errors,
+                "error" raises a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError].
             fallback: A function to call when an unknown value is encountered,
                 if `None` a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError] error is raised.
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
@@ -309,7 +310,7 @@ class SchemaSerializer:
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         round_trip: bool = False,
-        warnings: bool = True,
+        warnings: bool | Literal['none', 'warn', 'error'] = True,
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
         context: dict[str, Any] | None = None,
@@ -328,7 +329,8 @@ class SchemaSerializer:
             exclude_defaults: Whether to exclude fields that are equal to their default value.
             exclude_none: Whether to exclude fields that have a value of `None`.
             round_trip: Whether to enable serialization and validation round-trip support.
-            warnings: Whether to log warnings when invalid fields are encountered.
+            warnings: How to handle invalid fields. False/"none" ignores them, True/"warn" logs errors,
+                "error" raises a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError].
             fallback: A function to call when an unknown value is encountered,
                 if `None` a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError] error is raised.
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use errors::{
 };
 pub use serializers::{
     to_json, to_jsonable_python, PydanticSerializationError, PydanticSerializationUnexpectedValue, SchemaSerializer,
+    WarningsArg,
 };
 pub use validators::{validate_core_schema, PySome, SchemaValidator};
 

--- a/tests/serializers/test_list_tuple.py
+++ b/tests/serializers/test_list_tuple.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 
-from pydantic_core import SchemaError, SchemaSerializer, core_schema, validate_core_schema
+from pydantic_core import PydanticSerializationError, SchemaError, SchemaSerializer, core_schema, validate_core_schema
 
 
 def test_list_any():
@@ -52,6 +52,16 @@ def test_list_str_fallback():
         '  Expected `str` but got `int` - serialized value may not be as expected\n'
         '  Expected `str` but got `int` - serialized value may not be as expected'
     ]
+    with pytest.raises(PydanticSerializationError) as warning_ex:
+        v.to_json([1, 2, 3], warnings='error')
+    assert str(warning_ex.value) == ''.join(
+        [
+            'Pydantic serializer warnings:\n'
+            '  Expected `str` but got `int` - serialized value may not be as expected\n'
+            '  Expected `str` but got `int` - serialized value may not be as expected\n'
+            '  Expected `str` but got `int` - serialized value may not be as expected'
+        ]
+    )
 
 
 def test_tuple_any():

--- a/tests/serializers/test_string.py
+++ b/tests/serializers/test_string.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 import pytest
 
-from pydantic_core import SchemaSerializer, core_schema
+from pydantic_core import PydanticSerializationError, SchemaSerializer, core_schema
 
 
 def test_str():
@@ -34,13 +34,44 @@ def test_str_fallback():
         assert s.to_python(123, mode='json') == 123
     with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
         assert s.to_json(123) == b'123'
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_python(123, warnings='warn') == 123
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_python(123, mode='json', warnings='warn') == 123
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_json(123, warnings='warn') == b'123'
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_python(123, warnings=True) == 123
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_python(123, mode='json', warnings=True) == 123
+    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+        assert s.to_json(123, warnings=True) == b'123'
 
 
 def test_str_no_warnings():
     s = SchemaSerializer(core_schema.str_schema())
     assert s.to_python(123, warnings=False) == 123
+    assert s.to_python(123, warnings='none') == 123
     assert s.to_python(123, mode='json', warnings=False) == 123
+    assert s.to_python(123, mode='json', warnings='none') == 123
     assert s.to_json(123, warnings=False) == b'123'
+    assert s.to_json(123, warnings='none') == b'123'
+
+
+def test_str_errors():
+    s = SchemaSerializer(core_schema.str_schema())
+    with pytest.raises(
+        PydanticSerializationError, match='Expected `str` but got `int` - serialized value may not be as expected'
+    ):
+        assert s.to_python(123, warnings='error') == 123
+    with pytest.raises(
+        PydanticSerializationError, match='Expected `str` but got `int` - serialized value may not be as expected'
+    ):
+        assert s.to_python(123, mode='json', warnings='error') == 123
+    with pytest.raises(
+        PydanticSerializationError, match='Expected `str` but got `int` - serialized value may not be as expected'
+    ):
+        assert s.to_json(123, warnings='error') == b'123'
 
 
 class StrSubclass(str):

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use _pydantic_core::{SchemaSerializer, SchemaValidator};
+    use _pydantic_core::{SchemaSerializer, SchemaValidator, WarningsArg};
     use pyo3::prelude::*;
     use pyo3::types::PyDict;
 
@@ -85,7 +85,20 @@ a = A()
             let serialized = SchemaSerializer::py_new(schema, None)
                 .unwrap()
                 .to_json(
-                    py, &a, None, None, None, true, false, false, false, false, true, None, false, None,
+                    py,
+                    &a,
+                    None,
+                    None,
+                    None,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    WarningsArg::Bool(true),
+                    None,
+                    false,
+                    None,
                 )
                 .unwrap();
             let serialized: &[u8] = serialized.extract(py).unwrap();
@@ -186,7 +199,7 @@ dump_json_input_2 = {'a': 'something'}
                     false,
                     false,
                     false,
-                    false,
+                    WarningsArg::Bool(false),
                     None,
                     false,
                     None,
@@ -207,7 +220,7 @@ dump_json_input_2 = {'a': 'something'}
                     false,
                     false,
                     false,
-                    false,
+                    WarningsArg::Bool(false),
                     None,
                     false,
                     None,


### PR DESCRIPTION
## Change Summary

This allows for `SchemaSerializer.to_python` and `SchemaSerializer.to_json` to throw a PydanticSerializerError if the user specifies `'error'` for the "warnings" parameter and the serialized result does not match the Pydantic core schema.

This change should not break backwards compatibility.

## Related issue number

https://github.com/pydantic/pydantic/issues/8978

## Checklist

* [X] Unit tests for the changes exist
* [X] Documentation reflects the changes where applicable
* [X] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin