### PR TITLE
Validate base64 standard encoding

### DIFF
--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -28,7 +28,7 @@ impl ValBytesMode {
     pub fn deserialize_string<'py>(self, s: &str) -> Result<EitherBytes<'_, 'py>, ErrorType> {
         match self.ser {
             BytesMode::Utf8 => Ok(EitherBytes::Cow(Cow::Borrowed(s.as_bytes()))),
-            BytesMode::Base64 => match base64::engine::general_purpose::URL_SAFE.decode(s) {
+            BytesMode::Base64 => match base64::engine::general_purpose::URL_SAFE.decode(to_base64_urlsafe(s)) {
                 Ok(bytes) => Ok(EitherBytes::from(bytes)),
                 Err(err) => Err(ErrorType::BytesInvalidEncoding {
                     encoding: "base64".to_string(),
@@ -45,5 +45,13 @@ impl ValBytesMode {
                 }),
             },
         }
+    }
+}
+
+fn to_base64_urlsafe(s: &str) -> String {
+    if s.contains('+') || s.contains('/') {
+        s.replace('+', "-").replace('/', "_")
+    } else {
+        s.to_string()
     }
 }

--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -49,7 +49,7 @@ impl ValBytesMode {
 }
 
 fn to_base64_urlsafe(s: &str) -> String {
-    if s.contains('+') || s.contains('/') {
+    if s.contains(|c| c == '+' || c == '/') {
         s.replace('+', "-").replace('/', "_")
     } else {
         s.to_string()

--- a/src/validators/config.rs
+++ b/src/validators/config.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use base64::Engine;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE};
+use base64::{DecodeError, Engine};
 use pyo3::types::{PyDict, PyString};
 use pyo3::{intern, prelude::*};
 
@@ -28,31 +29,18 @@ impl ValBytesMode {
     pub fn deserialize_string<'py>(self, s: &str) -> Result<EitherBytes<'_, 'py>, ErrorType> {
         match self.ser {
             BytesMode::Utf8 => Ok(EitherBytes::Cow(Cow::Borrowed(s.as_bytes()))),
-            BytesMode::Base64 => {
-                fn decode(input: &str) -> Result<Vec<u8>, ErrorType> {
-                    base64::engine::general_purpose::URL_SAFE.decode(input).map_err(|err| {
-                        ErrorType::BytesInvalidEncoding {
-                            encoding: "base64".to_string(),
-                            encoding_error: err.to_string(),
-                            context: None,
-                        }
-                    })
-                }
-                let result = if s.contains(|c| c == '+' || c == '/') {
-                    let replaced: String = s
-                        .chars()
-                        .map(|c| match c {
-                            '+' => '-',
-                            '/' => '_',
-                            _ => c,
-                        })
-                        .collect();
-                    decode(&replaced)
-                } else {
-                    decode(s)
-                };
-                result.map(EitherBytes::from)
-            }
+            BytesMode::Base64 => URL_SAFE
+                .decode(s)
+                .or_else(|err| match err {
+                    DecodeError::InvalidByte(_, b'/' | b'+') => STANDARD.decode(s),
+                    _ => Err(err),
+                })
+                .map(EitherBytes::from)
+                .map_err(|err| ErrorType::BytesInvalidEncoding {
+                    encoding: "base64".to_string(),
+                    encoding_error: err.to_string(),
+                    context: None,
+                }),
             BytesMode::Hex => match hex::decode(s) {
                 Ok(vec) => Ok(EitherBytes::from(vec)),
                 Err(err) => Err(ErrorType::BytesInvalidEncoding {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -379,9 +379,9 @@ def test_partial_parse():
 
 
 def test_json_bytes_base64_round_trip():
-    data = b'TDR3\xbe\x11J\xe9\x9f\xa4&\x91\xff\xc8\xef4\xdf\xd3$\xf3^\xca\xb5\x14V \xdeDH\n\x85\x8b'
-    encoded_std = b'"VERSM74RSumfpCaR/8jvNN/TJPNeyrUUViDeREgKhYs="'
-    encoded_url = b'"VERSM74RSumfpCaR_8jvNN_TJPNeyrUUViDeREgKhYs="'
+    data = b'\xd8\x07\xc1Tx$\x91F%\xf3\xf3I\xca\xd8@\x0c\xee\xc3\xab\xff\x7f\xd3\xcd\xcd\xf9\xc2\x10\xe4\xa1\xb01e'
+    encoded_std = b'"2AfBVHgkkUYl8/NJythADO7Dq/9/083N+cIQ5KGwMWU="'
+    encoded_url = b'"2AfBVHgkkUYl8_NJythADO7Dq_9_083N-cIQ5KGwMWU="'
     assert to_json(data, bytes_mode='base64') == encoded_url
 
     v = SchemaValidator({'type': 'bytes'}, {'val_json_bytes': 'base64'})


### PR DESCRIPTION
## Change Summary

Extends bytes base64 validation to accept standard encoding, in addition to the existing URL-safe.

I think a user providing base64 standard input is more likely to want successful (and unambiguous) decoding rather than a validation error. (Even while `ser_json_bytes="base64"` continues to emit the URL-safe variant.)

## Related issue number

No issue, but this extends #1308: https://github.com/pydantic/pydantic-core/pull/1308#issuecomment-2143130478

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu