### PR TITLE
Allow subclassing ValidationError and PydanticCustomError

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -736,20 +736,19 @@ class SchemaError(Exception):
             A list of [`ErrorDetails`][pydantic_core.ErrorDetails] for each error in the schema.
         """
 
-@final
 class ValidationError(ValueError):
     """
     `ValidationError` is the exception raised by `pydantic-core` when validation fails, it contains a list of errors
     which detail why validation failed.
     """
-
-    @staticmethod
+    @classmethod
     def from_exception_data(
+        cls,
         title: str,
         line_errors: list[InitErrorDetails],
         input_type: Literal['python', 'json'] = 'python',
         hide_input: bool = False,
-    ) -> ValidationError:
+    ) -> Self:
         """
         Python constructor for a Validation Error.
 
@@ -820,7 +819,6 @@ class ValidationError(ValueError):
         before the first validation error is created.
         """
 
-@final
 class PydanticCustomError(ValueError):
     def __new__(
         cls, error_type: LiteralString, message_template: LiteralString, context: dict[str, Any] | None = None

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -54,7 +54,7 @@ impl PydanticUseDefault {
     }
 }
 
-#[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core")]
+#[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core", subclass)]
 #[derive(Debug, Clone, Default)]
 pub struct PydanticCustomError {
     error_type: String,

--- a/tests/test_custom_errors.py
+++ b/tests/test_custom_errors.py
@@ -1,0 +1,149 @@
+from typing import Any, LiteralString, Self, override
+from unittest import TestCase
+from unittest.mock import ANY
+
+import pytest
+
+from pydantic_core import ErrorDetails, InitErrorDetails, PydanticCustomError, ValidationError
+
+
+def test_validation_error_subclassable():
+    """Assert subclassable and inheritance hierarchy as expected"""
+
+    class CustomValidationError(ValidationError):
+        pass
+
+    with pytest.raises(ValidationError) as exception_info:
+        raise CustomValidationError.from_exception_data(
+            'My CustomError',
+            [
+                InitErrorDetails(
+                    type='value_error',
+                    loc=('myField',),
+                    msg='This is my custom error.',
+                    input='something invalid',
+                    ctx={
+                        'myField': 'something invalid',
+                        'error': "'something invalid' is not a valid value for 'myField'",
+                    },
+                )
+            ],
+        )
+    assert isinstance(exception_info.value, CustomValidationError)
+
+
+def test_validation_error_loc_overrides():
+    """Override methods in rust pyclass and assert change in behavior: ValidationError.errors"""
+
+    class CustomLocOverridesError(ValidationError):
+        """Unnests some errors"""
+
+        @override
+        def errors(
+            self, *, include_url: bool = True, include_context: bool = True, include_input: bool = True
+        ) -> list[ErrorDetails]:
+            errors = super().errors(
+                include_url=include_url, include_context=include_context, include_input=include_input
+            )
+            return [error | {'loc': error['loc'][1:]} for error in errors]
+
+    with pytest.raises(CustomLocOverridesError) as exception_info:
+        raise CustomLocOverridesError.from_exception_data(
+            'My CustomError',
+            [
+                InitErrorDetails(
+                    type='value_error',
+                    loc=(
+                        'hide_this',
+                        'myField',
+                    ),
+                    msg='This is my custom error.',
+                    input='something invalid',
+                    ctx={
+                        'myField': 'something invalid',
+                        'error': "'something invalid' is not a valid value for 'myField'",
+                    },
+                ),
+                InitErrorDetails(
+                    type='value_error',
+                    loc=(
+                        'hide_this',
+                        'myFieldToo',
+                    ),
+                    msg='This is my custom error.',
+                    input='something invalid',
+                    ctx={
+                        'myFieldToo': 'something invalid',
+                        'error': "'something invalid' is not a valid value for 'myFieldToo'",
+                    },
+                ),
+            ],
+        )
+
+    TestCase().assertCountEqual(
+        exception_info.value.errors(),
+        [
+            {
+                'type': 'value_error',
+                'loc': ('myField',),
+                'msg': "Value error, 'something invalid' is not a valid value for 'myField'",
+                'input': 'something invalid',
+                'ctx': {
+                    'error': "'something invalid' is not a valid value for 'myField'",
+                    'myField': 'something invalid',
+                },
+                'url': ANY,
+            },
+            {
+                'type': 'value_error',
+                'loc': ('myFieldToo',),
+                'msg': "Value error, 'something invalid' is not a valid value for 'myFieldToo'",
+                'input': 'something invalid',
+                'ctx': {
+                    'error': "'something invalid' is not a valid value for 'myFieldToo'",
+                    'myFieldToo': 'something invalid',
+                },
+                'url': ANY,
+            },
+        ],
+    )
+
+
+def test_custom_pydantic_error_subclassable():
+    """Assert subclassable and inheritance hierarchy as expected"""
+
+    class MyCustomError(PydanticCustomError):
+        pass
+
+    with pytest.raises(PydanticCustomError) as exception_info:
+        raise MyCustomError(
+            'not_my_custom_thing',
+            "value is not compatible with my custom field, got '{wrong_value}'",
+            {'wrong_value': 'non compatible value'},
+        )
+    assert isinstance(exception_info.value, MyCustomError)
+
+
+def test_custom_pydantic_error_overrides():
+    """Override methods in rust pyclass and assert change in behavior: PydanticCustomError.__new__"""
+
+    class CustomErrorWithCustomTemplate(PydanticCustomError):
+        @override
+        def __new__(
+            cls, error_type: LiteralString, my_custom_setting: str, context: dict[str, Any] | None = None
+        ) -> Self:
+            message_template = (
+                "'{my_custom_value}' setting requires a specific my custom field value, got '{wrong_value}'"
+            )
+            context = context | {'my_custom_value': my_custom_setting}
+            return super().__new__(cls, error_type, message_template, context)
+
+    with pytest.raises(CustomErrorWithCustomTemplate) as exception_info:
+        raise CustomErrorWithCustomTemplate(
+            'not_my_custom_thing', 'my_setting', {'wrong_value': 'non compatible value'}
+        )
+
+    assert (
+        exception_info.value.message()
+        == "'my_setting' setting requires a specific my custom field value, got 'non compatible value'"
+    )

--- a/tests/test_custom_errors.py
+++ b/tests/test_custom_errors.py
@@ -1,8 +1,9 @@
-from typing import Any, LiteralString, Self, override
+from typing import Any
 from unittest import TestCase
 from unittest.mock import ANY
 
 import pytest
+from typing_extensions import LiteralString, Self, override
 
 from pydantic_core import ErrorDetails, InitErrorDetails, PydanticCustomError, ValidationError
 

--- a/tests/test_custom_errors.py
+++ b/tests/test_custom_errors.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 from unittest import TestCase
 from unittest.mock import ANY
 
@@ -42,11 +42,11 @@ def test_validation_error_loc_overrides():
         @override
         def errors(
             self, *, include_url: bool = True, include_context: bool = True, include_input: bool = True
-        ) -> list[ErrorDetails]:
+        ) -> List[ErrorDetails]:
             errors = super().errors(
                 include_url=include_url, include_context=include_context, include_input=include_input
             )
-            return [error | {'loc': error['loc'][1:]} for error in errors]
+            return [{**error, 'loc': error['loc'][1:]} for error in errors]
 
     with pytest.raises(CustomLocOverridesError) as exception_info:
         raise CustomLocOverridesError.from_exception_data(
@@ -136,7 +136,7 @@ def test_custom_pydantic_error_overrides():
             message_template = (
                 "'{my_custom_value}' setting requires a specific my custom field value, got '{wrong_value}'"
             )
-            context = context | {'my_custom_value': my_custom_setting}
+            context = {**context, 'my_custom_value': my_custom_setting}
             return super().__new__(cls, error_type, message_template, context)
 
     with pytest.raises(CustomErrorWithCustomTemplate) as exception_info:

--- a/tests/test_custom_errors.py
+++ b/tests/test_custom_errors.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 from unittest import TestCase
 from unittest.mock import ANY
 
@@ -131,7 +131,7 @@ def test_custom_pydantic_error_overrides():
     class CustomErrorWithCustomTemplate(PydanticCustomError):
         @override
         def __new__(
-            cls, error_type: LiteralString, my_custom_setting: str, context: dict[str, Any] | None = None
+            cls, error_type: LiteralString, my_custom_setting: str, context: Optional[Dict[str, Any]] = None
         ) -> Self:
             message_template = (
                 "'{my_custom_value}' setting requires a specific my custom field value, got '{wrong_value}'"


### PR DESCRIPTION
## Change Summary

- Add ValidationError.__new__
- Change from_exception_data to classmethod
- remove @final decorators.

## Related issue number
https://github.com/pydantic/pydantic/issues/9686
#1380
https://github.com/pydantic/pydantic/issues/8092


## Checklist
* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt