### PR TITLE
tests: use zoneinfo instead of pytz

### DIFF
--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -86,7 +86,7 @@ async function main() {
     FS.mkdir('/test_dir');
     FS.mount(FS.filesystems.NODEFS, {root: path.join(root_dir, 'tests')}, '/test_dir');
     FS.chdir('/test_dir');
-    await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
+    await pyodide.loadPackage(['micropip', 'pytest']);
     // language=python
     errcode = await pyodide.runPythonAsync(`
 import micropip
@@ -101,6 +101,7 @@ await micropip.install([
     'hypothesis',
     'pytest-speed',
     'pytest-mock',
+    'tzdata',
     'file:${wheel_path}',
     'typing-extensions',
 ])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+backports.zoneinfo==0.2.1;python_version<"3.9"
 coverage==7.5.0
 dirty-equals==0.7.1.post0
 hypothesis==6.100.2
@@ -16,7 +17,7 @@ pytest-speed==0.3.5
 pytest-mock==3.14.0
 pytest-pretty==1.2.0
 pytest-timeout==2.3.1
-pytz==2024.1
 # numpy doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
 numpy==1.26.2; python_version >= "3.9" and python_version < "3.13" and implementation_name == "cpython" and platform_machine == 'x86_64'
 exceptiongroup==1.1; python_version < "3.11"
+tzdata==2024.1

--- a/wasm-preview/run_tests.py
+++ b/wasm-preview/run_tests.py
@@ -37,7 +37,7 @@ async def main(tests_zip: str, tag_name: str):
 
     print(f'Mounted {count} test files, installing dependencies...')
 
-    await micropip.install(['dirty-equals', 'hypothesis', 'pytest-speed', 'pytest-mock', pydantic_core_wheel])
+    await micropip.install(['dirty-equals', 'hypothesis', 'pytest-speed', 'pytest-mock', pydantic_core_wheel, 'tzdata'])
     importlib.invalidate_caches()
 
     # print('installed packages:')

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -97,7 +97,7 @@ async function main() {
     setupStreams(FS, pyodide._module.TTY);
     FS.mkdir('/test_dir');
     FS.chdir('/test_dir');
-    await pyodide.loadPackage(['micropip', 'pytest', 'pytz', 'numpy']);
+    await pyodide.loadPackage(['micropip', 'pytest', 'numpy']);
     if (pydantic_core_version < '2.0.0') await pyodide.loadPackage(['typing-extensions']);
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});
     post();


### PR DESCRIPTION
## Change Summary

In general seems better to use `zoneinfo` over `pytz` these days.

## Related issue number

Might help with #1302 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
