### PR TITLE
Clean up serialization warnings for invalid data in unions

### DIFF
--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -392,7 +392,15 @@ impl CollectWarnings {
         if value.is_none() {
             Ok(())
         } else if extra.check.enabled() {
-            Err(PydanticSerializationUnexpectedValue::new_err(None))
+            let type_name = value
+                .get_type()
+                .qualname()
+                .unwrap_or_else(|_| PyString::new_bound(value.py(), "<unknown python object>"));
+
+            let value_str = truncate_safe_repr(value, None);
+            Err(PydanticSerializationUnexpectedValue::new_err(Some(format!(
+                "Expected `{field_type}` but got `{type_name}` with value `{value_str}` - serialized value may not be as expected"
+            ))))
         } else {
             self.fallback_warning(field_type, value);
             Ok(())

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -226,9 +226,12 @@ impl GeneralFieldsSerializer {
                 None => "<unknown python object>".to_string(),
             };
 
-            Err(PydanticSerializationUnexpectedValue::new_err(Some(format!(
-                "Expected {required_fields} fields but got {used_req_fields} for type `{type_name}` with value `{field_value}` - serialized value may not be as expected."
-            ))))
+            extra.warnings.custom_warning(
+                format!(
+                    "Expected {required_fields} fields but got {used_req_fields} for type `{type_name}` with value `{field_value}` - serialized value may not be as expected."
+                ),
+            );
+            Ok(output_dict)
         } else {
             Ok(output_dict)
         }

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -226,12 +226,9 @@ impl GeneralFieldsSerializer {
                 None => "<unknown python object>".to_string(),
             };
 
-            extra.warnings.custom_warning(
-                format!(
-                    "Expected {required_fields} fields but got {used_req_fields} for type `{type_name}` with value `{field_value}` - serialized value may not be as expected."
-                ),
-            );
-            Ok(output_dict)
+            Err(PydanticSerializationUnexpectedValue::new_err(Some(format!(
+                "Expected {required_fields} fields but got {used_req_fields} for type `{type_name}` with value `{field_value}` - serialized value may not be as expected."
+            ))))
         } else {
             Ok(output_dict)
         }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -8,7 +8,6 @@ use std::borrow::Cow;
 use crate::build_tools::py_schema_err;
 use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
-use crate::serializers::type_serializers::py_err_se_err;
 use crate::tools::{truncate_safe_repr, SchemaDict};
 use crate::PydanticSerializationUnexpectedValue;
 
@@ -77,7 +76,6 @@ fn to_python(
     exclude: Option<&Bound<'_, PyAny>>,
     extra: &Extra,
     choices: &[CombinedSerializer],
-    name: &str,
     retry_with_lax_check: bool,
 ) -> PyResult<PyObject> {
     // try the serializers in left to right order with error_on fallback=true
@@ -88,22 +86,15 @@ fn to_python(
     for comb_serializer in choices {
         match comb_serializer.to_python(value, include, exclude, &new_extra) {
             Ok(v) => return Ok(v),
-            Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(value.py()) {
-                true => (),
-                false => errors.push(err),
-            },
+            Err(err) => errors.push(err),
         }
     }
 
     if retry_with_lax_check {
         new_extra.check = SerCheck::Lax;
         for comb_serializer in choices {
-            match comb_serializer.to_python(value, include, exclude, &new_extra) {
-                Ok(v) => return Ok(v),
-                Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(value.py()) {
-                    true => (),
-                    false => errors.push(err),
-                },
+            if let Ok(v) = comb_serializer.to_python(value, include, exclude, &new_extra) {
+                return Ok(v);
             }
         }
     }
@@ -112,7 +103,6 @@ fn to_python(
         extra.warnings.custom_warning(err.to_string());
     }
 
-    extra.warnings.on_fallback_py(name, value, extra)?;
     infer_to_python(value, include, exclude, extra)
 }
 
@@ -120,7 +110,6 @@ fn json_key<'a>(
     key: &'a Bound<'_, PyAny>,
     extra: &Extra,
     choices: &[CombinedSerializer],
-    name: &str,
     retry_with_lax_check: bool,
 ) -> PyResult<Cow<'a, str>> {
     let mut new_extra = extra.clone();
@@ -140,12 +129,8 @@ fn json_key<'a>(
     if retry_with_lax_check {
         new_extra.check = SerCheck::Lax;
         for comb_serializer in choices {
-            match comb_serializer.json_key(key, &new_extra) {
-                Ok(v) => return Ok(v),
-                Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(key.py()) {
-                    true => (),
-                    false => errors.push(err),
-                },
+            if let Ok(v) = comb_serializer.json_key(key, &new_extra) {
+                return Ok(v);
             }
         }
     }
@@ -154,7 +139,6 @@ fn json_key<'a>(
         extra.warnings.custom_warning(err.to_string());
     }
 
-    extra.warnings.on_fallback_py(name, key, extra)?;
     infer_json_key(key, extra)
 }
 
@@ -166,7 +150,6 @@ fn serde_serialize<S: serde::ser::Serializer>(
     exclude: Option<&Bound<'_, PyAny>>,
     extra: &Extra,
     choices: &[CombinedSerializer],
-    name: &str,
     retry_with_lax_check: bool,
 ) -> Result<S::Ok, S::Error> {
     let py = value.py();
@@ -187,12 +170,8 @@ fn serde_serialize<S: serde::ser::Serializer>(
     if retry_with_lax_check {
         new_extra.check = SerCheck::Lax;
         for comb_serializer in choices {
-            match comb_serializer.to_python(value, include, exclude, &new_extra) {
-                Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-                Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(py) {
-                    true => (),
-                    false => errors.push(err),
-                },
+            if let Ok(v) = comb_serializer.to_python(value, include, exclude, &new_extra) {
+                return infer_serialize(v.bind(py), serializer, None, None, extra);
             }
         }
     }
@@ -201,7 +180,6 @@ fn serde_serialize<S: serde::ser::Serializer>(
         extra.warnings.custom_warning(err.to_string());
     }
 
-    extra.warnings.on_fallback_ser::<S>(name, value, extra)?;
     infer_serialize(value, serializer, include, exclude, extra)
 }
 
@@ -219,13 +197,12 @@ impl TypeSerializer for UnionSerializer {
             exclude,
             extra,
             &self.choices,
-            self.get_name(),
             self.retry_with_lax_check(),
         )
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        json_key(key, extra, &self.choices, self.get_name(), self.retry_with_lax_check())
+        json_key(key, extra, &self.choices, self.retry_with_lax_check())
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(
@@ -243,7 +220,6 @@ impl TypeSerializer for UnionSerializer {
             exclude,
             extra,
             &self.choices,
-            self.get_name(),
             self.retry_with_lax_check(),
         )
     }
@@ -313,8 +289,6 @@ impl TypeSerializer for TaggedUnionSerializer {
         exclude: Option<&Bound<'_, PyAny>>,
         extra: &Extra,
     ) -> PyResult<PyObject> {
-        let py = value.py();
-
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
 
@@ -325,15 +299,14 @@ impl TypeSerializer for TaggedUnionSerializer {
 
                 match serializer.to_python(value, include, exclude, &new_extra) {
                     Ok(v) => return Ok(v),
-                    Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(py) {
-                        true => {
-                            if self.retry_with_lax_check() {
-                                new_extra.check = SerCheck::Lax;
-                                return serializer.to_python(value, include, exclude, &new_extra);
+                    Err(_) => {
+                        if self.retry_with_lax_check() {
+                            new_extra.check = SerCheck::Lax;
+                            if let Ok(v) = serializer.to_python(value, include, exclude, &new_extra) {
+                                return Ok(v);
                             }
                         }
-                        false => return Err(err),
-                    },
+                    }
                 }
             }
         }
@@ -344,13 +317,11 @@ impl TypeSerializer for TaggedUnionSerializer {
             exclude,
             extra,
             &self.choices,
-            self.get_name(),
             self.retry_with_lax_check(),
         )
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        let py = key.py();
         let mut new_extra = extra.clone();
         new_extra.check = SerCheck::Strict;
 
@@ -361,20 +332,19 @@ impl TypeSerializer for TaggedUnionSerializer {
 
                 match serializer.json_key(key, &new_extra) {
                     Ok(v) => return Ok(v),
-                    Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(py) {
-                        true => {
-                            if self.retry_with_lax_check() {
-                                new_extra.check = SerCheck::Lax;
-                                return serializer.json_key(key, &new_extra);
+                    Err(_) => {
+                        if self.retry_with_lax_check() {
+                            new_extra.check = SerCheck::Lax;
+                            if let Ok(v) = serializer.json_key(key, &new_extra) {
+                                return Ok(v);
                             }
                         }
-                        false => return Err(err),
-                    },
+                    }
                 }
             }
         }
 
-        json_key(key, extra, &self.choices, self.get_name(), self.retry_with_lax_check())
+        json_key(key, extra, &self.choices, self.retry_with_lax_check())
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(
@@ -396,18 +366,14 @@ impl TypeSerializer for TaggedUnionSerializer {
 
                 match selected_serializer.to_python(value, include, exclude, &new_extra) {
                     Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-                    Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(py) {
-                        true => {
-                            if self.retry_with_lax_check() {
-                                new_extra.check = SerCheck::Lax;
-                                match selected_serializer.to_python(value, include, exclude, &new_extra) {
-                                    Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-                                    Err(err) => return Err(py_err_se_err(err)),
-                                }
+                    Err(_) => {
+                        if self.retry_with_lax_check() {
+                            new_extra.check = SerCheck::Lax;
+                            if let Ok(v) = selected_serializer.to_python(value, include, exclude, &new_extra) {
+                                return infer_serialize(v.bind(py), serializer, None, None, extra);
                             }
                         }
-                        false => return Err(py_err_se_err(err)),
-                    },
+                    }
                 }
             }
         }
@@ -419,7 +385,6 @@ impl TypeSerializer for TaggedUnionSerializer {
             exclude,
             extra,
             &self.choices,
-            self.get_name(),
             self.retry_with_lax_check(),
         )
     }

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -9,7 +9,6 @@ use crate::build_tools::py_schema_err;
 use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
 use crate::tools::{truncate_safe_repr, SchemaDict};
-use crate::PydanticSerializationUnexpectedValue;
 
 use super::{
     infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, SerCheck,
@@ -119,10 +118,7 @@ fn json_key<'a>(
     for comb_serializer in choices {
         match comb_serializer.json_key(key, &new_extra) {
             Ok(v) => return Ok(v),
-            Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(key.py()) {
-                true => (),
-                false => errors.push(err),
-            },
+            Err(err) => errors.push(err),
         }
     }
 
@@ -160,10 +156,7 @@ fn serde_serialize<S: serde::ser::Serializer>(
     for comb_serializer in choices {
         match comb_serializer.to_python(value, include, exclude, &new_extra) {
             Ok(v) => return infer_serialize(v.bind(py), serializer, None, None, extra),
-            Err(err) => match err.is_instance_of::<PydanticSerializationUnexpectedValue>(py) {
-                true => (),
-                false => errors.push(err),
-            },
+            Err(err) => errors.push(err),
         }
     }
 

--- a/tests/serializers/test_model.py
+++ b/tests/serializers/test_model.py
@@ -15,7 +15,6 @@ from dirty_equals import IsJson
 
 from pydantic_core import (
     PydanticSerializationError,
-    PydanticSerializationUnexpectedValue,
     SchemaSerializer,
     SchemaValidator,
     core_schema,
@@ -1150,8 +1149,6 @@ def test_warn_on_missing_field() -> None:
         )
     )
 
-    with pytest.raises(
-        PydanticSerializationUnexpectedValue, match='Expected 2 fields but got 1 for type `.*AModel` with value `.*`.+'
-    ):
+    with pytest.warns(UserWarning, match='Expected 2 fields but got 1 for type `.*AModel` with value `.*`.+'):
         value = BasicModel(root=AModel(type='a'))
         s.to_python(value)

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
-import re
 import uuid
+import warnings
 from decimal import Decimal
 from typing import Any, ClassVar, Union
 
@@ -32,9 +32,17 @@ def test_union_bool_int(input_value, expected_value, bool_case_label, int_case_l
 
 def test_union_error():
     s = SchemaSerializer(core_schema.union_schema([core_schema.bool_schema(), core_schema.int_schema()]))
-    msg = "Expected `Union[bool, int]` but got `str` with value `'a string'` - serialized value may not be as expected"
-    with pytest.warns(UserWarning, match=re.escape(msg)):
-        assert s.to_python('a string') == 'a string'
+
+    messages = [
+        "Expected `bool` but got `str` with value `'a string'` - serialized value may not be as expected",
+        "Expected `int` but got `str` with value `'a string'` - serialized value may not be as expected",
+    ]
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        s.to_python('a string')
+        for m in messages:
+            assert m in str(w[0].message)
 
 
 class ModelA:


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/10363
Fix https://github.com/pydantic/pydantic/issues/10344

This makes it such that we report all warnings associated with union serialization. This is similar to union validation, where the errors can be quite verbose. One example that clearly demonstrates the change is the following. We used to raise one error saying `expected Union[A, B], got C` (or something similar). Now we report on all warnings.

```py
from pydantic import BaseModel, TypeAdapter

class A(BaseModel):
    a: int

class B(BaseModel):
    b: int

class C(BaseModel):
    c: int

ta = TypeAdapter(A | B)
print(ta.dump_python(C(c=1)))

"""
PydanticSerializationUnexpectedValue: Expected `A` but got `C` with value `C(c=1)` - serialized value may not be as expected
PydanticSerializationUnexpectedValue: Expected `B` but got `C` with value `C(c=1)` - serialized value may not be as expected
"""
```

I think there's still more to improve here - we should probably group the errors more intuitively, and use shared logic across much of the `PydanticSerializationUnexpectedValue` initialization steps. Also, in the long term, we should remove the fallback to the union serializer for tagged unions and jump straight to inference instead. Will probably retain this for backwards compatibility for a few minor versions as we iron out small issues like this one.