### PR TITLE
use full type names in errors

### DIFF
--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -572,7 +572,7 @@ impl PyLineError {
             let input_str = safe_repr(input_value);
             truncate_input_value!(output, &input_str.to_cow());
 
-            if let Ok(type_) = input_value.get_type().qualname() {
+            if let Ok(type_) = input_value.get_type().fully_qualified_name() {
                 write!(output, ", input_type={type_}")?;
             }
         }

--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -83,9 +83,9 @@ async function main() {
     const pyodide = await loadPyodide();
     const FS = pyodide.FS;
     setupStreams(FS, pyodide._module.TTY);
-    FS.mkdir('/test_dir');
-    FS.mount(FS.filesystems.NODEFS, {root: path.join(root_dir, 'tests')}, '/test_dir');
-    FS.chdir('/test_dir');
+    FS.mkdir('/tests');
+    FS.mount(FS.filesystems.NODEFS, {root: path.join(root_dir, 'tests')}, '/tests');
+    FS.chdir('/tests');
     await pyodide.loadPackage(['micropip', 'pytest']);
     // language=python
     errcode = await pyodide.runPythonAsync(`

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -730,7 +730,7 @@ def test_error_on_repr(pydantic_version):
     assert str(exc_info.value) == (
         '1 validation error for int\n'
         '  Input should be a valid integer '
-        '[type=int_type, input_value=<unprintable BadRepr object>, input_type=BadRepr]\n'
+        '[type=int_type, input_value=<unprintable BadRepr object>, input_type=tests.test_errors.BadRepr]\n'
         f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/int_type'
     )
     assert exc_info.value.errors(include_url=False) == [

--- a/tests/validators/test_arguments.py
+++ b/tests/validators/test_arguments.py
@@ -1095,7 +1095,7 @@ def test_error_display(pydantic_version):
         '1 validation error for arguments\n'
         'b\n'
         '  Missing required argument [type=missing_argument, '
-        "input_value=ArgsKwargs((), {'a': 1}), input_type=ArgsKwargs]\n"
+        "input_value=ArgsKwargs((), {'a': 1}), input_type=pydantic_core._pydantic_core.ArgsKwargs]\n"
         f'    For further information visit https://errors.pydantic.dev/{pydantic_version}/v/missing_argument'
     )
     # insert_assert(exc_info.value.json(include_url=False))

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -358,7 +358,9 @@ def test_non_finite_json_values(py_and_json: PyAndJson, input_value, allow_inf_n
         (
             Decimal('nan'),
             False,
-            Err("Input should be a finite number [type=finite_number, input_value=Decimal('NaN'), input_type=Decimal]"),
+            Err(
+                "Input should be a finite number [type=finite_number, input_value=Decimal('NaN'), input_type=decimal.Decimal]"
+            ),
         ),
     ],
 )
@@ -379,21 +381,21 @@ def test_non_finite_decimal_values(strict, input_value, allow_inf_nan, expected)
             Decimal('+inf'),
             False,
             Err(
-                "Input should be a finite number [type=finite_number, input_value=Decimal('Infinity'), input_type=Decimal]"
+                "Input should be a finite number [type=finite_number, input_value=Decimal('Infinity'), input_type=decimal.Decimal]"
             ),
         ),
         (
             Decimal('-inf'),
             True,
             Err(
-                "Input should be greater than 0 [type=greater_than, input_value=Decimal('-Infinity'), input_type=Decimal]"
+                "Input should be greater than 0 [type=greater_than, input_value=Decimal('-Infinity'), input_type=decimal.Decimal]"
             ),
         ),
         (
             Decimal('-inf'),
             False,
             Err(
-                "Input should be a finite number [type=finite_number, input_value=Decimal('-Infinity'), input_type=Decimal]"
+                "Input should be a finite number [type=finite_number, input_value=Decimal('-Infinity'), input_type=decimal.Decimal]"
             ),
         ),
     ],

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -122,7 +122,7 @@ def test_int_py_and_json(py_and_json: PyAndJson, input_value, expected):
             Decimal('1.001'),
             Err(
                 'Input should be a valid integer, got a number with a fractional part '
-                "[type=int_from_float, input_value=Decimal('1.001'), input_type=Decimal]"
+                "[type=int_from_float, input_value=Decimal('1.001'), input_type=decimal.Decimal]"
             ),
             id='decimal-remainder',
         ),
@@ -169,7 +169,7 @@ def test_int(input_value, expected):
             Decimal('1.001'),
             Err(
                 'Input should be a valid integer, got a number with a fractional part '
-                "[type=int_from_float, input_value=Decimal('1.001'), input_type=Decimal]"
+                "[type=int_from_float, input_value=Decimal('1.001'), input_type=decimal.Decimal]"
             ),
             id='decimal-remainder',
         ),

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -50,7 +50,9 @@ def test_str(py_and_json: PyAndJson, input_value, expected):
         (123, Err('Input should be a valid string [type=string_type, input_value=123, input_type=int]')),
         (
             Decimal('123'),
-            Err("Input should be a valid string [type=string_type, input_value=Decimal('123'), input_type=Decimal]"),
+            Err(
+                "Input should be a valid string [type=string_type, input_value=Decimal('123'), input_type=decimal.Decimal]"
+            ),
         ),
     ],
 )

--- a/wasm-preview/worker.js
+++ b/wasm-preview/worker.js
@@ -95,8 +95,8 @@ async function main() {
     const pyodide = await loadPyodide();
     const {FS} = pyodide;
     setupStreams(FS, pyodide._module.TTY);
-    FS.mkdir('/test_dir');
-    FS.chdir('/test_dir');
+    FS.mkdir('/tests');
+    FS.chdir('/tests');
     await pyodide.loadPackage(['micropip', 'pytest', 'numpy']);
     if (pydantic_core_version < '2.0.0') await pyodide.loadPackage(['typing-extensions']);
     await pyodide.runPythonAsync(python_code, {globals: pyodide.toPy({pydantic_core_version, tests_zip})});


### PR DESCRIPTION
## Change Summary

Supersedes #1276, using a new PyO3 0.22 API to get the full type name.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7911

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
