### PR TITLE
string: Use 're.Pattern.search' instead of 're.Pattern.match'

### DIFF
--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -277,7 +277,7 @@ impl Pattern {
         match &self.engine {
             RegexEngine::RustRegex(regex) => Ok(regex.is_match(target)),
             RegexEngine::PythonRe(py_regex) => {
-                Ok(!py_regex.call_method1(py, intern!(py, "match"), (target,))?.is_none(py))
+                Ok(!py_regex.call_method1(py, intern!(py, "search"), (target,))?.is_none(py))
             }
         }
     }

--- a/tests/validators/test_string.py
+++ b/tests/validators/test_string.py
@@ -80,6 +80,8 @@ def test_str_not_json(input_value, expected):
         ({'pattern': r'^\d+$'}, '12345', '12345'),
         ({'pattern': r'\d+$'}, 'foobar 123', 'foobar 123'),
         ({'pattern': r'^\d+$'}, '12345a', Err("String should match pattern '^\\d+$' [type=string_pattern_mismatch")),
+        ({'pattern': r'[a-z]'}, 'Abc', 'Abc'),
+        ({'pattern': re.compile(r'[a-z]')}, 'Abc', 'Abc'),
         # strip comes after length check
         ({'max_length': 5, 'strip_whitespace': True}, '1234  ', '1234'),
         # to_upper and strip comes after pattern check


### PR DESCRIPTION
## Change Summary

Rust's `Regex.is_match` behaves like Python's `re.Pattern.search`, here's a snippet from the docs of the former:

> Returns true if and only if there is a match for the regex *anywhere*  in the haystack given.

Given the implementation of the regex matching mechanism for the `validators.string.Pattern`, this leads to an inconsistent behavior:

```python
import re
from pydantic import BaseModel, Field

class A(BaseModel):
    b: str = Field(pattern=r"[a-z]")
    c: str = Field(pattern=re.compile(r"[a-z]"))

A.model_validate({"b": "Abc", "c": "Abc"})
```
In this snippet of code, `b` will validate fine, but `c` won't.

Since the test cases for string already establish the expected behavior (the Rust's `Regex.is_match` case), let's use `re.Pattern.search` instead of `re.Pattern.match` to unify the results when a `re.Pattern` object is passed.

## Related issue number

fix #1367

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
