### PR TITLE
Expose AnySerializer via core schema

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -219,6 +219,7 @@ ExpectedSerializationTypes = Literal[
     'multi-host-url',
     'json',
     'uuid',
+    'any',
 ]
 
 

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -652,3 +652,32 @@ def test_ser_json_inf_nan_with_list_of_any() -> None:
     assert isnan(s.to_python([nan])[0])
     assert s.to_python([nan], mode='json')[0] is None
     assert s.to_json([nan]) == b'[null]'
+
+
+def test_simple_any_ser_schema_repr():
+    assert (
+        plain_repr(SchemaSerializer(core_schema.simple_ser_schema('any')))
+        == 'SchemaSerializer(serializer=Any(AnySerializer),definitions=[])'
+    )
+
+
+def test_simple_any_ser_schema():
+    import operator
+
+    class MyEnum(Enum):
+        A = (1,)
+        B = (2,)
+
+    v = SchemaSerializer(
+        core_schema.no_info_after_validator_function(
+            operator.attrgetter('value'),
+            core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())),
+            serialization=core_schema.simple_ser_schema('any'),
+        ),
+    )
+
+    assert v.to_python({MyEnum.A: 'x'}) == {MyEnum.A: 'x'}
+    assert v.to_python({MyEnum.A: 'x'}, mode='json') == {'1': 'x'}
+    assert v.to_json({MyEnum.A: 'x'}) == b'{"1":"x"}'
+    assert v.to_python(1) == 1
+    assert v.to_json(1) == b'1'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes #1245

Allows `simple_ser_schema` to specify `'any'` so that `AnySerializer` can be used when creating core schemas. The `test_any.py` file seems to adequately test the actual implementation of `AnySerializer` so I've only added tests that check that `simple_ser_schema('any')` actually results in an `AnySerializer` rather than duplicating the entire file :sweat_smile: 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
