### PR TITLE
Automatically URL encode passwords for `MultiHostUrl` when using the `build` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "speedate"
 version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a20480dbd4c693f0b0f3210f2cee5bfa21a176c1fa4df0e65cc0474e7fa557"
 dependencies = [
  "strum",
  "strum_macros",

--- a/src/url.rs
+++ b/src/url.rs
@@ -396,9 +396,17 @@ impl PyMultiHostUrl {
                 }
                 multi_url
             } else if host.is_some() {
+                let pw = match password.map(String::from) {
+                    Some(p) => Some(
+                        url::form_urlencoded::Serializer::new(String::new())
+                            .append_key_only(&p)
+                            .finish(),
+                    ),
+                    p => p,
+                };
                 let url_host = UrlHostParts {
                     username: username.map(Into::into),
-                    password: password.map(Into::into),
+                    password: pw,
                     host: host.map(Into::into),
                     port: port.map(Into::into),
                 };

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -1233,6 +1233,21 @@ def test_multi_url_build() -> None:
     assert str(url) == 'postgresql://testuser:testpassword@127.0.0.1:5432/database?sslmode=require#test'
 
 
+def test_multi_url_build_chars_in_password() -> None:
+    url = MultiHostUrl.build(
+        scheme='postgresql',
+        username='testuser',
+        password='test?password',
+        host='127.0.0.1',
+        port=5432,
+        path='database',
+        query='sslmode=require',
+        fragment='test',
+    )
+    assert url == MultiHostUrl('postgresql://testuser:test%3Fpassword@127.0.0.1:5432/database?sslmode=require#test')
+    assert str(url) == 'postgresql://testuser:test%3Fpassword@127.0.0.1:5432/database?sslmode=require#test'
+
+
 @pytest.mark.parametrize('field', ['host', 'password', 'username', 'port'])
 def test_multi_url_build_hosts_set_with_single_value(field) -> None:
     """Hosts can't be provided with any single url values."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
