### PR TITLE
defer to PyO3 i64 extraction to avoid implicit integer casts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,9 @@ testpaths = 'tests'
 log_format = '%(name)s %(levelname)s: %(message)s'
 filterwarnings = [
     'error',
-    # Work around https://github.com/pytest-dev/pytest/issues/10977 for Python 3.12
-    'ignore:(ast\.Str|ast\.NameConstant|ast\.Num|Attribute s) is deprecated and will be removed.*:DeprecationWarning:',
-    # issue with pytz - https://github.com/stub42/pytz/issues/105 for Python 3.12
-    'ignore:datetime\.utcfromtimestamp\(\) is deprecated.*:DeprecationWarning:',
+    # Python 3.9 and below allowed truncation of float to integers in some
+    # cases, by not making this an error we can test for this behaviour
+    'ignore:(.+)Implicit conversion to integers using __int__ is deprecated',
 ]
 timeout = 30
 xfail_strict = true


### PR DESCRIPTION
## Change Summary

As per https://github.com/PyO3/pyo3/pull/3742, the PyO3 logic for i64 extraction has workarounds for older Python versions which allowed float -> int casts in some contexts.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9018

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
