### PR TITLE
For missing fields, we don't warn on `exclude_`, so don't warn on `exclude`

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -206,7 +206,7 @@ impl GeneralFieldsSerializer {
 
         if extra.check.enabled()
             // If any of these are true we can't count fields
-            && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none)
+            && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none || exclude.is_some())
             // Check for missing fields, we can't have extra fields here
             && self.required_fields > used_req_fields
         {

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import platform
+import warnings
 from random import randint
 from typing import Any, ClassVar, Dict
 
@@ -1080,3 +1081,23 @@ def test_extra_custom_serializer():
     m.__pydantic_extra__ = {'extra': 'extra'}
 
     assert s.to_python(m) == {'extra': 'extra bam!'}
+
+
+def test_no_warn_on_exclude() -> None:
+    warnings.simplefilter('error')
+
+    s = SchemaSerializer(
+        core_schema.model_schema(
+            BasicModel,
+            core_schema.model_fields_schema(
+                {
+                    'a': core_schema.model_field(core_schema.int_schema()),
+                    'b': core_schema.model_field(core_schema.int_schema()),
+                }
+            ),
+        )
+    )
+
+    value = BasicModel(a=0, b=1)
+    assert s.to_python(value, exclude={'b'}) == {'a': 0}
+    assert s.to_python(value, mode='json', exclude={'b'}) == {'a': 0}


### PR DESCRIPTION
Inspired by @adriangb's https://github.com/pydantic/pydantic-core/pull/727

Fix https://github.com/pydantic/pydantic/issues/9882