### PR TITLE
Fixes discriminated union bug regression when using enums

### DIFF
--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -89,7 +89,7 @@ impl LiteralSerializer {
                 if let Ok(py_str) = value.downcast::<PyString>() {
                     let s = py_str.to_str()?;
                     if self.expected_str.contains(s) {
-                        return Ok(OutputValue::OkStr(py_str.clone()));
+                        return Ok(OutputValue::OkStr(PyString::new_bound(value.py(), s)));
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes regression documented in pydantic/pydantic#9235, which was introduced in upgrade to pyo3 v0.21

<!-- Please give a short summary of the changes. -->

## Related issue number

pydantic/pydantic#9235
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu