### PR TITLE
tidy up `tagged_union_schema`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2466,8 +2466,8 @@ class TaggedUnionSchema(TypedDict, total=False):
 
 
 def tagged_union_schema(
-    choices: Dict[Hashable, CoreSchema],
-    discriminator: str | list[str | int] | list[list[str | int]] | Callable[[Any], Hashable],
+    choices: Dict[Any, CoreSchema],
+    discriminator: str | list[str | int] | list[list[str | int]] | Callable[[Any], Any],
     *,
     custom_error_type: str | None = None,
     custom_error_message: str | None = None,

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -344,11 +344,9 @@ impl BuildValidator for TaggedUnionValidator {
         let mut tags_repr = String::with_capacity(50);
         let mut descr = String::with_capacity(50);
         let mut first = true;
-        let mut discriminators = Vec::with_capacity(choices.len());
         let schema_choices: Bound<PyDict> = schema.get_as_req(intern!(py, "choices"))?;
         let mut lookup_map = Vec::with_capacity(choices.len());
         for (choice_key, choice_schema) in schema_choices {
-            discriminators.push(choice_key.clone());
             let validator = build_validator(&choice_schema, config, definitions)?;
             let tag_repr = choice_key.repr()?.to_string();
             if first {


### PR DESCRIPTION
Closes #925

While checking out the suggested type hints there and comparing to the implementation, I saw that we stick all unhashable discriminants in a list and to equality comparison on them. So I decided to keep things simple and relax the `Hashable` bound to `Any`.

At the same time, I saw that the list was not necessary and we could use a Rust `Vec`. So I simplified the implementation a little.