### PR TITLE
Add ser_json_inf_nan='strings' mode to produce valid JSON

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -355,7 +355,7 @@ def to_json(
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
     bytes_mode: Literal['utf8', 'base64'] = 'utf8',
-    inf_nan_mode: Literal['null', 'constants'] = 'constants',
+    inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
@@ -376,7 +376,7 @@ def to_json(
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
         bytes_mode: How to serialize `bytes` objects, either `'utf8'` or `'base64'`.
-        inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'` or `'constants'`.
+        inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
         serialize_unknown: Attempt to serialize unknown types, `str(value)` will be used, if that fails
             `"<Unserializable {value_type} object>"` will be used.
         fallback: A function to call when an unknown value is encountered,
@@ -430,7 +430,7 @@ def to_jsonable_python(
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
     bytes_mode: Literal['utf8', 'base64'] = 'utf8',
-    inf_nan_mode: Literal['null', 'constants'] = 'constants',
+    inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
@@ -451,7 +451,7 @@ def to_jsonable_python(
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
         bytes_mode: How to serialize `bytes` objects, either `'utf8'` or `'base64'`.
-        inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'` or `'constants'`.
+        inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
         serialize_unknown: Attempt to serialize unknown types, `str(value)` will be used, if that fails
             `"<Unserializable {value_type} object>"` will be used.
         fallback: A function to call when an unknown value is encountered,

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -106,7 +106,7 @@ class CoreConfig(TypedDict, total=False):
     # the config options are used to customise serialization to JSON
     ser_json_timedelta: Literal['iso8601', 'float']  # default: 'iso8601'
     ser_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'
-    ser_json_inf_nan: Literal['null', 'constants']  # default: 'null'
+    ser_json_inf_nan: Literal['null', 'constants', 'strings']  # default: 'null'
     # used to hide input data from ValidationError repr
     hide_input_in_errors: bool
     validation_error_cause: bool  # default: False

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -104,6 +104,7 @@ serialization_mode! {
     "ser_json_inf_nan",
     Null => "null",
     Constants => "constants",
+    Strings => "strings",
 }
 
 impl TimedeltaMode {

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -623,6 +623,14 @@ def test_ser_json_inf_nan_with_any() -> None:
     assert s.to_python(nan, mode='json') is None
     assert s.to_json(nan) == b'null'
 
+    s = SchemaSerializer(core_schema.any_schema(), core_schema.CoreConfig(ser_json_inf_nan='strings'))
+    assert isinf(s.to_python(inf))
+    assert isinf(s.to_python(inf, mode='json'))
+    assert s.to_json(inf) == b'"Infinity"'
+    assert isnan(s.to_python(nan))
+    assert isnan(s.to_python(nan, mode='json'))
+    assert s.to_json(nan) == b'"NaN"'
+
 
 def test_ser_json_inf_nan_with_list_of_any() -> None:
     s = SchemaSerializer(

--- a/tests/serializers/test_simple.py
+++ b/tests/serializers/test_simple.py
@@ -152,6 +152,9 @@ def test_numpy():
         (float('inf'), 'Infinity', {'ser_json_inf_nan': 'constants'}),
         (float('-inf'), '-Infinity', {'ser_json_inf_nan': 'constants'}),
         (float('nan'), 'NaN', {'ser_json_inf_nan': 'constants'}),
+        (float('inf'), '"Infinity"', {'ser_json_inf_nan': 'strings'}),
+        (float('-inf'), '"-Infinity"', {'ser_json_inf_nan': 'strings'}),
+        (float('nan'), '"NaN"', {'ser_json_inf_nan': 'strings'}),
     ],
 )
 def test_float_inf_and_nan_serializers(value, expected_json, config):

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -387,6 +387,10 @@ def test_allow_inf_nan_true_json() -> None:
     assert v.validate_json('Infinity') == float('inf')
     assert v.validate_json('-Infinity') == float('-inf')
 
+    assert v.validate_json('"NaN"') == IsFloatNan()
+    assert v.validate_json('"Infinity"') == float('inf')
+    assert v.validate_json('"-Infinity"') == float('-inf')
+
 
 def test_allow_inf_nan_false_json() -> None:
     v = SchemaValidator(core_schema.float_schema(), core_schema.CoreConfig(allow_inf_nan=False))


### PR DESCRIPTION
## Change Summary

Add a new float serialization mode that emits strings for special values: `"Infinity"`, `"-Infinity"`, `"NaN"`. This is valid JSON (unlike the output of `constants`) and preserves information (unlike `null`, which conflates them all).

Both serialization and validation are exercised by new unit tests. In fact, validation already worked so that direction didn't require code changes.

## Related issue number

None.

## Checklist

* [X] Unit tests for the changes exist
* [X] Documentation reflects the changes where applicable
* [X] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review


Selected Reviewer: @dmontagu