### PR TITLE
fix interaction between `extra != 'ignore'` and `from_attributes=True`

### DIFF
--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -622,7 +622,7 @@ fn from_attributes_applicable(obj: &Bound<'_, PyAny>) -> bool {
     // I don't think it's a very good list at all! But it doesn't have to be at perfect, it just needs to avoid
     // the most egregious foot guns, it's mostly just to catch "builtins"
     // still happy to add more or do something completely different if anyone has a better idea???
-    // dbg!(obj, module_name);
+    // dbg!(obj, &module_name);
     !matches!(module_name.to_str(), Ok("builtins" | "datetime" | "collections"))
 }
 
@@ -806,6 +806,10 @@ impl<'py> ValidatedDict<'py> for GenericPyMapping<'_, 'py> {
             Self::Mapping(mapping) => key.py_get_mapping_item(mapping),
             Self::GetAttr(obj, dict) => key.py_get_attr(obj, dict.as_ref()),
         }
+    }
+
+    fn is_py_get_attr(&self) -> bool {
+        matches!(self, Self::GetAttr(..))
     }
 
     fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>> {

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -156,10 +156,12 @@ impl Validator for TypedDictValidator {
 
         // we only care about which keys have been used if we're iterating over the object for extra after
         // the first pass
-        let mut used_keys: Option<AHashSet<&str>> = match self.extra_behavior {
-            ExtraBehavior::Allow | ExtraBehavior::Forbid => Some(AHashSet::with_capacity(self.fields.len())),
-            ExtraBehavior::Ignore => None,
-        };
+        let mut used_keys: Option<AHashSet<&str>> =
+            if self.extra_behavior == ExtraBehavior::Ignore || dict.is_py_get_attr() {
+                None
+            } else {
+                Some(AHashSet::with_capacity(self.fields.len()))
+            };
 
         {
             let state = &mut state.rebind_extra(|extra| extra.data = Some(output_dict.clone()));


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

This is a bugfix to set the interaction between `extra` and `from_attributes` to match the pre-2.7 behaviour.

To be honest, I don't love it, basically if `from_attributes` is set then `extra` basically always functions as "ignore". I can sort of see why, and we didn't intend to change it in 2.7, but I wonder if there's more satisfying long-term behaviour. 

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9242
Fixes https://github.com/pydantic/pydantic/issues/9250

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin