### PR TITLE
Fix variance issue in `_IncEx` type alias, only allow `True`

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Mapping
 from typing import Any, Callable, Generic, Literal, TypeVar, final
 
 from _typeshed import SupportsAllComparisons
@@ -237,7 +238,7 @@ class SchemaValidator:
             `None` if the schema has no default value, otherwise a [`Some`][pydantic_core.Some] containing the default.
         """
 
-_IncEx: TypeAlias = set[int] | set[str] | dict[int, _IncEx | bool] | dict[str, _IncEx | bool]
+_IncEx: TypeAlias = set[int] | set[str] | Mapping[int, _IncEx | Literal[True]] | Mapping[str, _IncEx | Literal[True]]
 
 @final
 class SchemaSerializer:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Part of https://github.com/pydantic/pydantic/issues/10335

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
