### PR TITLE
Validate bytes based on ser_json_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,7 @@ dependencies = [
  "ahash",
  "base64",
  "enum_dispatch",
+ "hex",
  "idna",
  "jiter",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ num-bigint = "0.4.4"
 python3-dll-a = "0.2.10"
 uuid = "1.8.0"
 jiter = { version = "0.5", features = ["python"] }
+hex = "0.4.3"
 
 [lib]
 name = "_pydantic_core"

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -352,7 +352,7 @@ def to_json(
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
-    bytes_mode: Literal['utf8', 'base64'] = 'utf8',
+    bytes_mode: Literal['utf8', 'base64', 'hex'] = 'utf8',
     inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
     fallback: Callable[[Any], Any] | None = None,
@@ -373,7 +373,7 @@ def to_json(
         exclude_none: Whether to exclude fields that have a value of `None`.
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
-        bytes_mode: How to serialize `bytes` objects, either `'utf8'` or `'base64'`.
+        bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
         serialize_unknown: Attempt to serialize unknown types, `str(value)` will be used, if that fails
             `"<Unserializable {value_type} object>"` will be used.
@@ -427,7 +427,7 @@ def to_jsonable_python(
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
-    bytes_mode: Literal['utf8', 'base64'] = 'utf8',
+    bytes_mode: Literal['utf8', 'base64', 'hex'] = 'utf8',
     inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
     fallback: Callable[[Any], Any] | None = None,
@@ -448,7 +448,7 @@ def to_jsonable_python(
         exclude_none: Whether to exclude fields that have a value of `None`.
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
-        bytes_mode: How to serialize `bytes` objects, either `'utf8'` or `'base64'`.
+        bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
         serialize_unknown: Attempt to serialize unknown types, `str(value)` will be used, if that fails
             `"<Unserializable {value_type} object>"` will be used.

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -70,6 +70,7 @@ class CoreConfig(TypedDict, total=False):
         ser_json_bytes: The serialization option for `bytes` values. Default is 'utf8'.
         ser_json_inf_nan: The serialization option for infinity and NaN values
             in float fields. Default is 'null'.
+        val_json_bytes: The validation option for `bytes` values, complementing ser_json_bytes. Default is 'utf8'.
         hide_input_in_errors: Whether to hide input data from `ValidationError` representation.
         validation_error_cause: Whether to add user-python excs to the __cause__ of a ValidationError.
             Requires exceptiongroup backport pre Python 3.11.
@@ -107,6 +108,7 @@ class CoreConfig(TypedDict, total=False):
     ser_json_timedelta: Literal['iso8601', 'float']  # default: 'iso8601'
     ser_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'
     ser_json_inf_nan: Literal['null', 'constants', 'strings']  # default: 'null'
+    val_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'
     # used to hide input data from ValidationError repr
     hide_input_in_errors: bool
     validation_error_cause: bool  # default: False

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3906,6 +3906,7 @@ ErrorType = Literal[
     'bytes_type',
     'bytes_too_short',
     'bytes_too_long',
+    'bytes_invalid_encoding',
     'value_error',
     'assertion_error',
     'literal_error',

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -519,7 +519,7 @@ impl ErrorType {
             Self::BytesType {..} => "Input should be a valid bytes",
             Self::BytesTooShort {..} => "Data should have at least {min_length} byte{expected_plural}",
             Self::BytesTooLong {..} => "Data should have at most {max_length} byte{expected_plural}",
-            Self::BytesInvalidEncoding { .. } => "Data should be valid {encoding}, {encoding_error}",
+            Self::BytesInvalidEncoding { .. } => "Data should be valid {encoding}: {encoding_error}",
             Self::ValueError {..} => "Value error, {error}",
             Self::AssertionError {..} => "Assertion failed, {error}",
             Self::CustomError {..} => "",  // custom errors are handled separately

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -290,6 +290,10 @@ error_types! {
     BytesTooLong {
         max_length: {ctx_type: usize, ctx_fn: field_from_context},
     },
+    BytesInvalidEncoding {
+        encoding: {ctx_type: String, ctx_fn: field_from_context},
+        encoding_error: {ctx_type: String, ctx_fn: field_from_context},
+    },
     // ---------------------
     // python errors from functions
     ValueError {
@@ -515,6 +519,7 @@ impl ErrorType {
             Self::BytesType {..} => "Input should be a valid bytes",
             Self::BytesTooShort {..} => "Data should have at least {min_length} byte{expected_plural}",
             Self::BytesTooLong {..} => "Data should have at most {max_length} byte{expected_plural}",
+            Self::BytesInvalidEncoding { .. } => "Data should be valid {encoding}, {encoding_error}",
             Self::ValueError {..} => "Value error, {error}",
             Self::AssertionError {..} => "Assertion failed, {error}",
             Self::CustomError {..} => "",  // custom errors are handled separately
@@ -664,6 +669,11 @@ impl ErrorType {
                 let expected_plural = plural_s(*max_length);
                 to_string_render!(tmpl, max_length, expected_plural)
             }
+            Self::BytesInvalidEncoding {
+                encoding,
+                encoding_error,
+                ..
+            } => render!(tmpl, encoding, encoding_error),
             Self::ValueError { error, .. } => {
                 let error = &error
                     .as_ref()

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -6,8 +6,8 @@ use pyo3::{intern, prelude::*};
 
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
-use crate::serializers::config::BytesMode;
 use crate::tools::py_err;
+use crate::validators::config::ValBytesMode;
 
 use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
 use super::return_enums::{EitherBytes, EitherInt, EitherString};
@@ -72,7 +72,7 @@ pub trait Input<'py>: fmt::Debug + ToPyObject {
 
     fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValMatch<EitherString<'_>>;
 
-    fn validate_bytes<'a>(&'a self, strict: bool, mode: BytesMode) -> ValMatch<EitherBytes<'a, 'py>>;
+    fn validate_bytes<'a>(&'a self, strict: bool, mode: ValBytesMode) -> ValMatch<EitherBytes<'a, 'py>>;
 
     fn validate_bool(&self, strict: bool) -> ValMatch<bool>;
 

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -6,6 +6,7 @@ use pyo3::{intern, prelude::*};
 
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
+use crate::serializers::config::BytesMode;
 use crate::tools::py_err;
 
 use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
@@ -71,7 +72,7 @@ pub trait Input<'py>: fmt::Debug + ToPyObject {
 
     fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValMatch<EitherString<'_>>;
 
-    fn validate_bytes<'a>(&'a self, strict: bool) -> ValMatch<EitherBytes<'a, 'py>>;
+    fn validate_bytes<'a>(&'a self, strict: bool, mode: BytesMode) -> ValMatch<EitherBytes<'a, 'py>>;
 
     fn validate_bool(&self, strict: bool) -> ValMatch<bool>;
 

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -7,7 +7,7 @@ use pyo3::{intern, prelude::*};
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
 use crate::tools::py_err;
-use crate::validators::config::ValBytesMode;
+use crate::validators::ValBytesMode;
 
 use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
 use super::return_enums::{EitherBytes, EitherInt, EitherString};

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -9,6 +9,7 @@ use strum::EnumMessage;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
+use crate::serializers::config::BytesMode;
 use crate::validators::decimal::create_decimal;
 
 use super::datetime::{
@@ -106,9 +107,16 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    fn validate_bytes<'a>(&'a self, _strict: bool) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
+    fn validate_bytes<'a>(
+        &'a self,
+        _strict: bool,
+        mode: BytesMode,
+    ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         match self {
-            JsonValue::Str(s) => Ok(ValidationMatch::strict(s.as_bytes().into())),
+            JsonValue::Str(s) => match mode.deserialize_string(s) {
+                Ok(b) => Ok(ValidationMatch::strict(b)),
+                Err(e) => Err(ValError::from(e)),
+            },
             _ => Err(ValError::new(ErrorTypeDefaults::BytesType, self)),
         }
     }
@@ -342,8 +350,15 @@ impl<'py> Input<'py> for str {
         Ok(ValidationMatch::strict(self.into()))
     }
 
-    fn validate_bytes<'a>(&'a self, _strict: bool) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
-        Ok(ValidationMatch::strict(self.as_bytes().into()))
+    fn validate_bytes<'a>(
+        &'a self,
+        _strict: bool,
+        mode: BytesMode,
+    ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
+        match mode.deserialize_string(self) {
+            Ok(b) => Ok(ValidationMatch::strict(b)),
+            Err(e) => Err(ValError::from(e)),
+        }
     }
 
     fn validate_bool(&self, _strict: bool) -> ValResult<ValidationMatch<bool>> {

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -9,7 +9,7 @@ use strum::EnumMessage;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
-use crate::serializers::config::BytesMode;
+use crate::validators::config::ValBytesMode;
 use crate::validators::decimal::create_decimal;
 
 use super::datetime::{
@@ -110,7 +110,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
     fn validate_bytes<'a>(
         &'a self,
         _strict: bool,
-        mode: BytesMode,
+        mode: ValBytesMode,
     ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         match self {
             JsonValue::Str(s) => match mode.deserialize_string(s) {
@@ -353,7 +353,7 @@ impl<'py> Input<'py> for str {
     fn validate_bytes<'a>(
         &'a self,
         _strict: bool,
-        mode: BytesMode,
+        mode: ValBytesMode,
     ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         match mode.deserialize_string(self) {
             Ok(b) => Ok(ValidationMatch::strict(b)),

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -9,8 +9,8 @@ use strum::EnumMessage;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
-use crate::validators::ValBytesMode;
 use crate::validators::decimal::create_decimal;
+use crate::validators::ValBytesMode;
 
 use super::datetime::{
     bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, float_as_datetime, float_as_duration,

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -9,7 +9,7 @@ use strum::EnumMessage;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
-use crate::validators::config::ValBytesMode;
+use crate::validators::ValBytesMode;
 use crate::validators::decimal::create_decimal;
 
 use super::datetime::{

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -115,7 +115,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         match self {
             JsonValue::Str(s) => match mode.deserialize_string(s) {
                 Ok(b) => Ok(ValidationMatch::strict(b)),
-                Err(e) => Err(ValError::from(e)),
+                Err(e) => Err(ValError::new(e, self)),
             },
             _ => Err(ValError::new(ErrorTypeDefaults::BytesType, self)),
         }
@@ -357,7 +357,7 @@ impl<'py> Input<'py> for str {
     ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         match mode.deserialize_string(self) {
             Ok(b) => Ok(ValidationMatch::strict(b)),
-            Err(e) => Err(ValError::from(e)),
+            Err(e) => Err(ValError::new(e, self)),
         }
     }
 

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -15,9 +15,9 @@ use speedate::MicrosecondsPrecisionOverflowBehavior;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::tools::{extract_i64, safe_repr};
-use crate::validators::ValBytesMode;
 use crate::validators::decimal::{create_decimal, get_decimal_type};
 use crate::validators::Exactness;
+use crate::validators::ValBytesMode;
 use crate::ArgsKwargs;
 
 use super::datetime::{

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -14,6 +14,7 @@ use pyo3::PyTypeCheck;
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
+use crate::serializers::config::BytesMode;
 use crate::tools::{extract_i64, safe_repr};
 use crate::validators::decimal::{create_decimal, get_decimal_type};
 use crate::validators::Exactness;
@@ -174,7 +175,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::StringType, self))
     }
 
-    fn validate_bytes<'a>(&'a self, strict: bool) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
+    fn validate_bytes<'a>(&'a self, strict: bool, mode: BytesMode) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         if let Ok(py_bytes) = self.downcast_exact::<PyBytes>() {
             return Ok(ValidationMatch::exact(py_bytes.into()));
         } else if let Ok(py_bytes) = self.downcast::<PyBytes>() {
@@ -185,7 +186,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
             if !strict {
                 return if let Ok(py_str) = self.downcast::<PyString>() {
                     let str = py_string_str(py_str)?;
-                    Ok(str.as_bytes().into())
+                    match mode.deserialize_string(str) {
+                        Ok(b) => Ok(b),
+                        Err(e) => Err(ValError::from(e)),
+                    }
                 } else if let Ok(py_byte_array) = self.downcast::<PyByteArray>() {
                     Ok(py_byte_array.to_vec().into())
                 } else {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -192,7 +192,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                     let str = py_string_str(py_str)?;
                     match mode.deserialize_string(str) {
                         Ok(b) => Ok(b),
-                        Err(e) => Err(ValError::from(e)),
+                        Err(e) => Err(ValError::new(e, self)),
                     }
                 } else if let Ok(py_byte_array) = self.downcast::<PyByteArray>() {
                     Ok(py_byte_array.to_vec().into())

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -14,8 +14,8 @@ use pyo3::PyTypeCheck;
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
-use crate::serializers::config::BytesMode;
 use crate::tools::{extract_i64, safe_repr};
+use crate::validators::config::ValBytesMode;
 use crate::validators::decimal::{create_decimal, get_decimal_type};
 use crate::validators::Exactness;
 use crate::ArgsKwargs;
@@ -175,7 +175,11 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::StringType, self))
     }
 
-    fn validate_bytes<'a>(&'a self, strict: bool, mode: BytesMode) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
+    fn validate_bytes<'a>(
+        &'a self,
+        strict: bool,
+        mode: ValBytesMode,
+    ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         if let Ok(py_bytes) = self.downcast_exact::<PyBytes>() {
             return Ok(ValidationMatch::exact(py_bytes.into()));
         } else if let Ok(py_bytes) = self.downcast::<PyBytes>() {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -15,7 +15,7 @@ use speedate::MicrosecondsPrecisionOverflowBehavior;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::tools::{extract_i64, safe_repr};
-use crate::validators::config::ValBytesMode;
+use crate::validators::ValBytesMode;
 use crate::validators::decimal::{create_decimal, get_decimal_type};
 use crate::validators::Exactness;
 use crate::ArgsKwargs;

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -114,7 +114,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         match self {
             Self::String(s) => py_string_str(s).and_then(|b| match mode.deserialize_string(b) {
                 Ok(b) => Ok(ValidationMatch::strict(b)),
-                Err(e) => Err(ValError::from(e)),
+                Err(e) => Err(ValError::new(e, self)),
             }),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::BytesType, self)),
         }

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -7,7 +7,7 @@ use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult}
 use crate::input::py_string_str;
 use crate::lookup_key::{LookupKey, LookupPath};
 use crate::tools::safe_repr;
-use crate::validators::config::ValBytesMode;
+use crate::validators::ValBytesMode;
 use crate::validators::decimal::create_decimal;
 
 use super::datetime::{

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -6,8 +6,8 @@ use speedate::MicrosecondsPrecisionOverflowBehavior;
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::input::py_string_str;
 use crate::lookup_key::{LookupKey, LookupPath};
-use crate::serializers::config::BytesMode;
 use crate::tools::safe_repr;
+use crate::validators::config::ValBytesMode;
 use crate::validators::decimal::create_decimal;
 
 use super::datetime::{
@@ -109,7 +109,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
     fn validate_bytes<'a>(
         &'a self,
         _strict: bool,
-        mode: BytesMode,
+        mode: ValBytesMode,
     ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
         match self {
             Self::String(s) => py_string_str(s).and_then(|b| match mode.deserialize_string(b) {

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -7,8 +7,8 @@ use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult}
 use crate::input::py_string_str;
 use crate::lookup_key::{LookupKey, LookupPath};
 use crate::tools::safe_repr;
-use crate::validators::ValBytesMode;
 use crate::validators::decimal::create_decimal;
+use crate::validators::ValBytesMode;
 
 use super::datetime::{
     bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, EitherDate, EitherDateTime, EitherTime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use jiter::{map_json_error, PartialMode, PythonParse, StringCacheMode};
 use pyo3::exceptions::PyTypeError;
 use pyo3::{prelude::*, sync::GILOnceCell};
 use serializers::config::BytesMode;
+use validators::config::ValBytesMode;
 
 // parse this first to get access to the contained macro
 #[macro_use]
@@ -56,7 +57,7 @@ pub fn from_json<'py>(
     allow_partial: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
     let v_match = data
-        .validate_bytes(false, BytesMode::Utf8)
+        .validate_bytes(false, ValBytesMode { ser: BytesMode::Utf8 })
         .map_err(|_| PyTypeError::new_err("Expected bytes, bytearray or str"))?;
     let json_either_bytes = v_match.into_inner();
     let json_bytes = json_either_bytes.as_slice();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 use jiter::StringCacheMode;
 use pyo3::exceptions::PyTypeError;
 use pyo3::{prelude::*, sync::GILOnceCell};
+use serializers::config::BytesMode;
 
 // parse this first to get access to the contained macro
 #[macro_use]
@@ -55,7 +56,7 @@ pub fn from_json<'py>(
     allow_partial: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
     let v_match = data
-        .validate_bytes(false)
+        .validate_bytes(false, BytesMode::Utf8)
         .map_err(|_| PyTypeError::new_err("Expected bytes, bytearray or str"))?;
     let json_either_bytes = v_match.into_inner();
     let json_bytes = json_either_bytes.as_slice();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ use std::sync::OnceLock;
 use jiter::{map_json_error, PartialMode, PythonParse, StringCacheMode};
 use pyo3::exceptions::PyTypeError;
 use pyo3::{prelude::*, sync::GILOnceCell};
-use serializers::config::BytesMode;
-use validators::config::ValBytesMode;
+use serializers::BytesMode;
+use validators::ValBytesMode;
 
 // parse this first to get access to the contained macro
 #[macro_use]

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::str::{from_utf8, FromStr, Utf8Error};
 
 use base64::Engine;
-use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDelta, PyDict, PyString};
@@ -10,7 +9,7 @@ use pyo3::types::{PyDelta, PyDict, PyString};
 use serde::ser::Error;
 
 use crate::build_tools::py_schema_err;
-use crate::input::{EitherBytes, EitherTimedelta};
+use crate::input::EitherTimedelta;
 use crate::tools::SchemaDict;
 
 use super::errors::py_err_se_err;
@@ -187,17 +186,6 @@ impl BytesMode {
             Self::Hex => {
                 serializer.serialize_str(&bytes.iter().fold(String::new(), |acc, b| acc + &format!("{b:02x}")))
             }
-        }
-    }
-
-    pub fn deserialize_string<'a, 'py>(&self, s: &'a str) -> PyResult<EitherBytes<'a, 'py>> {
-        match self {
-            Self::Utf8 => Ok(EitherBytes::Cow(Cow::Borrowed(s.as_bytes()))),
-            Self::Base64 => match base64::engine::general_purpose::URL_SAFE.decode(s) {
-                Ok(bytes) => Ok(EitherBytes::from(bytes)),
-                Err(err) => Err(PyValueError::new_err(format!("Base64 decode error: {err}"))),
-            },
-            Self::Hex => Err(PyValueError::new_err("Hex deserialization is not supported")),
         }
     }
 }

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -183,9 +183,7 @@ impl BytesMode {
                 Err(e) => Err(Error::custom(e.to_string())),
             },
             Self::Base64 => serializer.serialize_str(&base64::engine::general_purpose::URL_SAFE.encode(bytes)),
-            Self::Hex => {
-                serializer.serialize_str(&bytes.iter().fold(String::new(), |acc, b| acc + &format!("{b:02x}")))
-            }
+            Self::Hex => serializer.serialize_str(hex::encode(bytes).as_str()),
         }
     }
 }

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -8,6 +8,7 @@ use pyo3::{PyTraverseError, PyVisit};
 use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::py_gc::PyGcTraverse;
 
+pub(crate) use config::BytesMode;
 use config::SerializationConfig;
 pub use errors::{PydanticSerializationError, PydanticSerializationUnexpectedValue};
 use extra::{CollectWarnings, SerRecursionState, WarningsMode};
@@ -16,7 +17,7 @@ pub use shared::CombinedSerializer;
 use shared::{to_json_bytes, BuildSerializer, TypeSerializer};
 
 mod computed_fields;
-pub(crate) mod config;
+mod config;
 mod errors;
 mod extra;
 mod fields;

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -16,7 +16,7 @@ pub use shared::CombinedSerializer;
 use shared::{to_json_bytes, BuildSerializer, TypeSerializer};
 
 mod computed_fields;
-mod config;
+pub(crate) mod config;
 mod errors;
 mod extra;
 mod fields;

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -6,6 +6,7 @@ use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
+use crate::serializers::config::{BytesMode, FromConfig};
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
@@ -13,6 +14,7 @@ use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationSta
 #[derive(Debug, Clone)]
 pub struct BytesValidator {
     strict: bool,
+    bytes_mode: BytesMode,
 }
 
 impl BuildValidator for BytesValidator {
@@ -31,6 +33,7 @@ impl BuildValidator for BytesValidator {
         } else {
             Ok(Self {
                 strict: is_strict(schema, config)?,
+                bytes_mode: BytesMode::from_config(config)?,
             }
             .into())
         }
@@ -47,7 +50,7 @@ impl Validator for BytesValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         input
-            .validate_bytes(state.strict_or(self.strict))
+            .validate_bytes(state.strict_or(self.strict), self.bytes_mode.clone())
             .map(|m| m.unpack(state).into_py(py))
     }
 
@@ -59,6 +62,7 @@ impl Validator for BytesValidator {
 #[derive(Debug, Clone)]
 pub struct BytesConstrainedValidator {
     strict: bool,
+    bytes_mode: BytesMode,
     max_length: Option<usize>,
     min_length: Option<usize>,
 }
@@ -72,7 +76,9 @@ impl Validator for BytesConstrainedValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
-        let either_bytes = input.validate_bytes(state.strict_or(self.strict))?.unpack(state);
+        let either_bytes = input
+            .validate_bytes(state.strict_or(self.strict), self.bytes_mode.clone())?
+            .unpack(state);
         let len = either_bytes.len()?;
 
         if let Some(min_length) = self.min_length {
@@ -110,6 +116,7 @@ impl BytesConstrainedValidator {
         let py = schema.py();
         Ok(Self {
             strict: is_strict(schema, config)?,
+            bytes_mode: BytesMode::from_config(config)?,
             min_length: schema.get_as(intern!(py, "min_length"))?,
             max_length: schema.get_as(intern!(py, "max_length"))?,
         }

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -6,15 +6,15 @@ use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
-use crate::serializers::config::{BytesMode, FromConfig};
 use crate::tools::SchemaDict;
 
+use super::config::ValBytesMode;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]
 pub struct BytesValidator {
     strict: bool,
-    bytes_mode: BytesMode,
+    bytes_mode: ValBytesMode,
 }
 
 impl BuildValidator for BytesValidator {
@@ -33,7 +33,7 @@ impl BuildValidator for BytesValidator {
         } else {
             Ok(Self {
                 strict: is_strict(schema, config)?,
-                bytes_mode: BytesMode::from_config(config)?,
+                bytes_mode: ValBytesMode::from_config(config)?,
             }
             .into())
         }
@@ -62,7 +62,7 @@ impl Validator for BytesValidator {
 #[derive(Debug, Clone)]
 pub struct BytesConstrainedValidator {
     strict: bool,
-    bytes_mode: BytesMode,
+    bytes_mode: ValBytesMode,
     max_length: Option<usize>,
     min_length: Option<usize>,
 }
@@ -116,7 +116,7 @@ impl BytesConstrainedValidator {
         let py = schema.py();
         Ok(Self {
             strict: is_strict(schema, config)?,
-            bytes_mode: BytesMode::from_config(config)?,
+            bytes_mode: ValBytesMode::from_config(config)?,
             min_length: schema.get_as(intern!(py, "min_length"))?,
             max_length: schema.get_as(intern!(py, "max_length"))?,
         }

--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -1,0 +1,38 @@
+use std::borrow::Cow;
+use std::str::FromStr;
+
+use base64::Engine;
+use pyo3::exceptions::PyValueError;
+use pyo3::types::{PyDict, PyString};
+use pyo3::{intern, prelude::*};
+
+use crate::input::EitherBytes;
+use crate::serializers::config::BytesMode;
+use crate::tools::SchemaDict;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValBytesMode {
+    pub ser: BytesMode,
+}
+
+impl ValBytesMode {
+    pub fn from_config(config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+        let Some(config_dict) = config else {
+            return Ok(Self::default());
+        };
+        let raw_mode = config_dict.get_as::<Bound<'_, PyString>>(intern!(config_dict.py(), "val_json_bytes"))?;
+        let ser_mode = raw_mode.map_or_else(|| Ok(BytesMode::default()), |raw| BytesMode::from_str(&raw.to_cow()?))?;
+        Ok(Self { ser: ser_mode })
+    }
+
+    pub fn deserialize_string<'py>(self, s: &str) -> PyResult<EitherBytes<'_, 'py>> {
+        match self.ser {
+            BytesMode::Utf8 => Ok(EitherBytes::Cow(Cow::Borrowed(s.as_bytes()))),
+            BytesMode::Base64 => match base64::engine::general_purpose::URL_SAFE.decode(s) {
+                Ok(bytes) => Ok(EitherBytes::from(bytes)),
+                Err(err) => Err(PyValueError::new_err(format!("Base64 decode error: {err}"))),
+            },
+            BytesMode::Hex => Err(PyValueError::new_err("Hex deserialization is not supported")),
+        }
+    }
+}

--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -36,27 +36,14 @@ impl ValBytesMode {
                     context: None,
                 }),
             },
-            BytesMode::Hex => {
-                if s.len() % 2 != 0 {
-                    return Err(ErrorType::BytesInvalidEncoding {
-                        encoding: "hex".to_string(),
-                        encoding_error: "Hex string must have an even number of characters".to_string(),
-                        context: None,
-                    });
-                }
-                let bytes = (0..s.len())
-                    .step_by(2)
-                    .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
-                    .collect::<Result<Vec<_>, _>>();
-                match bytes {
-                    Ok(vec) => Ok(EitherBytes::from(vec)),
-                    Err(err) => Err(ErrorType::BytesInvalidEncoding {
-                        encoding: "hex".to_string(),
-                        encoding_error: err.to_string(),
-                        context: None,
-                    }),
-                }
-            }
+            BytesMode::Hex => match hex::decode(s) {
+                Ok(vec) => Ok(EitherBytes::from(vec)),
+                Err(err) => Err(ErrorType::BytesInvalidEncoding {
+                    encoding: "hex".to_string(),
+                    encoding_error: err.to_string(),
+                    context: None,
+                }),
+            },
         }
     }
 }

--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -7,7 +7,7 @@ use pyo3::{intern, prelude::*};
 
 use crate::errors::ErrorType;
 use crate::input::EitherBytes;
-use crate::serializers::config::BytesMode;
+use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -9,6 +9,7 @@ use crate::input::{EitherBytes, Input, InputType, ValidationMatch};
 use crate::serializers::config::BytesMode;
 use crate::tools::SchemaDict;
 
+use super::config::ValBytesMode;
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug)]
@@ -88,7 +89,7 @@ impl Validator for JsonValidator {
 pub fn validate_json_bytes<'a, 'py>(
     input: &'a (impl Input<'py> + ?Sized),
 ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
-    match input.validate_bytes(false, BytesMode::Utf8) {
+    match input.validate_bytes(false, ValBytesMode { ser: BytesMode::Utf8 }) {
         Ok(v_match) => Ok(v_match),
         Err(ValError::LineErrors(e)) => Err(ValError::LineErrors(
             e.into_iter().map(map_bytes_error).collect::<Vec<_>>(),

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -6,7 +6,7 @@ use jiter::{JsonValue, PartialMode, PythonParse};
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{EitherBytes, Input, InputType, ValidationMatch};
-use crate::serializers::config::BytesMode;
+use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 
 use super::config::ValBytesMode;

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -6,6 +6,7 @@ use jiter::JsonValue;
 
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{EitherBytes, Input, InputType, ValidationMatch};
+use crate::serializers::config::BytesMode;
 use crate::tools::SchemaDict;
 
 use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
@@ -79,7 +80,7 @@ impl Validator for JsonValidator {
 pub fn validate_json_bytes<'a, 'py>(
     input: &'a (impl Input<'py> + ?Sized),
 ) -> ValResult<ValidationMatch<EitherBytes<'a, 'py>>> {
-    match input.validate_bytes(false) {
+    match input.validate_bytes(false, BytesMode::Utf8) {
         Ok(v_match) => Ok(v_match),
         Err(ValError::LineErrors(e)) => Err(ValError::LineErrors(
             e.into_iter().map(map_bytes_error).collect::<Vec<_>>(),

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -24,6 +24,7 @@ mod bytes;
 mod call;
 mod callable;
 mod chain;
+pub(crate) mod config;
 mod custom_error;
 mod dataclass;
 mod date;

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -10,13 +10,13 @@ use pyo3::types::{PyAny, PyDict, PyString, PyTuple, PyType};
 use pyo3::{intern, PyTraverseError, PyVisit};
 
 use crate::build_tools::{py_schema_err, py_schema_error_type, SchemaError};
-pub(crate) use config::ValBytesMode;
 use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::errors::{LocItem, ValError, ValResult, ValidationError};
 use crate::input::{Input, InputType, StringMapping};
 use crate::py_gc::PyGcTraverse;
 use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
+pub(crate) use config::ValBytesMode;
 
 mod any;
 mod arguments;

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyAny, PyDict, PyString, PyTuple, PyType};
 use pyo3::{intern, PyTraverseError, PyVisit};
 
 use crate::build_tools::{py_schema_err, py_schema_error_type, SchemaError};
+pub(crate) use config::ValBytesMode;
 use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::errors::{LocItem, ValError, ValResult, ValidationError};
 use crate::input::{Input, InputType, StringMapping};
@@ -24,7 +25,7 @@ mod bytes;
 mod call;
 mod callable;
 mod chain;
-pub(crate) mod config;
+mod config;
 mod custom_error;
 mod dataclass;
 mod date;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -13,7 +13,7 @@ use crate::input::input_as_python_instance;
 use crate::input::Input;
 use crate::input::InputType;
 use crate::input::ValidationMatch;
-use crate::serializers::config::BytesMode;
+use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 
 use super::config::ValBytesMode;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -16,6 +16,7 @@ use crate::input::ValidationMatch;
 use crate::serializers::config::BytesMode;
 use crate::tools::SchemaDict;
 
+use super::config::ValBytesMode;
 use super::model::create_class;
 use super::model::force_setattr;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator};
@@ -170,7 +171,7 @@ impl UuidValidator {
             }
             None => {
                 let either_bytes = input
-                    .validate_bytes(true, BytesMode::Utf8)
+                    .validate_bytes(true, ValBytesMode { ser: BytesMode::Utf8 })
                     .map_err(|_| ValError::new(ErrorTypeDefaults::UuidType, input))?
                     .into_inner();
                 let bytes_slice = either_bytes.as_slice();

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -13,6 +13,7 @@ use crate::input::input_as_python_instance;
 use crate::input::Input;
 use crate::input::InputType;
 use crate::input::ValidationMatch;
+use crate::serializers::config::BytesMode;
 use crate::tools::SchemaDict;
 
 use super::model::create_class;
@@ -169,7 +170,7 @@ impl UuidValidator {
             }
             None => {
                 let either_bytes = input
-                    .validate_bytes(true)
+                    .validate_bytes(true, BytesMode::Utf8)
                     .map_err(|_| ValError::new(ErrorTypeDefaults::UuidType, input))?
                     .into_inner();
                 let bytes_slice = either_bytes.as_slice();

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -320,6 +320,16 @@ all_errors = [
     ('bytes_too_short', 'Data should have at least 1 byte', {'min_length': 1}),
     ('bytes_too_long', 'Data should have at most 42 bytes', {'max_length': 42}),
     ('bytes_too_long', 'Data should have at most 1 byte', {'max_length': 1}),
+    (
+        'bytes_invalid_encoding',
+        'Data should be valid base64, base64 error',
+        {'encoding': 'base64', 'encoding_error': 'base64 error'},
+    ),
+    (
+        'bytes_invalid_encoding',
+        'Data should be valid hex, hex error',
+        {'encoding': 'hex', 'encoding_error': 'hex error'},
+    ),
     ('value_error', 'Value error, foobar', {'error': ValueError('foobar')}),
     ('assertion_error', 'Assertion failed, foobar', {'error': AssertionError('foobar')}),
     ('literal_error', 'Input should be foo', {'expected': 'foo'}),

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -322,13 +322,13 @@ all_errors = [
     ('bytes_too_long', 'Data should have at most 1 byte', {'max_length': 1}),
     (
         'bytes_invalid_encoding',
-        'Data should be valid base64, base64 error',
-        {'encoding': 'base64', 'encoding_error': 'base64 error'},
+        'Data should be valid base64: Invalid byte 1, offset 1',
+        {'encoding': 'base64', 'encoding_error': 'Invalid byte 1, offset 1'},
     ),
     (
         'bytes_invalid_encoding',
-        'Data should be valid hex, hex error',
-        {'encoding': 'hex', 'encoding_error': 'hex error'},
+        'Data should be valid hex: Odd number of digits',
+        {'encoding': 'hex', 'encoding_error': 'Odd number of digits'},
     ),
     ('value_error', 'Value error, foobar', {'error': ValueError('foobar')}),
     ('assertion_error', 'Assertion failed, foobar', {'error': AssertionError('foobar')}),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -403,7 +403,7 @@ def test_json_bytes_base64_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': f'Data should be valid base64, Invalid byte {ord("!")}, offset {len(wrong_input)-1}.',
+            'msg': f'Data should be valid base64: Invalid byte {ord("!")}, offset {len(wrong_input)-1}.',
             'input': wrong_input,
         }
     ]
@@ -435,7 +435,7 @@ def test_json_bytes_hex_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': 'Data should be valid hex, Odd number of digits',
+            'msg': 'Data should be valid hex: Odd number of digits',
             'input': wrong_input,
         }
     ]
@@ -447,7 +447,7 @@ def test_json_bytes_hex_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': "Data should be valid hex, Invalid character 'g' at position 1",
+            'msg': "Data should be valid hex: Invalid character 'g' at position 1",
             'input': wrong_input,
         }
     ]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -386,8 +386,17 @@ def test_json_bytes_base64_round_trip():
     v = SchemaValidator({'type': 'bytes'}, {'val_json_bytes': 'base64'})
     assert v.validate_json(encoded) == data
 
-    with pytest.raises(ValueError):
-        v.validate_json('"wrong!"')
+    wrong_input = 'wrong!'
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_json(json.dumps(wrong_input))
+    assert exc_info.value.errors(include_url=False, include_context=False) == [
+        {
+            'type': 'bytes_invalid_encoding',
+            'loc': (),
+            'msg': f'Data should be valid base64, Invalid byte {ord('!')}, offset {len(wrong_input)-1}.',
+            'input': wrong_input,
+        }
+    ]
 
     assert to_json({'key': data}, bytes_mode='base64') == b'{"key":"aGVsbG8="}'
     v = SchemaValidator(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -403,7 +403,7 @@ def test_json_bytes_base64_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': f'Data should be valid base64, Invalid byte {ord('!')}, offset {len(wrong_input)-1}.',
+            'msg': f'Data should be valid base64, Invalid byte {ord("!")}, offset {len(wrong_input)-1}.',
             'input': wrong_input,
         }
     ]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -435,7 +435,7 @@ def test_json_bytes_hex_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': 'Data should be valid hex, Hex string must have an even number of characters',
+            'msg': 'Data should be valid hex, Odd number of digits',
             'input': wrong_input,
         }
     ]
@@ -447,7 +447,7 @@ def test_json_bytes_hex_invalid():
         {
             'type': 'bytes_invalid_encoding',
             'loc': (),
-            'msg': 'Data should be valid hex, invalid digit found in string',
+            'msg': "Data should be valid hex, Invalid character 'g' at position 1",
             'input': wrong_input,
         }
     ]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -383,7 +383,7 @@ def test_json_bytes_base64_round_trip():
     encoded = b'"aGVsbG8="'
     assert to_json(data, bytes_mode='base64') == encoded
 
-    v = SchemaValidator({'type': 'bytes'}, {'ser_json_bytes': 'base64'})
+    v = SchemaValidator({'type': 'bytes'}, {'val_json_bytes': 'base64'})
     assert v.validate_json(encoded) == data
 
     with pytest.raises(ValueError):
@@ -392,6 +392,6 @@ def test_json_bytes_base64_round_trip():
     assert to_json({'key': data}, bytes_mode='base64') == b'{"key":"aGVsbG8="}'
     v = SchemaValidator(
         {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'bytes'}},
-        {'ser_json_bytes': 'base64'},
+        {'val_json_bytes': 'base64'},
     )
     assert v.validate_json('{"key":"aGVsbG8="}') == {'key': data}


### PR DESCRIPTION
## Change Summary

`ser_json_bytes` transforms values (with base64 encoding) during serialization. But validation doesn't do a complementary base64 decode, so a serialization round-trip into the same model type yields an unequal object.

## Related issue number

None for this directly. Other users have mentioned base64 decoding, though: https://github.com/pydantic/pydantic/issues/7000#issuecomment-1669967897

## Checklist

* [X] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review


Selected Reviewer: @davidhewitt