### PR TITLE
Fix float serialization behavior in strict mode

### DIFF
--- a/src/serializers/type_serializers/float.rs
+++ b/src/serializers/type_serializers/float.rs
@@ -14,6 +14,7 @@ use super::{
     infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, IsType, ObType,
     SerCheck, SerMode, TypeSerializer,
 };
+use crate::serializers::errors::PydanticSerializationUnexpectedValue;
 
 #[derive(Debug, Clone)]
 pub struct FloatSerializer {
@@ -74,10 +75,7 @@ impl TypeSerializer for FloatSerializer {
         match extra.ob_type_lookup.is_type(value, ObType::Float) {
             IsType::Exact => Ok(value.into_py(py)),
             IsType::Subclass => match extra.check {
-                SerCheck::Strict => {
-                    extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
-                    infer_to_python(value, include, exclude, extra)
-                }
+                SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_err(None)),
                 SerCheck::Lax | SerCheck::None => match extra.mode {
                     SerMode::Json => {
                         let rust_value = value.extract::<f64>()?;

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -626,3 +626,15 @@ def test_union_serializer_picks_exact_type_over_subclass_json(
     )
     assert s.to_python(input_value, mode='json') == expected_value
     assert s.to_json(input_value) == json.dumps(expected_value).encode()
+
+
+def test_union_float_int() -> None:
+    s = SchemaSerializer(core_schema.union_schema([core_schema.float_schema(), core_schema.int_schema()]))
+
+    assert s.to_python(1) == 1
+    assert json.loads(s.to_json(1)) == 1
+
+    s = SchemaSerializer(core_schema.union_schema([core_schema.int_schema(), core_schema.float_schema()]))
+
+    assert s.to_python(1) == 1
+    assert json.loads(s.to_json(1)) == 1


### PR DESCRIPTION
Fixes this case:

```py
from pydantic import BaseModel, Field
from typing import Union


class FloatThenInt(BaseModel):
    value: Union[float, int, str] = Field(union_mode='smart')


class IntThenFloat(BaseModel):
    value: Union[int, float, str] = Field(union_mode='smart')


float_then_int = FloatThenInt(value=100)
print(f'float then int: {float_then_int.value} {type(float_then_int.value)}')
print(float_then_int.model_dump_json())

int_then_float = IntThenFloat(value=100)
print(f'int then float: {int_then_float.value} {type(int_then_float.value)}')
print(int_then_float.model_dump_json())
```

Note, there may be other cases where we could fix union serialization behavior by introducing these strict checks.

Fix https://github.com/pydantic/pydantic/issues/9417