### PR TITLE
dont embed `RUSTFLAGS` in final binary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,15 @@ fn main() {
         println!("cargo:rustc-cfg=has_coverage_attribute");
     }
     println!("cargo:rustc-check-cfg=cfg(has_coverage_attribute)");
+
+    if std::env::var("RUSTFLAGS")
+        .unwrap_or_default()
+        .contains("-Cprofile-use=")
+    {
+        println!("cargo:rustc-cfg=specified_profile_use");
+    }
+    println!("cargo:rustc-check-cfg=cfg(specified_profile_use)");
+
     generate_self_schema();
     println!("cargo:rustc-env=PROFILE={}", std::env::var("PROFILE").unwrap());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,10 @@ pub fn build_info() -> String {
     format!(
         "profile={} pgo={}",
         env!("PROFILE"),
-        option_env!("RUSTFLAGS").unwrap_or("").contains("-Cprofile-use="),
+        // We use a `cfg!` here not `env!`/`option_env!` as those would
+        // embed `RUSTFLAGS` into the generated binary which causes problems
+        // with reproducable builds.
+        cfg!(specified_profile_use),
     )
 }
 


### PR DESCRIPTION
## Change Summary

Fixes #1365

Using `option_env!` produces a static `str` literal for the value of the env var, this necessarily results in it being stored in the final binary. In this case the entirety of `RUSTFLAGS` would be present which can include paths which causes issues for reproducible builds.

I'm not sure if we have any way to really test for this though, it seems unfortunate to just fix stuff like this then wait until someone complains if we break something :sweat_smile: 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
