### PR TITLE
feat: add `join` method to `Url` class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "speedate"
 version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a20480dbd4c693f0b0f3210f2cee5bfa21a176c1fa4df0e65cc0474e7fa557"
 dependencies = [
  "strum",
  "strum_macros",

--- a/src/url.rs
+++ b/src/url.rs
@@ -7,7 +7,7 @@ use idna::punycode::decode_to_string;
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
 use pyo3::sync::GILOnceCell;
-use pyo3::types::{PyDict, PyType};
+use pyo3::types::{PyDict, PyTuple, PyType};
 use pyo3::{intern, prelude::*};
 use url::Url;
 
@@ -189,6 +189,37 @@ impl PyUrl {
             url.push_str(fragment);
         }
         cls.call1((url,))
+    }
+
+    #[pyo3(signature=(path, *args, no_trailing_slash=false))]
+    pub fn join(&self, path: &str, args: &Bound<'_, PyTuple>, no_trailing_slash: bool) -> PyResult<Self> {
+        let join_path = |base: &Url, partial_path: String| -> Result<Url, PyErr> {
+            base.join(&partial_path)
+                .map_err(|err| PyValueError::new_err(err.to_string()))
+        };
+
+        let add_trailing_slash = |path_str: &mut String| {
+            if !path_str.trim_end().ends_with('/') {
+                path_str.push('/');
+            }
+        };
+
+        let num_of_args = args.len();
+        let mut path_str = path.to_string();
+        if num_of_args != 0 || !no_trailing_slash {
+            add_trailing_slash(&mut path_str);
+        }
+
+        let mut new_url = join_path(&self.lib_url, path_str)?;
+
+        for i in 0..num_of_args {
+            let mut arg_str = args.get_item(i)?.to_string();
+            if i != num_of_args - 1 || !no_trailing_slash {
+                add_trailing_slash(&mut arg_str);
+            }
+            new_url = join_path(&new_url, arg_str)?;
+        }
+        Ok(PyUrl::new(new_url))
     }
 }
 


### PR DESCRIPTION
- added support for URL path joining with optional trailing slashes and multiple arguments.

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->
This PR implements a feature based on pydantic/pydantic#9794 to join URL path into the base URL. It uses the `join` method from the `url` crate.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix pydantic/pydantic#9794

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
