### PR TITLE
Fix generate_self_schema for Python 3.12+

### DIFF
--- a/generate_self_schema.py
+++ b/generate_self_schema.py
@@ -190,7 +190,12 @@ def all_literal_values(type_: type[core_schema.Literal]) -> list[any]:
 
 def eval_forward_ref(type_: Any) -> Any:
     try:
-        return type_._evaluate(core_schema.__dict__, None, set())
+        try:
+            # Python 3.12+
+            return type_._evaluate(core_schema.__dict__, None, type_params=set(), recursive_guard=set())
+        except TypeError:
+            # Python 3.9+
+            return type_._evaluate(core_schema.__dict__, None, set())
     except TypeError:
         # for Python 3.8
         return type_._evaluate(core_schema.__dict__, None)


### PR DESCRIPTION
For reference: https://github.com/python/cpython/blob/8c96850161da23ad2b37551d2a89c7d4716fe024/Lib/typing.py#L916

Ran into this trying to install pydantic on 3.14.

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
