### PR TITLE
Support `BigInt` serialization for `int` subclasses

### DIFF
--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -45,6 +45,7 @@ pub(crate) fn infer_to_python_known(
     mut extra: &Extra,
 ) -> PyResult<PyObject> {
     let py = value.py();
+
     let mode = extra.mode;
     let mut guard = match extra.recursion_guard(value, INFER_DEF_REF_ID) {
         Ok(v) => v,
@@ -110,6 +111,7 @@ pub(crate) fn infer_to_python_known(
         );
         serializer.serializer.to_python(value, include, exclude, &extra)
     };
+
     let value = match extra.mode {
         SerMode::Json => match ob_type {
             // `bool` and `None` can't be subclasses, `ObType::Int`, `ObType::Float`, `ObType::Str` refer to exact types

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use num_bigint::BigInt;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -44,7 +45,6 @@ pub(crate) fn infer_to_python_known(
     mut extra: &Extra,
 ) -> PyResult<PyObject> {
     let py = value.py();
-
     let mode = extra.mode;
     let mut guard = match extra.recursion_guard(value, INFER_DEF_REF_ID) {
         Ok(v) => v,
@@ -110,16 +110,20 @@ pub(crate) fn infer_to_python_known(
         );
         serializer.serializer.to_python(value, include, exclude, &extra)
     };
-
     let value = match extra.mode {
         SerMode::Json => match ob_type {
             // `bool` and `None` can't be subclasses, `ObType::Int`, `ObType::Float`, `ObType::Str` refer to exact types
             ObType::None | ObType::Bool | ObType::Int | ObType::Str => value.into_py(py),
             // have to do this to make sure subclasses of for example str are upcast to `str`
-            ObType::IntSubclass => match extract_i64(value) {
-                Some(v) => v.into_py(py),
-                None => return py_err!(PyTypeError; "expected int, got {}", safe_repr(value)),
-            },
+            ObType::IntSubclass => {
+                if let Some(v) = extract_i64(value) {
+                    v.into_py(py)
+                } else if let Ok(b) = value.extract::<BigInt>() {
+                    b.into_py(py)
+                } else {
+                    return py_err!(PyTypeError; "Expected int, got {}", safe_repr(value));
+                }
+            }
             ObType::Float | ObType::FloatSubclass => {
                 let v = value.extract::<f64>()?;
                 if (v.is_nan() || v.is_infinite()) && extra.config.inf_nan_mode == InfNanMode::Null {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Modified the `infer.rs` `infer_to_python_known` function to support the inference of BigInt/int beyond the i64 limit for IntSubclass object type when `SerMode=Json`.

My approach is similar to code inside `return_enums.extract_bound`. I attempted to import that function into `infer.rs` and re-use it but couldn't get it working so I duplicated the `if` logics instead (first time to rust). As this was my first time working with Rust, I’m uncertain whether re-using it is the best solution especially since it doesn’t seem to align precisely with the purpose of return_enums.extract_bound.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix https://github.com/pydantic/pydantic/issues/10152
- Custom integer type serialization TypeError #10152




## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle