### PR TITLE
support big ints in literals and enums

### DIFF
--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -549,6 +549,7 @@ impl<'a> EitherInt<'a> {
             Ok(Self::BigInt(big_int))
         }
     }
+
     pub fn into_i64(self, py: Python<'a>) -> ValResult<i64> {
         match self {
             EitherInt::I64(i) => Ok(i),

--- a/tests/validators/test_enums.py
+++ b/tests/validators/test_enums.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from enum import Enum, IntFlag
+from enum import Enum, IntEnum, IntFlag
 
 import pytest
 
@@ -331,3 +331,16 @@ def test_missing_error_converted_to_val_error() -> None:
 
     with pytest.raises(ValidationError):
         v.validate_python(None)
+
+
+def test_big_int():
+    class ColorEnum(IntEnum):
+        GREEN = 1 << 63
+        BLUE = 1 << 64
+
+    v = SchemaValidator(
+        core_schema.with_default_schema(schema=core_schema.enum_schema(ColorEnum, list(ColorEnum.__members__.values())))
+    )
+
+    assert v.validate_python(ColorEnum.GREEN) is ColorEnum.GREEN
+    assert v.validate_python(1 << 63) is ColorEnum.GREEN

--- a/tests/validators/test_literal.py
+++ b/tests/validators/test_literal.py
@@ -378,3 +378,14 @@ def test_mix_str_enum_with_str(reverse: Callable[[List[Any]], List[Any]], err: A
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python('bar_val')
     assert exc_info.value.errors(include_url=False) == err
+
+
+def test_big_int():
+    big_int = 2**64 + 1
+    massive_int = 2**128 + 1
+    v = SchemaValidator(core_schema.literal_schema([big_int, massive_int]))
+    assert v.validate_python(big_int) == big_int
+    assert v.validate_python(massive_int) == massive_int
+    m = r'Input should be 18446744073709551617 or 340282366920938463463374607431768211457 \[type=literal_error'
+    with pytest.raises(ValidationError, match=m):
+        v.validate_python(37)


### PR DESCRIPTION
## Change Summary

Support ints greater than 2 ^ 64 in literal and enum validators

## Related issue number

fixes https://github.com/pydantic/pydantic/issues/9314

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
