### PR TITLE
Introduce a schema variant to reuse Validators, Serializers and CoreSchema

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1437,6 +1437,30 @@ def uuid_schema(
     )
 
 
+class NestedSchema(TypedDict, total=False):
+    type: Required[Literal['nested']]
+    cls: Required[Type[Any]]
+    # Should return `(CoreSchema, SchemaValidator, SchemaSerializer)` but this requires a forward ref
+    get_info: Required[Callable[[], Any]]
+    metadata: Dict[str, Any]
+    serialization: SerSchema
+
+def nested_schema(
+    *,
+    cls: Type[Any],
+    get_info: Callable[[], Any],
+    metadata: Dict[str, Any] | None = None,
+    serialization: SerSchema | None = None
+) -> NestedSchema:
+    return _dict_not_none(
+        type='nested',
+        cls=cls,
+        get_info=get_info,
+        metadata=metadata,
+        serialization=serialization
+    )
+
+
 class IncExSeqSerSchema(TypedDict, total=False):
     type: Required[Literal['include-exclude-sequence']]
     include: Set[int]
@@ -3866,6 +3890,7 @@ if not MYPY:
         DefinitionReferenceSchema,
         UuidSchema,
         ComplexSchema,
+        NestedSchema,
     ]
 elif False:
     CoreSchema: TypeAlias = Mapping[str, Any]
@@ -3922,6 +3947,7 @@ CoreSchemaType = Literal[
     'definition-ref',
     'uuid',
     'complex',
+    'nested',
 ]
 
 CoreSchemaFieldType = Literal['model-field', 'dataclass-field', 'typed-dict-field', 'computed-field']

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -143,6 +143,7 @@ combined_serializer! {
         Recursive: super::type_serializers::definitions::DefinitionRefSerializer;
         Tuple: super::type_serializers::tuple::TupleSerializer;
         Complex: super::type_serializers::complex::ComplexSerializer;
+        Nested: super::type_serializers::nested::NestedSerializer;
     }
 }
 
@@ -254,6 +255,7 @@ impl PyGcTraverse for CombinedSerializer {
             CombinedSerializer::Tuple(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Uuid(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Complex(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Nested(inner) => inner.py_gc_traverse(visit),
         }
     }
 }

--- a/src/serializers/type_serializers/mod.rs
+++ b/src/serializers/type_serializers/mod.rs
@@ -16,6 +16,7 @@ pub mod json_or_python;
 pub mod list;
 pub mod literal;
 pub mod model;
+pub mod nested;
 pub mod nullable;
 pub mod other;
 pub mod set_frozenset;

--- a/src/serializers/type_serializers/nested.rs
+++ b/src/serializers/type_serializers/nested.rs
@@ -1,0 +1,135 @@
+use std::{borrow::Cow, sync::OnceLock};
+
+use pyo3::{
+    intern,
+    types::{PyAnyMethods, PyDict, PyDictMethods, PyTuple, PyType},
+    Bound, Py, PyAny, PyObject, PyResult, Python,
+};
+
+use crate::{
+    definitions::DefinitionsBuilder,
+    serializers::{
+        shared::{BuildSerializer, TypeSerializer},
+        CombinedSerializer, Extra,
+    },
+    SchemaSerializer,
+};
+
+#[derive(Debug)]
+pub struct NestedSerializer {
+    model: Py<PyType>,
+    name: String,
+    get_serializer: Py<PyAny>,
+    serializer: OnceLock<PyResult<Py<SchemaSerializer>>>,
+}
+
+impl_py_gc_traverse!(NestedSerializer {
+    model,
+    get_serializer,
+    serializer
+});
+
+impl BuildSerializer for NestedSerializer {
+    const EXPECTED_TYPE: &'static str = "nested";
+
+    fn build(
+        schema: &Bound<'_, PyDict>,
+        _config: Option<&Bound<'_, PyDict>>,
+        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
+    ) -> PyResult<CombinedSerializer> {
+        let py = schema.py();
+
+        let get_serializer = schema
+            .get_item(intern!(py, "get_info"))?
+            .expect("Invalid core schema for `nested` type, no `get_info`")
+            .unbind();
+
+        let model = schema
+            .get_item(intern!(py, "cls"))?
+            .expect("Invalid core schema for `nested` type, no `model`")
+            .downcast::<PyType>()
+            .expect("Invalid core schema for `nested` type, not a `PyType`")
+            .clone();
+
+        let name = model.getattr(intern!(py, "__name__"))?.extract()?;
+
+        Ok(CombinedSerializer::Nested(NestedSerializer {
+            model: model.clone().unbind(),
+            name,
+            get_serializer,
+            serializer: OnceLock::new(),
+        }))
+    }
+}
+
+impl NestedSerializer {
+    fn nested_serializer<'py>(&self, py: Python<'py>) -> PyResult<&Py<SchemaSerializer>> {
+        self.serializer
+            .get_or_init(|| {
+                Ok(self
+                    .get_serializer
+                    .bind(py)
+                    .call((), None)?
+                    .downcast::<PyTuple>()?
+                    .get_item(2)?
+                    .downcast::<SchemaSerializer>()?
+                    .clone()
+                    .unbind())
+            })
+            .as_ref()
+            .map_err(|e| e.clone_ref(py))
+    }
+}
+
+impl TypeSerializer for NestedSerializer {
+    fn to_python(
+        &self,
+        value: &Bound<'_, PyAny>,
+        include: Option<&Bound<'_, PyAny>>,
+        exclude: Option<&Bound<'_, PyAny>>,
+        mut extra: &Extra,
+    ) -> PyResult<PyObject> {
+        let mut guard = extra.recursion_guard(value, self.model.as_ptr() as usize)?;
+
+        self.nested_serializer(value.py())?
+            .bind(value.py())
+            .get()
+            .serializer
+            .to_python(value, include, exclude, guard.state())
+    }
+
+    fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
+        self.nested_serializer(key.py())?
+            .bind(key.py())
+            .get()
+            .serializer
+            .json_key(key, extra)
+    }
+
+    fn serde_serialize<S: serde::ser::Serializer>(
+        &self,
+        value: &Bound<'_, PyAny>,
+        serializer: S,
+        include: Option<&Bound<'_, PyAny>>,
+        exclude: Option<&Bound<'_, PyAny>>,
+        mut extra: &Extra,
+    ) -> Result<S::Ok, S::Error> {
+        use super::py_err_se_err;
+
+        let mut guard = extra
+            .recursion_guard(value, self.model.as_ptr() as usize)
+            .map_err(py_err_se_err)?;
+
+        self.nested_serializer(value.py())
+            // FIXME(BoxyUwU): Don't unwrap this
+            .unwrap()
+            .bind(value.py())
+            .get()
+            .serializer
+            .serde_serialize(value, serializer, include, exclude, guard.state())
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+}

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -49,6 +49,7 @@ mod list;
 mod literal;
 mod model;
 mod model_fields;
+mod nested;
 mod none;
 mod nullable;
 mod set;
@@ -584,6 +585,7 @@ pub fn build_validator(
         definitions::DefinitionRefValidator,
         definitions::DefinitionsValidatorBuilder,
         complex::ComplexValidator,
+        nested::NestedValidator,
     )
 }
 
@@ -738,6 +740,8 @@ pub enum CombinedValidator {
     // input dependent
     JsonOrPython(json_or_python::JsonOrPython),
     Complex(complex::ComplexValidator),
+    // Schema for reusing an existing validator
+    Nested(nested::NestedValidator),
 }
 
 /// This trait must be implemented by all validators, it allows various validators to be accessed consistently,

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -77,7 +77,7 @@ impl BuildValidator for ModelValidator {
 
         let class: Bound<'_, PyType> = schema.get_as_req(intern!(py, "cls"))?;
         let sub_schema = schema.get_as_req(intern!(py, "schema"))?;
-        let validator = build_validator(&sub_schema, config.as_ref(), definitions)?;
+        let validator: CombinedValidator = build_validator(&sub_schema, config.as_ref(), definitions)?;
         let name = class.getattr(intern!(py, "__name__"))?.extract()?;
 
         Ok(Self {

--- a/src/validators/nested.rs
+++ b/src/validators/nested.rs
@@ -1,0 +1,115 @@
+use std::sync::OnceLock;
+
+use pyo3::{
+    intern,
+    types::{PyAnyMethods, PyDict, PyDictMethods, PyTuple, PyTupleMethods, PyType},
+    Bound, Py, PyAny, PyObject, PyResult, Python,
+};
+
+use crate::{
+    definitions::DefinitionsBuilder,
+    errors::{ErrorTypeDefaults, ValError, ValResult},
+    input::Input,
+    recursion_guard::RecursionGuard,
+};
+
+use super::{BuildValidator, CombinedValidator, SchemaValidator, ValidationState, Validator};
+
+#[derive(Debug)]
+pub struct NestedValidator {
+    cls: Py<PyType>,
+    name: String,
+    get_validator: Py<PyAny>,
+    validator: OnceLock<PyResult<Py<SchemaValidator>>>,
+}
+
+impl_py_gc_traverse!(NestedValidator {
+    cls,
+    get_validator,
+    validator
+});
+
+impl BuildValidator for NestedValidator {
+    const EXPECTED_TYPE: &'static str = "nested";
+
+    fn build(
+        schema: &Bound<'_, PyDict>,
+        _config: Option<&Bound<'_, PyDict>>,
+        _definitions: &mut DefinitionsBuilder<super::CombinedValidator>,
+    ) -> PyResult<super::CombinedValidator> {
+        let py = schema.py();
+
+        let get_validator = schema.get_item(intern!(py, "get_info"))?.unwrap().unbind();
+
+        let cls = schema
+            .get_item(intern!(py, "cls"))?
+            .unwrap()
+            .downcast::<PyType>()?
+            .clone();
+
+        let name = cls.getattr(intern!(py, "__name__"))?.extract()?;
+
+        Ok(CombinedValidator::Nested(NestedValidator {
+            cls: cls.clone().unbind(),
+            name,
+            get_validator: get_validator,
+            validator: OnceLock::new(),
+        }))
+    }
+}
+
+impl NestedValidator {
+    fn nested_validator<'py>(&self, py: Python<'py>) -> PyResult<&Py<SchemaValidator>> {
+        self.validator
+            .get_or_init(|| {
+                Ok(self
+                    .get_validator
+                    .bind(py)
+                    .call((), None)?
+                    .downcast::<PyTuple>()?
+                    .get_item(1)?
+                    .downcast::<SchemaValidator>()?
+                    .clone()
+                    .unbind())
+            })
+            .as_ref()
+            .map_err(|e| e.clone_ref(py))
+    }
+}
+
+impl Validator for NestedValidator {
+    fn validate<'py>(
+        &self,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<PyObject> {
+        let Some(id) = input.as_python().map(py_identity) else {
+            return self
+                .nested_validator(py)?
+                .bind(py)
+                .get()
+                .validator
+                .validate(py, input, state);
+        };
+
+        // Python objects can be cyclic, so need recursion guard
+        let Ok(mut guard) = RecursionGuard::new(state, id, self.cls.as_ptr() as usize) else {
+            return Err(ValError::new(ErrorTypeDefaults::RecursionLoop, input));
+        };
+
+        self.nested_validator(py)?
+            .bind(py)
+            .get()
+            .validator
+            .validate(py, input, guard.state())
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn py_identity(obj: &Bound<'_, PyAny>) -> usize {
+    obj.as_ptr() as usize
+}


### PR DESCRIPTION
Introduces a `nested` `CoreSchema` variant that reuses the specified model's schema/validator/serializer. As an example, the core schema for the following pydantic models:
```python
class A(BaseModel):
    field3: 'B'

class B(BaseModel):
    field1: list[A]

class Wrapper(BaseModel):
    a: A
    b: B

```
```
{
    'type': 'model',
    'cls': <class '__main__.A'>,
    'schema': {
        'type': 'model-fields',
        'fields': {
            'field3': {
                'type': 'model-field',
                'schema': {
                    'type': 'nested',
                    'cls': <class '__main__.B'>,
                    'get_info': <function GenerateSchema._generate_schema_from_property.<locals>.get_model_info at 0x7f9ec650be20>
                }
            }
        },
        'model_name': 'A'
    },
    'ref': '__main__.A:20628480'
}
{
    'type': 'model',
    'cls': <class '__main__.B'>,
    'schema': {
        'type': 'model-fields',
        'fields': {
            'field1': {
                'type': 'model-field',
                'schema': {
                    'type': 'list',
                    'items_schema': {
                        'type': 'nested',
                        'cls': <class '__main__.A'>,
                        'get_info': <function GenerateSchema._generate_schema_from_property.<locals>.get_model_info at 0x7f9ec650ba60>
                    }
                }
            }
        },
        'model_name': 'B'
    },
    'ref': '__main__.B:20632592'
}
{
    'type': 'model',
    'cls': <class '__main__.Wrapper'>,
    'schema': {
        'type': 'model-fields',
        'fields': {
            'a': {
                'type': 'model-field',
                'schema': {
                    'type': 'nested',
                    'cls': <class '__main__.A'>,
                    'get_info': <function GenerateSchema._generate_schema_from_property.<locals>.get_model_info at 0x7f9ec650bec0>
                }
            },
            'b': {
                'type': 'model-field',
                'schema': {
                    'type': 'nested',
                    'cls': <class '__main__.B'>,
                    'get_info': <function GenerateSchema._generate_schema_from_property.<locals>.get_model_info at 0x7f9ec65c8040>
                }
            }
        },
        'model_name': 'Wrapper'
    },
    'ref': '__main__.Wrapper:20635728'
}
```

<details><summary>Compare to the schema generated on main</summary>
<p>

```
{
    'type': 'definitions',
    'schema': {'type': 'definition-ref', 'schema_ref': '__main__.A:37460656'},
    'definitions': [
        {
            'type': 'model',
            'cls': <class '__main__.A'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field3': {'type': 'model-field', 'schema': {'type': 'definition-ref', 'schema_ref': '__main__.B:37433488'}}},
                'model_name': 'A'
            },
            'ref': '__main__.A:37460656'
        },
        {
            'type': 'model',
            'cls': <class '__main__.B'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field1': {'type': 'model-field', 'schema': {'type': 'list', 'items_schema': {'type': 'definition-ref', 'schema_ref': '__main__.A:37460656'}}}},
                'model_name': 'B'
            },
            'ref': '__main__.B:37433488'
        }
    ]
}
{
    'type': 'definitions',
    'schema': {'type': 'definition-ref', 'schema_ref': '__main__.B:37433488'},
    'definitions': [
        {
            'type': 'model',
            'cls': <class '__main__.A'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field3': {'type': 'model-field', 'schema': {'type': 'definition-ref', 'schema_ref': '__main__.B:37433488'}}},
                'model_name': 'A'
            },
            'ref': '__main__.A:37460656'
        },
        {
            'type': 'model',
            'cls': <class '__main__.B'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field1': {'type': 'model-field', 'schema': {'type': 'list', 'items_schema': {'type': 'definition-ref', 'schema_ref': '__main__.A:37460656'}}}},
                'model_name': 'B'
            },
            'ref': '__main__.B:37433488'
        }
    ]
}
{
    'type': 'definitions',
    'schema': {
        'type': 'model',
        'cls': <class '__main__.Wrapper'>,
        'schema': {
            'type': 'model-fields',
            'fields': {
                'a': {'type': 'model-field', 'schema': {'type': 'definition-ref', 'schema_ref': '__main__.A:37460656'}},
                'b': {'type': 'model-field', 'schema': {'type': 'definition-ref', 'schema_ref': '__main__.B:37433488'}}
            },
            'model_name': 'Wrapper'
        },
        'ref': '__main__.Wrapper:37440960'
    },
    'definitions': [
        {
            'type': 'model',
            'cls': <class '__main__.A'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field3': {'type': 'model-field', 'schema': {'type': 'definition-ref', 'schema_ref': '__main__.B:37433488'}}},
                'model_name': 'A'
            },
            'ref': '__main__.A:37460656'
        },
        {
            'type': 'model',
            'cls': <class '__main__.B'>,
            'schema': {
                'type': 'model-fields',
                'fields': {'field1': {'type': 'model-field', 'schema': {'type': 'list', 'items_schema': {'type': 'definition-ref', 'schema_ref': '__main__.A:37460656'}}}},
                'model_name': 'B'
            },
            'ref': '__main__.B:37433488'
        }
    ]
}
```

</p>
</details>

This is similar to the current definitions-ref setup but it has a number of benefits:
- The nested model does not need to have its schema built already in order to reuse it. Currently sometimes (I think) we build the core schema for a model twice if it has not been built by the first time it is referenced in another model.
- The nested models schema is not inlined so the built `CoreSchema` is smaller which means walking it can be significantly faster in cases with lots of nested models when we do not need to recurse into `nested-model
- There is no "flattening" step after generating the schema like with `definitions` schemas where we walk the built schema and ensure that any nested models' schemas does not have a `definitions` schema. This is what I believe is a significant portion of the performance wins since we now have to do significantly less complex tree traversals over python datastructures in python.
- We can reuse validators and serializers with this setup which in theory should result in less memory overhead in cases with deeply recursive model definitions where the innermost model may have its validator constructed significantly 
more times than once

See pydantic/pydantic#10246 for the implementation of generating this new schema variant and also the benchmak results.

## Before Merging

- We don't propagate errors out of `serde_serialize`
- The `PyGcTraversible` implementation for `Result` ignores the error variant as `PyErr` is not traversible
- Make sure that the `nested` schema variant is defined flexibly enough to be useable for more than just models.
- Make sure that pydantic/pydantic#10246 can be merged with positive perf wins otherwise there's no point :3

---

There is an issue pydantic/pydantic#10394 tracking future work on the pydantic side to use this schema more 