### PR TITLE
uuid: allow str subclass as input

### DIFF
--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -12,6 +12,7 @@ use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::input_as_python_instance;
 use crate::input::Input;
 use crate::input::InputType;
+use crate::input::ValidationMatch;
 use crate::tools::SchemaDict;
 
 use super::model::create_class;
@@ -152,7 +153,7 @@ impl Validator for UuidValidator {
 
 impl UuidValidator {
     fn get_uuid<'py>(&self, input: &(impl Input<'py> + ?Sized)) -> ValResult<Uuid> {
-        let uuid = match input.exact_str().ok() {
+        let uuid = match input.validate_str(true, false).ok().map(ValidationMatch::into_inner) {
             Some(either_string) => {
                 let cow = either_string.as_cow()?;
                 let uuid_str = cow.as_ref();

--- a/tests/validators/test_uuid.py
+++ b/tests/validators/test_uuid.py
@@ -9,6 +9,9 @@ from pydantic_core import SchemaValidator, ValidationError, core_schema
 from ..conftest import Err, PyAndJson
 
 
+class MyStr(str): ...
+
+
 @pytest.mark.parametrize(
     'input_value,expected',
     [
@@ -25,6 +28,7 @@ from ..conftest import Err, PyAndJson
         ('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11', UUID('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11')),
         ('00000000-8000-4000-8000-000000000000', UUID('00000000-8000-4000-8000-000000000000')),
         ('00000000-0000-4000-0000-000000000000', UUID('00000000-0000-4000-0000-000000000000')),
+        (MyStr('00000000-0000-4000-0000-000000000000'), UUID('00000000-0000-4000-0000-000000000000')),
         (b'\x12\x34\x56\x78' * 4, UUID('12345678-1234-5678-1234-567812345678')),
         (b'\x00\x00\x00\x00' * 4, UUID('00000000-0000-0000-0000-000000000000')),
         (b'ebcdab58-6eb8-46fb-a190-d07a33e9eac8', UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8')),


### PR DESCRIPTION
## Change Summary

I see no reason not to allow this.

## Related issue number

Closes #1294

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
