### PR TITLE
Adding tagged union serializer 🚀 

### DIFF
--- a/src/common/discriminator.rs
+++ b/src/common/discriminator.rs
@@ -1,0 +1,49 @@
+use pyo3::prelude::*;
+use pyo3::types::PyString;
+use pyo3::{PyTraverseError, PyVisit};
+
+use crate::lookup_key::LookupKey;
+use crate::py_gc::PyGcTraverse;
+
+#[derive(Debug, Clone)]
+pub enum Discriminator {
+    /// use `LookupKey` to find the tag, same as we do to find values in typed_dict aliases
+    LookupKey(LookupKey),
+    /// call a function to find the tag to use
+    Function(PyObject),
+    /// Custom discriminator specifically for the root `Schema` union in self-schema
+    SelfSchema,
+}
+
+impl Discriminator {
+    pub fn new(py: Python, raw: &Bound<'_, PyAny>) -> PyResult<Self> {
+        if raw.is_callable() {
+            return Ok(Self::Function(raw.to_object(py)));
+        } else if let Ok(py_str) = raw.downcast::<PyString>() {
+            if py_str.to_str()? == "self-schema-discriminator" {
+                return Ok(Self::SelfSchema);
+            }
+        }
+
+        let lookup_key = LookupKey::from_py(py, raw, None)?;
+        Ok(Self::LookupKey(lookup_key))
+    }
+
+    pub fn to_string_py(&self, py: Python) -> PyResult<String> {
+        match self {
+            Self::Function(f) => Ok(format!("{}()", f.getattr(py, "__name__")?)),
+            Self::LookupKey(lookup_key) => Ok(lookup_key.to_string()),
+            Self::SelfSchema => Ok("self-schema".to_string()),
+        }
+    }
+}
+
+impl PyGcTraverse for Discriminator {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match self {
+            Self::Function(obj) => visit.call(obj)?,
+            Self::LookupKey(_) | Self::SelfSchema => {}
+        }
+        Ok(())
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod discriminator;
+pub(crate) mod union;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod discriminator;

--- a/src/common/union.rs
+++ b/src/common/union.rs
@@ -39,3 +39,5 @@ impl PyGcTraverse for Discriminator {
         Ok(())
     }
 }
+
+pub(crate) const SMALL_UNION_THRESHOLD: usize = 4;

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -237,7 +237,6 @@ pub trait ValidatedDict<'py> {
     where
         Self: 'a;
     fn get_item<'k>(&self, key: &'k LookupKey) -> ValResult<Option<(&'k LookupPath, Self::Item<'_>)>>;
-    fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>>;
     // FIXME this is a bit of a leaky abstraction
     fn is_py_get_attr(&self) -> bool {
         false
@@ -278,9 +277,6 @@ impl<'py> ValidatedDict<'py> for Never {
     type Key<'a> = Bound<'py, PyAny>;
     type Item<'a> = Bound<'py, PyAny>;
     fn get_item<'k>(&self, _key: &'k LookupKey) -> ValResult<Option<(&'k LookupPath, Self::Item<'_>)>> {
-        unreachable!()
-    }
-    fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>> {
         unreachable!()
     }
     fn iterate<'a, R>(

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -476,10 +476,6 @@ impl<'py, 'data> ValidatedDict<'py> for &'_ JsonObject<'data> {
         key.json_get(self)
     }
 
-    fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>> {
-        None
-    }
-
     fn iterate<'a, R>(
         &'a self,
         consumer: impl ConsumeIterator<ValResult<(Self::Key<'a>, Self::Item<'a>)>, Output = R>,

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -775,13 +775,6 @@ impl<'py> ValidatedDict<'py> for GenericPyMapping<'_, 'py> {
         matches!(self, Self::GetAttr(..))
     }
 
-    fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>> {
-        match self {
-            Self::Dict(dict) => Some(dict),
-            _ => None,
-        }
-    }
-
     fn iterate<'a, R>(
         &'a self,
         consumer: impl ConsumeIterator<ValResult<(Self::Key<'a>, Self::Item<'a>)>, Output = R>,

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -284,9 +284,6 @@ impl<'py> ValidatedDict<'py> for StringMappingDict<'py> {
     fn get_item<'k>(&self, key: &'k LookupKey) -> ValResult<Option<(&'k LookupPath, Self::Item<'_>)>> {
         key.py_get_string_mapping_item(&self.0)
     }
-    fn as_py_dict(&self) -> Option<&Bound<'py, PyDict>> {
-        None
-    }
     fn iterate<'a, R>(
         &'a self,
         consumer: impl super::ConsumeIterator<ValResult<(Self::Key<'a>, Self::Item<'a>)>, Output = R>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod py_gc;
 
 mod argument_markers;
 mod build_tools;
+mod common;
 mod definitions;
 mod errors;
 mod input;

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -88,7 +88,6 @@ combined_serializer! {
     // `find_only` is for type_serializers which are built directly via the `type` key and `find_serializer`
     // but aren't actually used for serialization, e.g. their `build` method must return another serializer
     find_only: {
-        super::type_serializers::union::TaggedUnionBuilder;
         super::type_serializers::other::ChainBuilder;
         super::type_serializers::other::CustomErrorBuilder;
         super::type_serializers::other::CallBuilder;
@@ -138,6 +137,7 @@ combined_serializer! {
         Json: super::type_serializers::json::JsonSerializer;
         JsonOrPython: super::type_serializers::json_or_python::JsonOrPythonSerializer;
         Union: super::type_serializers::union::UnionSerializer;
+        TaggedUnion: super::type_serializers::union::TaggedUnionSerializer;
         Literal: super::type_serializers::literal::LiteralSerializer;
         Enum: super::type_serializers::enum_::EnumSerializer;
         Recursive: super::type_serializers::definitions::DefinitionRefSerializer;
@@ -246,6 +246,7 @@ impl PyGcTraverse for CombinedSerializer {
             CombinedSerializer::Json(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::JsonOrPython(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Union(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::TaggedUnion(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Literal(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Enum(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Recursive(inner) => inner.py_gc_traverse(visit),

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -8,9 +8,10 @@ use std::borrow::Cow;
 use crate::build_tools::py_schema_err;
 use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
+use crate::errors::write_truncated_to_50_bytes;
 use crate::lookup_key::LookupKey;
 use crate::serializers::type_serializers::py_err_se_err;
-use crate::tools::SchemaDict;
+use crate::tools::{safe_repr, SchemaDict};
 use crate::PydanticSerializationUnexpectedValue;
 
 use super::{
@@ -445,9 +446,15 @@ impl TaggedUnionSerializer {
             Discriminator::Function(func) => func.call1(py, (value,)).ok(),
         };
         if discriminator_value.is_none() {
+            let input_str = safe_repr(value);
+            let mut value_str = String::with_capacity(100);
+            value_str.push_str("with value `");
+            write_truncated_to_50_bytes(&mut value_str, input_str.to_cow()).expect("Writing to a `String` failed");
+            value_str.push('`');
+
             extra.warnings.custom_warning(
                 format!(
-                    "Failed to get discriminator value for tagged union serialization for {value} - defaulting to left to right union serialization."
+                    "Failed to get discriminator value for tagged union serialization {value_str} - defaulting to left to right union serialization."
                 )
             );
         }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -6,11 +6,11 @@ use smallvec::SmallVec;
 use std::borrow::Cow;
 
 use crate::build_tools::py_schema_err;
-use crate::common::discriminator::Discriminator;
+use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
 use crate::lookup_key::LookupKey;
 use crate::serializers::type_serializers::py_err_se_err;
-use crate::tools::{SchemaDict, UNION_ERR_SMALLVEC_CAPACITY};
+use crate::tools::SchemaDict;
 use crate::PydanticSerializationUnexpectedValue;
 
 use super::{
@@ -83,7 +83,7 @@ impl TypeSerializer for UnionSerializer {
         // try the serializers in left to right order with error_on fallback=true
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; SMALL_UNION_THRESHOLD]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {
@@ -118,7 +118,7 @@ impl TypeSerializer for UnionSerializer {
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; SMALL_UNION_THRESHOLD]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.json_key(key, &new_extra) {
@@ -161,7 +161,7 @@ impl TypeSerializer for UnionSerializer {
         let py = value.py();
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; SMALL_UNION_THRESHOLD]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -290,18 +290,6 @@ impl TypeSerializer for TaggedUnionSerializer {
                     return s.to_python(value, include, exclude, extra);
                 }
             }
-            Discriminator::SelfSchema => {
-                // not really sure about this case, but it's here for completeness
-                for comb_serializer in &self.choices {
-                    match comb_serializer.to_python(value, include, exclude, &new_extra) {
-                        Ok(v) => return Ok(v),
-                        Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(value.py()) {
-                            true => (),
-                            false => return Err(err),
-                        },
-                    }
-                }
-            }
         }
 
         extra.warnings.on_fallback_py(self.get_name(), value, extra)?;

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -221,11 +221,11 @@ impl BuildSerializer for TaggedUnionSerializer {
         let py = schema.py();
         let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
 
-        let choice_list: Bound<PyDict> = schema.get_as_req(intern!(py, "choices"))?;
-        let mut lookup: HashMap<String, CombinedSerializer> = HashMap::with_capacity(choice_list.len());
-        let mut choices: Vec<CombinedSerializer> = Vec::with_capacity(choice_list.len());
+        let choices_map: Bound<PyDict> = schema.get_as_req(intern!(py, "choices"))?;
+        let mut lookup: HashMap<String, CombinedSerializer> = HashMap::with_capacity(choices_map.len());
+        let mut choices: Vec<CombinedSerializer> = Vec::with_capacity(choices_map.len());
 
-        for (choice_key, choice_schema) in choice_list {
+        for (choice_key, choice_schema) in choices_map {
             let serializer = CombinedSerializer::build(choice_schema.downcast()?, config, definitions).unwrap();
             choices.push(serializer.clone());
             lookup.insert(choice_key.to_string(), serializer);

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -260,12 +260,9 @@ impl TypeSerializer for TaggedUnionSerializer {
                         false => return Err(err),
                     },
                 }
-            } else {
-                return Err(self.tag_not_found());
             }
         }
 
-        // Fallback processing
         let basic_union_ser = UnionSerializer::from_choices(self.choices.clone());
         if let Ok(s) = basic_union_ser {
             return s.to_python(value, include, exclude, extra);
@@ -293,12 +290,9 @@ impl TypeSerializer for TaggedUnionSerializer {
                         }
                     }
                 }
-            } else {
-                return Err(self.tag_not_found());
             }
         }
 
-        // Fallback processing
         let basic_union_ser = UnionSerializer::from_choices(self.choices.clone());
         if let Ok(s) = basic_union_ser {
             return s.json_key(key, extra);
@@ -337,12 +331,9 @@ impl TypeSerializer for TaggedUnionSerializer {
                         }
                     }
                 }
-            } else {
-                return Err(py_err_se_err(self.tag_not_found()));
             }
         }
 
-        // Fallback processing
         let basic_union_ser = UnionSerializer::from_choices(self.choices.clone());
         if let Ok(s) = basic_union_ser {
             return s.serde_serialize(value, serializer, include, exclude, extra);
@@ -373,9 +364,5 @@ impl TaggedUnionSerializer {
                     .ok()
             }),
         }
-    }
-
-    fn tag_not_found(&self) -> PyErr {
-        PydanticSerializationUnexpectedValue::new_err(Some("Tag not found in tagged union for value: {:?}".to_string()))
     }
 }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -359,6 +359,10 @@ impl TypeSerializer for TaggedUnionSerializer {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn retry_with_lax_check(&self) -> bool {
+        self.choices.iter().any(CombinedSerializer::retry_with_lax_check)
+    }
 }
 
 impl TaggedUnionSerializer {

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -8,6 +8,8 @@ use std::borrow::Cow;
 use crate::build_tools::py_schema_err;
 use crate::common::discriminator::Discriminator;
 use crate::definitions::DefinitionsBuilder;
+use crate::lookup_key::LookupKey;
+use crate::serializers::type_serializers::py_err_se_err;
 use crate::tools::{SchemaDict, UNION_ERR_SMALLVEC_CAPACITY};
 use crate::PydanticSerializationUnexpectedValue;
 

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -243,9 +243,7 @@ impl TypeSerializer for TaggedUnionSerializer {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
 
-        let discriminator_value = self.get_discriminator_value(value);
-
-        if let Some(tag) = discriminator_value {
+        if let Some(tag) = self.get_discriminator_value(value) {
             let tag_str = tag.to_string();
             if let Some(serializer) = self.lookup.get(&tag_str) {
                 match serializer.to_python(value, include, exclude, &new_extra) {
@@ -276,9 +274,7 @@ impl TypeSerializer for TaggedUnionSerializer {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
 
-        let discriminator_value = self.get_discriminator_value(key);
-
-        if let Some(tag) = discriminator_value {
+        if let Some(tag) = self.get_discriminator_value(key) {
             let tag_str = tag.to_string();
             if let Some(serializer) = self.lookup.get(&tag_str) {
                 match serializer.json_key(key, &new_extra) {
@@ -314,9 +310,7 @@ impl TypeSerializer for TaggedUnionSerializer {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
 
-        let discriminator_value = self.get_discriminator_value(value);
-
-        if let Some(tag) = discriminator_value {
+        if let Some(tag) = self.get_discriminator_value(value) {
             let tag_str = tag.to_string();
             if let Some(selected_serializer) = self.lookup.get(&tag_str) {
                 match selected_serializer.to_python(value, include, exclude, &new_extra) {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -146,5 +146,3 @@ pub(crate) fn new_py_string<'py>(py: Python<'py>, s: &str, cache_str: StringCach
         pystring_fast_new(py, s, ascii_only)
     }
 }
-
-pub(crate) const UNION_ERR_SMALLVEC_CAPACITY: usize = 4;

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -9,10 +9,10 @@ use smallvec::SmallVec;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config};
-use crate::common::discriminator::Discriminator;
+use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::errors::{ErrorType, ToErrorValue, ValError, ValLineError, ValResult};
 use crate::input::{BorrowInput, Input, ValidatedDict};
-use crate::tools::{SchemaDict, UNION_ERR_SMALLVEC_CAPACITY};
+use crate::tools::SchemaDict;
 
 use super::custom_error::CustomError;
 use super::literal::LiteralLookup;
@@ -249,7 +249,7 @@ struct ChoiceLineErrors<'a> {
 
 enum MaybeErrors<'a> {
     Custom(&'a CustomError),
-    Errors(SmallVec<[ChoiceLineErrors<'a>; UNION_ERR_SMALLVEC_CAPACITY]>),
+    Errors(SmallVec<[ChoiceLineErrors<'a>; SMALL_UNION_THRESHOLD]>),
 }
 
 impl<'a> MaybeErrors<'a> {

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -626,3 +626,52 @@ def test_union_serializer_picks_exact_type_over_subclass_json(
     )
     assert s.to_python(input_value, mode='json') == expected_value
     assert s.to_json(input_value) == json.dumps(expected_value).encode()
+
+
+def test_tagged_union() -> None:
+    @dataclasses.dataclass
+    class ModelA:
+        field: int
+        tag: Literal['a'] = 'a'
+
+    @dataclasses.dataclass
+    class ModelB:
+        field: int
+        tag: Literal['b'] = 'b'
+
+    s = SchemaSerializer(
+        core_schema.tagged_union_schema(
+            choices={
+                'a': core_schema.dataclass_schema(
+                    ModelA,
+                    core_schema.dataclass_args_schema(
+                        'ModelA',
+                        [
+                            core_schema.dataclass_field(name='field', schema=core_schema.int_schema()),
+                            core_schema.dataclass_field(name='tag', schema=core_schema.literal_schema(['a'])),
+                        ],
+                    ),
+                    ['field', 'tag'],
+                ),
+                'b': core_schema.dataclass_schema(
+                    ModelB,
+                    core_schema.dataclass_args_schema(
+                        'ModelB',
+                        [
+                            core_schema.dataclass_field(name='field', schema=core_schema.int_schema()),
+                            core_schema.dataclass_field(name='tag', schema=core_schema.literal_schema(['b'])),
+                        ],
+                    ),
+                    ['field', 'tag'],
+                ),
+            },
+            discriminator='tag',
+        )
+    )
+
+    assert 'TaggedUnionSerializer' in repr(s)
+
+    model_a = ModelA(field=1)
+    model_b = ModelB(field=1)
+    assert s.to_python(model_a) == {'field': 1, 'tag': 'a'}
+    assert s.to_python(model_b) == {'field': 1, 'tag': 'b'}


### PR DESCRIPTION
Implementing a tagged union serializer to unify patterns for union validation and serialization.

Similar to the validation phase, we attempt to check the discriminator value for the data being serialized. If we find it, we select the serializer corresponding to said tag. In most cases, if we have trouble with this, we fall back to standard union serialization in order to preserve backwards compatibility. This is consistent with our general serialization approach, which is to first try with a designated serializer, then just fallback to inference.

I could see a case for adding support for an explicit serialization discriminator at some point, and this is a good step in the direction of supporting that on the core side of things.

A few notes:
* I've removed the `SelfSchema` member of the `Discriminator` enum because its usage was terminated with https://github.com/pydantic/pydantic-core/commit/5efeaf9fe6cb5e57c77e42644387afa781b127e0
* I've moved the `Discriminator` structure to a common directory, as it's used across validators and serializers