### PR TITLE
Try each option in union serializer before inference

### DIFF
--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -103,7 +103,6 @@ impl TypeSerializer for UnionSerializer {
 
         extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
         infer_to_python(value, include, exclude, extra)
-        // Need to push all other errors if serialization didn't succeed
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -112,7 +112,10 @@ impl TypeSerializer for UnionSerializer {
         for comb_serializer in &self.choices {
             match comb_serializer.json_key(key, &new_extra) {
                 Ok(v) => return Ok(v),
-                Err(err) => extra.warnings.custom_warning(err.to_string()),
+                Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(key.py()) {
+                    true => (),
+                    false => extra.warnings.custom_warning(err.to_string()),
+                },
             }
         }
         if self.retry_with_lax_check() {
@@ -120,7 +123,10 @@ impl TypeSerializer for UnionSerializer {
             for comb_serializer in &self.choices {
                 match comb_serializer.json_key(key, &new_extra) {
                     Ok(v) => return Ok(v),
-                    Err(err) => extra.warnings.custom_warning(err.to_string()),
+                    Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(key.py()) {
+                        true => (),
+                        false => extra.warnings.custom_warning(err.to_string()),
+                    },
                 }
             }
         }
@@ -144,7 +150,10 @@ impl TypeSerializer for UnionSerializer {
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {
                 Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-                Err(err) => extra.warnings.custom_warning(err.to_string()),
+                Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(value.py()) {
+                    true => (),
+                    false => extra.warnings.custom_warning(err.to_string()),
+                },
             }
         }
         if self.retry_with_lax_check() {
@@ -152,7 +161,10 @@ impl TypeSerializer for UnionSerializer {
             for comb_serializer in &self.choices {
                 match comb_serializer.to_python(value, include, exclude, &new_extra) {
                     Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-                    Err(err) => extra.warnings.custom_warning(err.to_string()),
+                    Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(value.py()) {
+                        true => (),
+                        false => extra.warnings.custom_warning(err.to_string()),
+                    },
                 }
             }
         }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use crate::build_tools::py_schema_err;
 use crate::definitions::DefinitionsBuilder;
-use crate::tools::SchemaDict;
+use crate::tools::{SchemaDict, UNION_ERR_SMALLVEC_CAPACITY};
 use crate::PydanticSerializationUnexpectedValue;
 
 use super::{
@@ -79,7 +79,7 @@ impl TypeSerializer for UnionSerializer {
         // try the serializers in left to right order with error_on fallback=true
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {
@@ -114,7 +114,7 @@ impl TypeSerializer for UnionSerializer {
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.json_key(key, &new_extra) {
@@ -157,7 +157,7 @@ impl TypeSerializer for UnionSerializer {
         let py = value.py();
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
+        let mut errors: SmallVec<[PyErr; UNION_ERR_SMALLVEC_CAPACITY]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -1,6 +1,7 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
+use smallvec::SmallVec;
 use std::borrow::Cow;
 
 use crate::build_tools::py_schema_err;
@@ -78,7 +79,7 @@ impl TypeSerializer for UnionSerializer {
         // try the serializers in left to right order with error_on fallback=true
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: Vec<PyErr> = Vec::new();
+        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {
@@ -113,7 +114,7 @@ impl TypeSerializer for UnionSerializer {
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: Vec<PyErr> = Vec::new();
+        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.json_key(key, &new_extra) {
@@ -156,7 +157,7 @@ impl TypeSerializer for UnionSerializer {
         let py = value.py();
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
-        let mut errors: Vec<PyErr> = Vec::new();
+        let mut errors: SmallVec<[PyErr; 16]> = SmallVec::new();
 
         for comb_serializer in &self.choices {
             match comb_serializer.to_python(value, include, exclude, &new_extra) {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -146,3 +146,5 @@ pub(crate) fn new_py_string<'py>(py: Python<'py>, s: &str, cache_str: StringCach
         pystring_fast_new(py, s, ascii_only)
     }
 }
+
+pub(crate) const UNION_ERR_SMALLVEC_CAPACITY: usize = 4;

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -12,7 +12,7 @@ use crate::errors::{ErrorType, ToErrorValue, ValError, ValLineError, ValResult};
 use crate::input::{BorrowInput, Input, ValidatedDict};
 use crate::lookup_key::LookupKey;
 use crate::py_gc::PyGcTraverse;
-use crate::tools::SchemaDict;
+use crate::tools::{SchemaDict, UNION_ERR_SMALLVEC_CAPACITY};
 
 use super::custom_error::CustomError;
 use super::literal::LiteralLookup;
@@ -249,7 +249,7 @@ struct ChoiceLineErrors<'a> {
 
 enum MaybeErrors<'a> {
     Custom(&'a CustomError),
-    Errors(SmallVec<[ChoiceLineErrors<'a>; 4]>),
+    Errors(SmallVec<[ChoiceLineErrors<'a>; UNION_ERR_SMALLVEC_CAPACITY]>),
 }
 
 impl<'a> MaybeErrors<'a> {

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -626,3 +626,26 @@ def test_union_serializer_picks_exact_type_over_subclass_json(
     )
     assert s.to_python(input_value, mode='json') == expected_value
     assert s.to_json(input_value) == json.dumps(expected_value).encode()
+
+
+def test_custom_serializer() -> None:
+    s = SchemaSerializer(
+        core_schema.union_schema(
+            [
+                core_schema.dict_schema(
+                    keys_schema=core_schema.any_schema(),
+                    values_schema=core_schema.any_schema(),
+                    serialization=core_schema.plain_serializer_function_ser_schema(lambda x: x['id']),
+                ),
+                core_schema.list_schema(
+                    items_schema=core_schema.dict_schema(
+                        keys_schema=core_schema.any_schema(),
+                        values_schema=core_schema.any_schema(),
+                        serialization=core_schema.plain_serializer_function_ser_schema(lambda x: x['id']),
+                    )
+                ),
+            ]
+        )
+    )
+    assert s.to_python([{'id': 1}, {'id': 2}]) == [1, 2]
+    assert s.to_python({'id': 1}) == 1

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -647,5 +647,6 @@ def test_custom_serializer() -> None:
             ]
         )
     )
+    print(s)
     assert s.to_python([{'id': 1}, {'id': 2}]) == [1, 2]
     assert s.to_python({'id': 1}) == 1


### PR DESCRIPTION
Consider the following case:

```py
from typing import Any
from pydantic import BaseModel, model_serializer


class Item(BaseModel):
    id: int

    @model_serializer
    def dump(self) -> dict[str, Any]:
        return {"id": self.id}

class ItemContainer(BaseModel):
    item_or_items: Item | list[Item]


def test_dump_json() -> None:
    items = [Item(id=i) for i in range(5)]
    ItemContainer(item_or_items=items).model_dump_json()
```

Previously, this used to error with:

```
pydantic_core._pydantic_core.PydanticSerializationError: Error serializing to JSON: PydanticSerializationError: Error calling function `dump`: AttributeError: 'list' object has no attribute 'id'
```

The problem here is that when attempting serialization against various union members, we immediately raised any error that wasn't an unexpected value error from `pydantic-core` (the one that @BoxyUwU just worked on improving).

This is inconsistent with our union validation logic, where we try validation against all union members, and swallow errors until all attempts fail, at which point we raise said errors.

With serialization in general, we're more relaxed, and often warn rather than error.

Now, with these changes, we collect any serialization errors and convert them to warnings if all serialization attempts fail. This helps to unify the logical patterns used for union validation and serialization, and enables more functional union serialization, especially in the case of custom serializers.

Fix https://github.com/pydantic/pydantic/issues/7642