### PR TITLE
clean up some string handling cases

### DIFF
--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::str::from_utf8;
 
 use pyo3::intern;
@@ -144,12 +143,8 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                         Err(_) => Err(ValError::new(ErrorTypeDefaults::StringUnicode, self)),
                     }
                 } else if let Ok(py_byte_array) = self.downcast::<PyByteArray>() {
-                    // Safety: the gil is held while from_utf8 is running so py_byte_array is not mutated,
-                    // and we immediately copy the bytes into a new Python string
-                    match from_utf8(unsafe { py_byte_array.as_bytes() }) {
-                        // Why Python not Rust? to avoid an unnecessary allocation on the Rust side, the
-                        // final output needs to be Python anyway.
-                        Ok(s) => Ok(PyString::new_bound(self.py(), s).into()),
+                    match bytearray_to_str(py_byte_array) {
+                        Ok(py_str) => Ok(py_str.into()),
                         Err(_) => Err(ValError::new(ErrorTypeDefaults::StringUnicode, self)),
                     }
                 } else if coerce_numbers_to_str && !self.is_exact_instance_of::<PyBool>() && {
@@ -204,8 +199,8 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
 
         if !strict {
-            if let Some(cow_str) = maybe_as_string(self, ErrorTypeDefaults::BoolParsing)? {
-                return str_as_bool(self, &cow_str).map(ValidationMatch::lax);
+            if let Some(s) = maybe_as_string(self, ErrorTypeDefaults::BoolParsing)? {
+                return str_as_bool(self, s).map(ValidationMatch::lax);
             } else if let Some(int) = extract_i64(self) {
                 return int_as_bool(self, int).map(ValidationMatch::lax);
             } else if let Ok(float) = self.extract::<f64>() {
@@ -241,8 +236,8 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
 
         'lax: {
             if !strict {
-                return if let Some(cow_str) = maybe_as_string(self, ErrorTypeDefaults::IntParsing)? {
-                    str_as_int(self, &cow_str)
+                return if let Some(s) = maybe_as_string(self, ErrorTypeDefaults::IntParsing)? {
+                    str_as_int(self, s)
                 } else if self.is_exact_instance_of::<PyFloat>() {
                     float_as_int(self, self.extract::<f64>()?)
                 } else if let Ok(decimal) = self.strict_decimal(self.py()) {
@@ -283,9 +278,9 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
 
         if !strict {
-            if let Some(cow_str) = maybe_as_string(self, ErrorTypeDefaults::FloatParsing)? {
+            if let Some(s) = maybe_as_string(self, ErrorTypeDefaults::FloatParsing)? {
                 // checking for bytes and string is fast, so do this before isinstance(float)
-                return str_as_float(self, &cow_str).map(ValidationMatch::lax);
+                return str_as_float(self, s).map(ValidationMatch::lax);
             }
         }
 
@@ -630,18 +625,29 @@ fn from_attributes_applicable(obj: &Bound<'_, PyAny>) -> bool {
 }
 
 /// Utility for extracting a string from a PyAny, if possible.
-fn maybe_as_string<'a>(v: &'a Bound<'_, PyAny>, unicode_error: ErrorType) -> ValResult<Option<Cow<'a, str>>> {
+fn maybe_as_string<'a>(v: &'a Bound<'_, PyAny>, unicode_error: ErrorType) -> ValResult<Option<&'a str>> {
     if let Ok(py_string) = v.downcast::<PyString>() {
-        let str = py_string_str(py_string)?;
-        Ok(Some(Cow::Borrowed(str)))
+        py_string_str(py_string).map(Some)
     } else if let Ok(bytes) = v.downcast::<PyBytes>() {
         match from_utf8(bytes.as_bytes()) {
-            Ok(s) => Ok(Some(Cow::Owned(s.to_string()))),
+            Ok(s) => Ok(Some(s)),
             Err(_) => Err(ValError::new(unicode_error, v)),
         }
     } else {
         Ok(None)
     }
+}
+
+/// Decode a Python bytearray to a Python string.
+///
+/// Using Python's built-in machinery for this should be efficient and avoids questions around
+/// safety of concurrent mutation of the bytearray (by leaving that to the Python interpreter).
+fn bytearray_to_str<'py>(bytearray: &Bound<'py, PyByteArray>) -> PyResult<Bound<'py, PyString>> {
+    let py = bytearray.py();
+    let py_string = bytearray
+        .call_method1(intern!(py, "decode"), (intern!(py, "utf-8"),))?
+        .downcast_into()?;
+    Ok(py_string)
 }
 
 /// Utility for extracting an enum value, if possible.

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -77,7 +77,7 @@ macro_rules! serialization_mode {
                     return Ok(Self::default());
                 };
                 let raw_mode = config_dict.get_as::<Bound<'_, PyString>>(intern!(config_dict.py(), $config_key))?;
-                raw_mode.map_or_else(|| Ok(Self::default()), |raw| Self::from_str(&raw.to_cow()?))
+                raw_mode.map_or_else(|| Ok(Self::default()), |raw| Self::from_str(raw.to_str()?))
             }
         }
 


### PR DESCRIPTION
## Change Summary

- Use `&str` instead of `Cow<'_, str>` in a couple places where it's good enough
- Avoid some potential unsafety in converting a bytearray to a string

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
