### PR TITLE
Fix lints firing since rust 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "speedate"
 version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a20480dbd4c693f0b0f3210f2cee5bfa21a176c1fa4df0e65cc0474e7fa557"
 dependencies = [
  "strum",
  "strum_macros",

--- a/build.rs
+++ b/build.rs
@@ -35,6 +35,7 @@ fn main() {
     if let Some(true) = version_check::supports_feature("coverage_attribute") {
         println!("cargo:rustc-cfg=has_coverage_attribute");
     }
+    println!("cargo:rustc-check-cfg=cfg(has_coverage_attribute)");
     generate_self_schema();
     println!("cargo:rustc-env=PROFILE={}", std::env::var("PROFILE").unwrap());
 }

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -290,7 +290,8 @@ impl ObTypeLookup {
     /// We care about order here since:
     /// 1. we pay a price for each `isinstance` call
     /// 2. some types are subclasses of others, e.g. `bool` is a subclass of `int`
-    /// hence we put common types first
+    ///    hence we put common types first
+    ///
     /// In addition, some types have inheritance set as a bitflag on the type object:
     /// https://github.com/python/cpython/blob/v3.12.0rc1/Include/object.h#L546-L553
     /// Hence they come first


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes lints that started warning as of `1.80`. Also checks in a change to `Cargo.lock` that seems to have been missed at some point when `speedate`'s version was bumped.

<!-- Please give a short summary of the changes. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
