### PR TITLE
Expose wrapped iterator in SerializationIterator

### DIFF
--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -155,6 +155,7 @@ impl TypeSerializer for GeneratorSerializer {
 #[pyclass(module = "pydantic_core._pydantic_core")]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct SerializationIterator {
+    #[pyo3(get)]
     iterator: Py<PyIterator>,
     #[pyo3(get)]
     index: usize,

--- a/tests/serializers/test_generator.py
+++ b/tests/serializers/test_generator.py
@@ -15,7 +15,9 @@ def gen_error(*things):
 
 def test_generator_any_iter():
     s = SchemaSerializer(core_schema.generator_schema(core_schema.any_schema()))
-    gen = s.to_python(gen_ok('a', b'b', 3))
+    gen_inner = gen_ok('a', b'b', 3)
+    gen = s.to_python(gen_inner)
+    assert gen.iterator is gen_inner
     assert repr(gen) == IsStr(regex=r'SerializationIterator\(index=0, iterator=<generator object gen_ok at 0x\w+>\)')
     assert str(gen) == repr(gen)
     assert gen.index == 0
@@ -33,7 +35,9 @@ def test_generator_any_iter():
 
 def test_any_iter():
     s = SchemaSerializer(core_schema.any_schema())
-    gen = s.to_python(gen_ok('a', b'b', 3))
+    gen_inner = gen_ok('a', b'b', 3)
+    gen = s.to_python(gen_inner)
+    assert gen.iterator is gen_inner
     assert repr(gen) == IsStr(regex=r'SerializationIterator\(index=0, iterator=<generator object gen_ok at 0x\w+>\)')
     assert str(gen) == repr(gen)
     assert next(gen) == 'a'
@@ -93,7 +97,9 @@ def test_generator_int():
     ):
         s.to_json(gen_ok(1, 'a'))
 
-    gen = s.to_python(gen_ok(1, 'a'))
+    gen_inner = gen_ok(1, 'a')
+    gen = s.to_python(gen_inner)
+    assert gen.iterator is gen_inner
     assert next(gen) == 1
     with pytest.warns(
         UserWarning, match="Expected `int` but got `str` with value `'a'` - serialized value may not be as expected"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

We're currently working around [pydantic#8907](https://github.com/pydantic/pydantic/issues/8907) by parsing the pointer out of the `repr()`. To make this workaround slightly better, we'd like to expose the wrapped iterator in `SerializationIterator` via `.iterator`.
<!-- Please give a short summary of the changes. -->

## Related issue number

- Related to: https://github.com/pydantic/pydantic/issues/8907
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
