### PR TITLE
use Uuid:::from_u128 for uuid_to_string

### DIFF
--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use uuid::Uuid;
 
 use crate::definitions::DefinitionsBuilder;
 
@@ -11,7 +12,9 @@ use super::{
 };
 
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
-    Ok(py_uuid.str()?.to_string())
+    let uuid_int_val: u128 = py_uuid.getattr("int")?.extract()?;
+    let uuid = Uuid::from_u128(uuid_int_val);
+    Ok(uuid.to_string())
 }
 
 #[derive(Debug, Clone)]

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::{intern, prelude::*};
 use uuid::Uuid;
 
 use crate::definitions::DefinitionsBuilder;
@@ -12,7 +12,8 @@ use super::{
 };
 
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
-    let uuid_int_val: u128 = py_uuid.getattr("int")?.extract()?;
+    let py = py_uuid.py();
+    let uuid_int_val: u128 = py_uuid.getattr(intern!(py, "int"))?.extract()?;
     let uuid = Uuid::from_u128(uuid_int_val);
     Ok(uuid.to_string())
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

First of all thanks for this awesome library.

## Change Summary

I have noticed that using rust `Uuid::from_u128` is ~4x faster than using the python `__str__` for the string conversion. 
(benchmark below shows an improvement of 35%).

I am unsure how to run your benchmark thought. Please let me know if this seems like a valid approach and if I can do anything else.

Thanks

## Related issue number

No issue linked.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
