### PR TITLE
Add coerce_numbers_to_str option in StringSchema

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -752,6 +752,7 @@ class StringSchema(TypedDict, total=False):
     to_upper: bool
     regex_engine: Literal['rust-regex', 'python-re']  # default: 'rust-regex'
     strict: bool
+    coerce_numbers_to_str: bool
     ref: str
     metadata: Any
     serialization: SerSchema

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -208,6 +208,7 @@ impl StrConstrainedValidator {
             || self.strip_whitespace
             || self.to_lower
             || self.to_upper
+            || self.coerce_numbers_to_str
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Adding `coerce_numbers_to_str` option in `StringSchema` typed dict definition, fixing the failing tests in pydantic side

<!-- Please give a short summary of the changes. -->

## Related issue number

pydantic/pydantic#9137

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
