### PR TITLE
Improve test_valid_complex_string_with_space() xfail condition

### DIFF
--- a/tests/validators/test_complex.py
+++ b/tests/validators/test_complex.py
@@ -85,7 +85,7 @@ def test_complex_strict(input_value, expected):
 
 
 @pytest.mark.xfail(
-    platform.python_implementation() == 'PyPy' and sys.version_info < (3, 10),
+    platform.python_implementation() == 'PyPy' and sys.pypy_version_info < (7, 3, 17),
     reason='PyPy cannot process this string due to a bug, even if this string is considered valid in python',
 )
 def test_valid_complex_string_with_space():


### PR DESCRIPTION
## Change Summary

Improve the xfail condition for `test_valid_complex_string_with_space()` to use PyPy version rather than Python version.  This corresponds to the fact that the issue was fixed in 7.3.17 releases.  The other condition works only because PyPy3.9 is no longer being developed, and therefore did not get a 7.3.17 release.

## Related issue number

This improves #1439, as discussed in comments.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
