### PR TITLE
Add to_python(..., serialize_generators=False)

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -266,6 +266,7 @@ class SchemaSerializer:
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
         context: Any | None = None,
+        serialize_generators: bool = True,
     ) -> Any:
         """
         Serialize/marshal a Python object to a Python object including transforming and filtering data.
@@ -289,6 +290,7 @@ class SchemaSerializer:
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
             context: The context to use for serialization, this is passed to functional serializers as
                 [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
+            serialize_generators: Whether to consume and wrap generators. If this is False, generators are treated as an unknown type.
 
         Raises:
             PydanticSerializationError: If serialization fails and no `fallback` function is provided.
@@ -312,6 +314,7 @@ class SchemaSerializer:
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
         context: Any | None = None,
+        serialize_generators: bool = True,
     ) -> bytes:
         """
         Serialize a Python object to JSON including transforming and filtering data.
@@ -334,6 +337,7 @@ class SchemaSerializer:
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
             context: The context to use for serialization, this is passed to functional serializers as
                 [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
+            serialize_generators: Whether to consume and wrap generators. If this is False, generators are treated as an unknown type.
 
         Raises:
             PydanticSerializationError: If serialization fails and no `fallback` function is provided.
@@ -358,6 +362,7 @@ def to_json(
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
     context: Any | None = None,
+    serialize_generators: bool = True,
 ) -> bytes:
     """
     Serialize a Python object to JSON including transforming and filtering data.
@@ -382,6 +387,7 @@ def to_json(
         serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
         context: The context to use for serialization, this is passed to functional serializers as
             [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
+        serialize_generators: Whether to consume and wrap generators. If this is False, generators are treated as an unknown type.
 
     Raises:
         PydanticSerializationError: If serialization fails and no `fallback` function is provided.
@@ -433,6 +439,7 @@ def to_jsonable_python(
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
     context: Any | None = None,
+    serialize_generators: bool = True,
 ) -> Any:
     """
     Serialize/marshal a Python object to a JSON-serializable Python object including transforming and filtering data.
@@ -457,6 +464,7 @@ def to_jsonable_python(
         serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
         context: The context to use for serialization, this is passed to functional serializers as
             [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
+        serialize_generators: Whether to consume and wrap generators. If this is False, generators are treated as an unknown type.
 
     Raises:
         PydanticSerializationError: If serialization fails and no `fallback` function is provided.

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -333,6 +333,7 @@ impl ValidationError {
             None,
             DuckTypingSerMode::SchemaBased,
             None,
+            true,
         );
         let serializer = ValidationErrorSerializer {
             py,

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -89,6 +89,7 @@ impl SerializationState {
         fallback: Option<&'py Bound<'_, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
         context: Option<&'py Bound<'_, PyAny>>,
+        serialize_generators: bool,
     ) -> Extra<'py> {
         Extra::new(
             py,
@@ -105,6 +106,7 @@ impl SerializationState {
             fallback,
             duck_typing_ser_mode,
             context,
+            serialize_generators,
         )
     }
 
@@ -138,6 +140,7 @@ pub(crate) struct Extra<'a> {
     pub fallback: Option<&'a Bound<'a, PyAny>>,
     pub duck_typing_ser_mode: DuckTypingSerMode,
     pub context: Option<&'a Bound<'a, PyAny>>,
+    pub serialize_generators: bool,
 }
 
 impl<'a> Extra<'a> {
@@ -157,6 +160,7 @@ impl<'a> Extra<'a> {
         fallback: Option<&'a Bound<'a, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
         context: Option<&'a Bound<'a, PyAny>>,
+        serialize_generators: bool,
     ) -> Self {
         Self {
             mode,
@@ -176,6 +180,7 @@ impl<'a> Extra<'a> {
             fallback,
             duck_typing_ser_mode,
             context,
+            serialize_generators,
         }
     }
 
@@ -236,6 +241,7 @@ pub(crate) struct ExtraOwned {
     pub fallback: Option<PyObject>,
     duck_typing_ser_mode: DuckTypingSerMode,
     pub context: Option<PyObject>,
+    serialize_generators: bool,
 }
 
 impl ExtraOwned {
@@ -257,6 +263,7 @@ impl ExtraOwned {
             fallback: extra.fallback.map(|model| model.clone().into()),
             duck_typing_ser_mode: extra.duck_typing_ser_mode,
             context: extra.context.map(|model| model.clone().into()),
+            serialize_generators: extra.serialize_generators,
         }
     }
 
@@ -279,6 +286,7 @@ impl ExtraOwned {
             fallback: self.fallback.as_ref().map(|m| m.bind(py)),
             duck_typing_ser_mode: self.duck_typing_ser_mode,
             context: self.context.as_ref().map(|m| m.bind(py)),
+            serialize_generators: self.serialize_generators,
         }
     }
 }

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -64,6 +64,7 @@ impl SchemaSerializer {
         fallback: Option<&'a Bound<'a, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
         context: Option<&'a Bound<'a, PyAny>>,
+        serialize_generators: bool,
     ) -> Extra<'b> {
         Extra::new(
             py,
@@ -80,6 +81,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            serialize_generators,
         )
     }
 }
@@ -107,7 +109,7 @@ impl SchemaSerializer {
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (value, *, mode = None, include = None, exclude = None, by_alias = true,
         exclude_unset = false, exclude_defaults = false, exclude_none = false, round_trip = false, warnings = WarningsArg::Bool(true),
-        fallback = None, serialize_as_any = false, context = None))]
+        fallback = None, serialize_as_any = false, context = None, serialize_generators = true))]
     pub fn to_python(
         &self,
         py: Python,
@@ -124,6 +126,7 @@ impl SchemaSerializer {
         fallback: Option<&Bound<'_, PyAny>>,
         serialize_as_any: bool,
         context: Option<&Bound<'_, PyAny>>,
+        serialize_generators: bool,
     ) -> PyResult<PyObject> {
         let mode: SerMode = mode.into();
         let warnings_mode = match warnings {
@@ -147,6 +150,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            serialize_generators,
         );
         let v = self.serializer.to_python(value, include, exclude, &extra)?;
         warnings.final_check(py)?;
@@ -156,7 +160,7 @@ impl SchemaSerializer {
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = true,
         exclude_unset = false, exclude_defaults = false, exclude_none = false, round_trip = false, warnings = WarningsArg::Bool(true),
-        fallback = None, serialize_as_any = false, context = None))]
+        fallback = None, serialize_as_any = false, context = None, serialize_generators = true))]
     pub fn to_json(
         &self,
         py: Python,
@@ -173,6 +177,7 @@ impl SchemaSerializer {
         fallback: Option<&Bound<'_, PyAny>>,
         serialize_as_any: bool,
         context: Option<&Bound<'_, PyAny>>,
+        serialize_generators: bool,
     ) -> PyResult<PyObject> {
         let warnings_mode = match warnings {
             WarningsArg::Bool(b) => b.into(),
@@ -195,6 +200,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            serialize_generators,
         );
         let bytes = to_json_bytes(
             value,
@@ -244,7 +250,7 @@ impl SchemaSerializer {
 #[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = true,
     exclude_none = false, round_trip = false, timedelta_mode = "iso8601", bytes_mode = "utf8",
     inf_nan_mode = "constants", serialize_unknown = false, fallback = None, serialize_as_any = false,
-    context = None))]
+    context = None, serialize_generators = true))]
 pub fn to_json(
     py: Python,
     value: &Bound<'_, PyAny>,
@@ -261,6 +267,7 @@ pub fn to_json(
     fallback: Option<&Bound<'_, PyAny>>,
     serialize_as_any: bool,
     context: Option<&Bound<'_, PyAny>>,
+    serialize_generators: bool,
 ) -> PyResult<PyObject> {
     let state = SerializationState::new(timedelta_mode, bytes_mode, inf_nan_mode)?;
     let duck_typing_ser_mode = DuckTypingSerMode::from_bool(serialize_as_any);
@@ -274,6 +281,7 @@ pub fn to_json(
         fallback,
         duck_typing_ser_mode,
         context,
+        serialize_generators,
     );
     let serializer = type_serializers::any::AnySerializer.into();
     let bytes = to_json_bytes(value, &serializer, include, exclude, &extra, indent, 1024)?;
@@ -286,7 +294,7 @@ pub fn to_json(
 #[pyfunction]
 #[pyo3(signature = (value, *, include = None, exclude = None, by_alias = true, exclude_none = false, round_trip = false,
     timedelta_mode = "iso8601", bytes_mode = "utf8", inf_nan_mode = "constants", serialize_unknown = false, fallback = None,
-    serialize_as_any = false, context = None))]
+    serialize_as_any = false, context = None, serialize_generators = true))]
 pub fn to_jsonable_python(
     py: Python,
     value: &Bound<'_, PyAny>,
@@ -302,6 +310,7 @@ pub fn to_jsonable_python(
     fallback: Option<&Bound<'_, PyAny>>,
     serialize_as_any: bool,
     context: Option<&Bound<'_, PyAny>>,
+    serialize_generators: bool,
 ) -> PyResult<PyObject> {
     let state = SerializationState::new(timedelta_mode, bytes_mode, inf_nan_mode)?;
     let duck_typing_ser_mode = DuckTypingSerMode::from_bool(serialize_as_any);
@@ -315,6 +324,7 @@ pub fn to_jsonable_python(
         fallback,
         duck_typing_ser_mode,
         context,
+        serialize_generators,
     );
     let v = infer::infer_to_python(value, include, exclude, &extra)?;
     state.final_check(py)?;

--- a/tests/serializers/test_generator.py
+++ b/tests/serializers/test_generator.py
@@ -1,8 +1,8 @@
 import pytest
 from dirty_equals import IsStr
 
-from pydantic_core import SchemaSerializer, core_schema
 import pydantic_core
+from pydantic_core import SchemaSerializer, core_schema
 
 
 def gen_ok(*things):
@@ -170,7 +170,7 @@ def test_generator_no_ser_any():
         assert s.to_json(iter(['a', b'b', 3]), serialize_generators=False) == b'["a","b",3]'
     assert s.to_json(iter(['a', b'b', 3]), serialize_generators=False, fallback=list) == b'["a","b",3]'
     assert s.to_json(gen_ok('a', b'b', 3), serialize_generators=False, fallback=list) == b'["a","b",3]'
-    assert s.to_python(gen_ok('a', b'b', 3), serialize_generators=False, fallback=list) == ["a", b"b", 3]
+    assert s.to_python(gen_ok('a', b'b', 3), serialize_generators=False, fallback=list) == ['a', b'b', 3]
 
     msg = 'Expected `generator` but got `int` with value `4` - serialized value may not be as expected'
     with pytest.warns(UserWarning, match=msg):
@@ -199,9 +199,16 @@ def test_no_ser_custom_serializer():
     assert s.to_python(gen_ok(1, 2), mode='json', serialize_generators=False, fallback=list) == [1, 2]
     assert s.to_json(gen_ok(1, 2), serialize_generators=False, fallback=list) == b'[1,2]'
 
+
 def test_no_ser_to_json():
     with pytest.raises(ValueError, match='Unable to serialize unknown type'):
         assert pydantic_core.to_jsonable_python(iter([]), serialize_generators=False)
-    assert pydantic_core.to_jsonable_python(iter([]), serialize_generators=False, serialize_unknown=True) == IsStr(regex=r'<list_iterator object at 0x\w+>')
-    assert pydantic_core.to_json(iter([]), serialize_generators=False, serialize_unknown=True).decode('utf8') == IsStr(regex=r'"<list_iterator object at 0x\w+>"')
-    assert pydantic_core.to_json(iter([]), serialize_generators=False, serialize_unknown=True).decode('utf8') == IsStr(regex=r'"<list_iterator object at 0x\w+>"')
+    assert pydantic_core.to_jsonable_python(iter([]), serialize_generators=False, serialize_unknown=True) == IsStr(
+        regex=r'<(list_|sequence)iterator object at 0x\w+>'
+    )
+    assert pydantic_core.to_json(iter([]), serialize_generators=False, serialize_unknown=True).decode('utf8') == IsStr(
+        regex=r'"<(list_|sequence)iterator object at 0x\w+>"'
+    )
+    assert pydantic_core.to_json(iter([]), serialize_generators=False, serialize_unknown=True).decode('utf8') == IsStr(
+        regex=r'"<(list_|sequence)iterator object at 0x\w+>"'
+    )

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -99,6 +99,7 @@ a = A()
                     None,
                     false,
                     None,
+                    true,
                 )
                 .unwrap();
             let serialized: &[u8] = serialized.extract(py).unwrap();
@@ -203,6 +204,7 @@ dump_json_input_2 = {'a': 'something'}
                     None,
                     false,
                     None,
+                    true,
                 )
                 .unwrap();
             let repr = format!("{}", serialization_result.bind(py).repr().unwrap());
@@ -224,6 +226,7 @@ dump_json_input_2 = {'a': 'something'}
                     None,
                     false,
                     None,
+                    true,
                 )
                 .unwrap();
             let repr = format!("{}", serialization_result.bind(py).repr().unwrap());


### PR DESCRIPTION
This disables wrapping/consuming generators while serializing, while calling the fallback function on them.

In many cases, we want to implement some custom serialization logic for generators (such as io.IOBase), instead of consuming them whole.

<!-- Thank you for your contribution! -->

## Change Summary

Add `serialize_generators` parameter to `to_python`, `to_json`, etc. This changes the serialization to handle generators as if they were 'unknown' types. By default, this calls `fallback` or leaves them alone in `to_python`, and calls `fallback` in `to_json` or errors there.

## Related issue number

pydantic-core part of a fix for https://github.com/pydantic/pydantic/issues/8907 . If this change gets merged, we'll submit another PR to `pydantic` to have `model_dump` forward a `serialize_generators` argument.
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
