### PR TITLE
fix case of checking truthiness of `NotImplemented`

### DIFF
--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -23,8 +23,7 @@ fn map_negative_index<'py>(value: &Bound<'py, PyAny>, len: Option<usize>) -> PyR
             .unwrap_or_else(|_| value.clone())),
         None => {
             // check that it's not negative
-            let negative = value.call_method1(intern!(py, "__lt__"), (0,))?.is_truthy()?;
-            if negative {
+            if value.lt(0).unwrap_or(false) {
                 Err(PyValueError::new_err(
                     "Negative indices cannot be used to exclude items on unsized iterables",
                 ))


### PR DESCRIPTION
## Change Summary

At the moment when checking for non-negative integers, we can get false-postives from types that aren't integer.

e.g. the original logic was equivalent to 

```python
>>> bool("__all__".__lt__(0))
<stdin>:1: DeprecationWarning: NotImplemented should not be used in a boolean context
True
```

... because comparisons between strings and integers are not implemented, and the dunder method does not raise type errors on `NotImplemented`.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9328

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
