### PR TITLE
stop clone-ing serializers

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -14,7 +14,7 @@ use crate::tools::SchemaDict;
 use super::errors::py_err_se_err;
 use super::Extra;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct ComputedFields(Vec<ComputedField>);
 
 impl ComputedFields {
@@ -109,7 +109,7 @@ impl ComputedFields {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct ComputedField {
     property_name: String,
     property_name_py: Py<PyString>,

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -20,7 +20,7 @@ use super::shared::PydanticSerializer;
 use super::shared::{CombinedSerializer, TypeSerializer};
 
 /// representation of a field for serialization
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct SerField {
     pub key_py: Py<PyString>,
     pub alias: Option<String>,
@@ -93,7 +93,7 @@ pub(super) enum FieldsMode {
 }
 
 /// General purpose serializer for fields - used by dataclasses, models and typed_dicts
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GeneralFieldsSerializer {
     fields: AHashMap<String, SerField>,
     computed_fields: Option<ComputedFields>,

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -266,7 +266,7 @@ pub(crate) fn infer_to_python_known(
             ObType::Generator => {
                 let iter = super::type_serializers::generator::SerializationIterator::new(
                     value.downcast()?,
-                    super::type_serializers::any::AnySerializer.into(),
+                    super::type_serializers::any::AnySerializer::get(),
                     SchemaFilter::default(),
                     include,
                     exclude,

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -40,7 +40,7 @@ macro_rules! combined_serializer {
         find_only: {$($builder:path;)*}
         both: {$($b_key:ident: $b_serializer:path;)*}
     ) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         #[enum_dispatch]
         pub enum CombinedSerializer {
             $($e_key($e_serializer),)*
@@ -256,7 +256,7 @@ impl PyGcTraverse for CombinedSerializer {
 }
 
 #[enum_dispatch(CombinedSerializer)]
-pub(crate) trait TypeSerializer: Send + Sync + Clone + Debug {
+pub(crate) trait TypeSerializer: Send + Sync + Debug {
     fn to_python(
         &self,
         value: &Bound<'_, PyAny>,

--- a/src/serializers/type_serializers/any.rs
+++ b/src/serializers/type_serializers/any.rs
@@ -1,4 +1,7 @@
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    sync::{Arc, OnceLock},
+};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -13,6 +16,13 @@ use super::{
 
 #[derive(Debug, Clone, Default)]
 pub struct AnySerializer;
+
+impl AnySerializer {
+    pub fn get() -> &'static Arc<CombinedSerializer> {
+        static ANY_SERIALIZER: OnceLock<Arc<CombinedSerializer>> = OnceLock::new();
+        ANY_SERIALIZER.get_or_init(|| Arc::new(Self.into()))
+    }
+}
 
 impl BuildSerializer for AnySerializer {
     const EXPECTED_TYPE: &'static str = "any";

--- a/src/serializers/type_serializers/bytes.rs
+++ b/src/serializers/type_serializers/bytes.rs
@@ -11,7 +11,7 @@ use super::{
     TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BytesSerializer {
     bytes_mode: BytesMode,
 }

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -61,7 +61,7 @@ impl BuildSerializer for DataclassArgsBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DataclassSerializer {
     class: Py<PyType>,
     serializer: Box<CombinedSerializer>,

--- a/src/serializers/type_serializers/datetime_etc.rs
+++ b/src/serializers/type_serializers/datetime_etc.rs
@@ -38,7 +38,7 @@ fn downcast_date_reject_datetime<'a, 'py>(py_date: &'a Bound<'py, PyAny>) -> PyR
 
 macro_rules! build_serializer {
     ($struct_name:ident, $expected_type:literal, $downcast:path, $convert_func:ident $(, $json_check_func:ident)?) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $struct_name;
 
         impl BuildSerializer for $struct_name {

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -11,7 +11,7 @@ use super::{
     infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DecimalSerializer {}
 
 impl BuildSerializer for DecimalSerializer {

--- a/src/serializers/type_serializers/definitions.rs
+++ b/src/serializers/type_serializers/definitions.rs
@@ -12,7 +12,7 @@ use crate::tools::SchemaDict;
 
 use super::{py_err_se_err, BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DefinitionsSerializerBuilder;
 
 impl BuildSerializer for DefinitionsSerializerBuilder {

--- a/src/serializers/type_serializers/dict.rs
+++ b/src/serializers/type_serializers/dict.rs
@@ -15,7 +15,7 @@ use super::{
     SchemaFilter, SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DictSerializer {
     key_serializer: Box<CombinedSerializer>,
     value_serializer: Box<CombinedSerializer>,

--- a/src/serializers/type_serializers/enum_.rs
+++ b/src/serializers/type_serializers/enum_.rs
@@ -15,7 +15,7 @@ use super::simple::IntSerializer;
 use super::string::StrSerializer;
 use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct EnumSerializer {
     class: Py<PyType>,
     serializer: Option<Box<CombinedSerializer>>,

--- a/src/serializers/type_serializers/float.rs
+++ b/src/serializers/type_serializers/float.rs
@@ -15,7 +15,7 @@ use super::{
     SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FloatSerializer {
     inf_nan_mode: InfNanMode,
 }

--- a/src/serializers/type_serializers/format.rs
+++ b/src/serializers/type_serializers/format.rs
@@ -53,7 +53,7 @@ impl WhenUsed {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FormatSerializer {
     format_func: PyObject,
     formatting_string: Py<PyString>,
@@ -161,7 +161,7 @@ impl TypeSerializer for FormatSerializer {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ToStringSerializer {
     when_used: WhenUsed,
 }

--- a/src/serializers/type_serializers/json.rs
+++ b/src/serializers/type_serializers/json.rs
@@ -16,7 +16,7 @@ use super::{
     TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct JsonSerializer {
     serializer: Box<CombinedSerializer>,
 }

--- a/src/serializers/type_serializers/json_or_python.rs
+++ b/src/serializers/type_serializers/json_or_python.rs
@@ -8,7 +8,7 @@ use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
 use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct JsonOrPythonSerializer {
     json: Box<CombinedSerializer>,
     python: Box<CombinedSerializer>,

--- a/src/serializers/type_serializers/list.rs
+++ b/src/serializers/type_serializers/list.rs
@@ -15,7 +15,7 @@ use super::{
     SchemaFilter, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ListSerializer {
     item_serializer: Box<CombinedSerializer>,
     filter: SchemaFilter<usize>,

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -16,7 +16,7 @@ use super::{
     SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LiteralSerializer {
     expected_int: AHashSet<i64>,
     expected_str: AHashSet<String>,

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -72,7 +72,7 @@ impl BuildSerializer for ModelFieldsBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ModelSerializer {
     class: Py<PyType>,
     serializer: Box<CombinedSerializer>,

--- a/src/serializers/type_serializers/nullable.rs
+++ b/src/serializers/type_serializers/nullable.rs
@@ -9,7 +9,7 @@ use crate::tools::SchemaDict;
 
 use super::{infer_json_key_known, BuildSerializer, CombinedSerializer, Extra, IsType, ObType, TypeSerializer};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NullableSerializer {
     serializer: Box<CombinedSerializer>,
 }

--- a/src/serializers/type_serializers/set_frozenset.rs
+++ b/src/serializers/type_serializers/set_frozenset.rs
@@ -17,7 +17,7 @@ use super::{
 
 macro_rules! build_serializer {
     ($struct_name:ident, $expected_type:literal, $py_type:ty) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $struct_name {
             item_serializer: Box<CombinedSerializer>,
             name: String,

--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -13,7 +13,7 @@ use super::{
     SerCheck, SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NoneSerializer;
 
 impl BuildSerializer for NoneSerializer {
@@ -87,7 +87,7 @@ impl TypeSerializer for NoneSerializer {
 
 macro_rules! build_simple_serializer {
     ($struct_name:ident, $expected_type:literal, $rust_type:ty, $ob_type:expr, $key_method:ident, $subtypes_allowed:expr) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $struct_name;
 
         impl $struct_name {

--- a/src/serializers/type_serializers/string.rs
+++ b/src/serializers/type_serializers/string.rs
@@ -10,7 +10,7 @@ use super::{
     IsType, ObType, SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StrSerializer;
 
 impl StrSerializer {

--- a/src/serializers/type_serializers/timedelta.rs
+++ b/src/serializers/type_serializers/timedelta.rs
@@ -12,7 +12,7 @@ use super::{
     TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TimeDeltaSerializer {
     timedelta_mode: TimedeltaMode,
 }

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -17,7 +17,7 @@ use super::{
     PydanticSerializer, SchemaFilter, SerMode, TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TupleSerializer {
     serializers: Vec<CombinedSerializer>,
     variadic_item_index: Option<usize>,

--- a/src/serializers/type_serializers/typed_dict.rs
+++ b/src/serializers/type_serializers/typed_dict.rs
@@ -11,7 +11,7 @@ use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, SerField};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TypedDictBuilder;
 
 impl BuildSerializer for TypedDictBuilder {

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -14,7 +14,7 @@ use super::{
     TypeSerializer,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UnionSerializer {
     choices: Vec<CombinedSerializer>,
     name: String,

--- a/src/serializers/type_serializers/url.rs
+++ b/src/serializers/type_serializers/url.rs
@@ -14,7 +14,7 @@ use super::{
 
 macro_rules! build_serializer {
     ($struct_name:ident, $expected_type:literal, $extract:ty) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $struct_name;
 
         impl BuildSerializer for $struct_name {

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -18,7 +18,7 @@ pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
     Ok(uuid.to_string())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UuidSerializer;
 
 impl_py_gc_traverse!(UuidSerializer {});

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -10,7 +10,7 @@ use crate::validators::DefaultType;
 
 use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WithDefaultSerializer {
     default: DefaultType,
     serializer: Box<CombinedSerializer>,


### PR DESCRIPTION
## Change Summary

In general, cloning serializers is a potentially expensive runtime operation; we should instead store `Arc<CombinedSerializer>` and cheaply clone that where needed.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
