### PR TITLE
Do not require padding when decoding base64 bytes

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -401,6 +401,12 @@ def test_json_bytes_base64_round_trip():
     assert v.validate_json(b'{"key":' + encoded_url + b'}') == {'key': data}
 
 
+def test_json_bytes_base64_no_padding():
+    v = SchemaValidator({'type': 'bytes'}, {'val_json_bytes': 'base64'})
+    base_64_without_padding = 'bm8tcGFkZGluZw'
+    assert v.validate_json(json.dumps(base_64_without_padding)) == b'no-padding'
+
+
 def test_json_bytes_base64_invalid():
     v = SchemaValidator({'type': 'bytes'}, {'val_json_bytes': 'base64'})
     wrong_input = 'wrong!'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Padding is optional in a base64 encoding, so I would expect pedantic to allow such strings when parsing base64 data. Because this is a relative small change I did not create an issue before opening this pull request. 

If you think this behaviour is not desired at all or not without a config option then feel free to close this pull request.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

ref #1308 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt