### PR TITLE
Introduce `exactness` into `Decimal` validation logic

### DIFF
--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -98,18 +98,7 @@ pub trait Input<'py>: fmt::Debug + ToPyObject {
 
     fn validate_float(&self, strict: bool) -> ValMatch<EitherFloat<'_>>;
 
-    fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
-        if strict {
-            self.strict_decimal(py)
-        } else {
-            self.lax_decimal(py)
-        }
-    }
-    fn strict_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>>;
-    #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn lax_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
-        self.strict_decimal(py)
-    }
+    fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>>;
 
     type Dict<'a>: ValidatedDict<'py>
     where

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -98,16 +98,16 @@ pub trait Input<'py>: fmt::Debug + ToPyObject {
 
     fn validate_float(&self, strict: bool) -> ValMatch<EitherFloat<'_>>;
 
-    fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValResult<Bound<'py, PyAny>> {
+    fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         if strict {
             self.strict_decimal(py)
         } else {
             self.lax_decimal(py)
         }
     }
-    fn strict_decimal(&self, py: Python<'py>) -> ValResult<Bound<'py, PyAny>>;
+    fn strict_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>>;
     #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn lax_decimal(&self, py: Python<'py>) -> ValResult<Bound<'py, PyAny>> {
+    fn lax_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         self.strict_decimal(py)
     }
 

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -165,7 +165,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    fn strict_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+    fn validate_decimal(&self, _strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
             JsonValue::Float(f) => {
                 create_decimal(&PyString::new_bound(py, &f.to_string()), self).map(ValidationMatch::strict)
@@ -374,8 +374,8 @@ impl<'py> Input<'py> for str {
         str_as_float(self, self).map(ValidationMatch::lax)
     }
 
-    fn strict_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
-        create_decimal(self.to_object(py).bind(py), self).map(ValidationMatch::strict)
+    fn validate_decimal(&self, _strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+        create_decimal(self.to_object(py).bind(py), self).map(ValidationMatch::lax)
     }
 
     type Dict<'a> = Never;

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -171,7 +171,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
                 create_decimal(&PyString::new_bound(py, &f.to_string()), self).map(ValidationMatch::strict)
             }
             JsonValue::Str(..) | JsonValue::Int(..) | JsonValue::BigInt(..) => {
-                create_decimal(self.to_object(py).bind(py), self).map(ValidationMatch::lax)
+                create_decimal(self.to_object(py).bind(py), self).map(ValidationMatch::strict)
             }
             _ => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),
         }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -248,7 +248,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                     str_as_int(self, s)
                 } else if self.is_exact_instance_of::<PyFloat>() {
                     float_as_int(self, self.extract::<f64>()?)
-                } else if let Ok(decimal) = self.strict_decimal(self.py()) {
+                } else if let Ok(decimal) = self.validate_decimal(strict, self.py()) {
                     decimal_as_int(self, &decimal.into_inner())
                 } else if let Ok(float) = self.extract::<f64>() {
                     float_as_int(self, float)
@@ -307,51 +307,38 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::FloatType, self))
     }
 
-    fn strict_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+    fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         let decimal_type = get_decimal_type(py);
+
         // Fast path for existing decimal objects
         if self.is_exact_instance(decimal_type) {
-            return Ok(ValidationMatch::exact(self.to_owned()));
-        }
-
-        // Try subclasses of decimals, they will be upcast to Decimal
-        if self.is_instance(decimal_type)? {
-            return create_decimal(self, self).map(ValidationMatch::strict);
-        }
-
-        Err(ValError::new(
-            ErrorType::IsInstanceOf {
-                class: decimal_type
-                    .qualname()
-                    .and_then(|name| name.extract())
-                    .unwrap_or_else(|_| "Decimal".to_owned()),
-                context: None,
-            },
-            self,
-        ))
-    }
-
-    fn lax_decimal(&self, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
-        let decimal_type = get_decimal_type(py);
-        // Fast path for existing decimal objects
-        if self.is_exact_instance(decimal_type) {
-            return Ok(ValidationMatch::exact(self.to_owned().clone()));
-        }
-
-        // TODO: I can see the case for int and float being strict - wdyt @davidhewitt?
-        return if self.is_instance_of::<PyString>()
-            || (self.is_instance_of::<PyInt>() && !self.is_instance_of::<PyBool>())
-        {
-            // checking isinstance for str / int / bool is fast compared to decimal / float
-            create_decimal(self, self).map(ValidationMatch::lax)
+            Ok(ValidationMatch::exact(self.to_owned().clone()))
         } else if self.is_instance(decimal_type)? {
-            // upcast subclasses to decimal
+            // Upcast subclasses to decimal
             create_decimal(self, self).map(ValidationMatch::strict)
-        } else if self.is_instance_of::<PyFloat>() {
-            create_decimal(self.str()?.as_any(), self).map(ValidationMatch::lax)
         } else {
-            Err(ValError::new(ErrorTypeDefaults::DecimalType, self))
-        };
+            if strict {
+                return Err(ValError::new(
+                    ErrorType::IsInstanceOf {
+                        class: decimal_type
+                            .qualname()
+                            .and_then(|name| name.extract())
+                            .unwrap_or_else(|_| "Decimal".to_owned()),
+                        context: None,
+                    },
+                    self,
+                ));
+            }
+            if self.is_instance_of::<PyString>() || (self.is_instance_of::<PyInt>() && !self.is_instance_of::<PyBool>())
+            {
+                // Checking isinstance for str / int / bool is fast compared to decimal / float
+                create_decimal(self, self).map(ValidationMatch::lax)
+            } else if self.is_instance_of::<PyFloat>() {
+                create_decimal(self.str()?.as_any(), self).map(ValidationMatch::lax)
+            } else {
+                Err(ValError::new(ErrorTypeDefaults::DecimalType, self))
+            }
+        }
     }
 
     type Dict<'a> = GenericPyMapping<'a, 'py> where Self: 'a;

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -248,7 +248,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                     str_as_int(self, s)
                 } else if self.is_exact_instance_of::<PyFloat>() {
                     float_as_int(self, self.extract::<f64>()?)
-                } else if let Ok(decimal) = self.validate_decimal(strict, self.py()) {
+                } else if let Ok(decimal) = self.validate_decimal(true, self.py()) {
                     decimal_as_int(self, &decimal.into_inner())
                 } else if let Ok(float) = self.extract::<f64>() {
                     float_as_int(self, float)

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -141,7 +141,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         }
     }
 
-    fn strict_decimal(&self, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+    fn validate_decimal(&self, _strict: bool, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
             Self::String(s) => create_decimal(s, self).map(ValidationMatch::strict),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -141,9 +141,9 @@ impl<'py> Input<'py> for StringMapping<'py> {
         }
     }
 
-    fn strict_decimal(&self, _py: Python<'py>) -> ValResult<Bound<'py, PyAny>> {
+    fn strict_decimal(&self, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
-            Self::String(s) => create_decimal(s, self),
+            Self::String(s) => create_decimal(s, self).map(ValidationMatch::strict),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),
         }
     }

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -122,7 +122,7 @@ impl Validator for DecimalValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
-        let decimal = input.validate_decimal(state.strict_or(self.strict), py)?;
+        let decimal = input.validate_decimal(state.strict_or(self.strict), py)?.unpack(state);
 
         if !self.allow_inf_nan || self.check_digits {
             if !decimal.call_method0(intern!(py, "is_finite"))?.extract()? {


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/10142
Fix https://github.com/pydantic/pydantic/issues/9795

Introducing `exactness` into various validation cases makes smart union validation better - we no longer match str input as `exact`, but rather `lax`.