### PR TITLE
Use `typing_extensions.TypedDict` on Python < 3.12

### DIFF
--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -34,7 +34,7 @@ if _sys.version_info < (3, 11):
 else:
     from typing import NotRequired as _NotRequired
 
-if _sys.version_info < (3, 9):
+if _sys.version_info < (3, 12):
     from typing_extensions import TypedDict as _TypedDict
 else:
     from typing import TypedDict as _TypedDict


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary
Use `typing_extensions.TypedDict` in `pydantic_core.__init__.py` on Python < 3.12.  The current use of typing.TypedDict` in `pydantic_core.__init__.py` on Python 3.9 to 3.11 is inconsistent Pydantic. For further information visit https://errors.pydantic.dev/2.8/u/typed-dict-version

Without the change in this PR, the following code will result in the subsequent error.

```py
from pydantic import BaseModel
from pydantic_core import ErrorDetails


class Foo(BaseModel):
    a: ErrorDetails
```

```console
pydantic.errors.PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
```


Please review.


## Checklist

* [ ] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
