### PR TITLE
Lower MSRV to 1.75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
     "!tests/.pytest_cache",
     "!*.so",
 ]
-rust-version = "1.76"
+rust-version = "1.75"
 
 [dependencies]
 pyo3 = { version = "0.21.2", features = ["generate-import-lib", "num-bigint"] }


### PR DESCRIPTION
## Change Summary

Lower MSRV to 1.75. Rust 1.75 is the lowest working Rust version.

## Related issue number

fix: #1315

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin