### PR TITLE
fix memory leak with iterable validation

### DIFF
--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 use std::sync::Arc;
 
-use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::{prelude::*, PyTraverseError, PyVisit};
 
 use crate::errors::{ErrorType, LocItem, ValError, ValResult};
 use crate::input::{BorrowInput, GenericIterator, Input};
+use crate::py_gc::PyGcTraverse;
 use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
 use crate::ValidationError;
@@ -200,6 +201,12 @@ impl ValidatorIterator {
 
     fn __str__(&self) -> String {
         self.__repr__()
+    }
+
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        self.iterator.py_gc_traverse(&visit)?;
+        self.validator.py_gc_traverse(&visit)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Change Summary

Fixes a memory leak when validating an iterable. I'll try to work out a test before this merges.

The general problem was that the `Iterable` field gets populated with a `ValidatorIterable`, which is a _huge_ stateful object which itself contained model's `__dict__`, which eventually includes the `ValidatorIterable` itself. This created a cycle which was opaque to the garbage collector.

Implementing the `__traverse__` for the `ValidatorIterable` object fixes the problem, but to be honest, it feels like a big design wart that we have such a big stateful iterable here. Arguably, it's a massive footgun.

For example, the following doesn't work, because the `elements` stored is the list iterator _wrapped up_ in the `ValidatorIterable`.

```python
from collections.abc import Iterable
from pydantic import BaseModel
import pydantic

class A(BaseModel):
    elements: Iterable[int] | None

# nope, elements is a ValidatorIterator
assert A(elements=[1, 2, 3]).elements == [1, 2, 3]
```

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9243

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
