### PR TITLE
Support wider variety of enum validation cases

### DIFF
--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -123,7 +123,6 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         if let Some(v) = T::validate_value(py, input, &self.lookup, strict)? {
             return Ok(v);
         } else if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
-            // as a last result, just try to initialize the enum with the input
             return Ok(res);
         } else if let Some(ref missing) = self.missing {
             let enum_value = missing.bind(py).call1((input.to_object(py),)).map_err(|_| {

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -1,7 +1,6 @@
 // Validator for Enums, so named because "enum" is a reserved keyword in Rust.
 use std::marker::PhantomData;
 
-use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
@@ -9,7 +8,7 @@ use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
 use crate::build_tools::{is_strict, py_schema_err};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
-use crate::tools::{safe_repr, SchemaDict};
+use crate::tools::SchemaDict;
 
 use super::is_instance::class_repr;
 use super::literal::{expected_repr_name, LiteralLookup};
@@ -119,33 +118,11 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         } else if let Some(v) = T::validate_value(py, input, &self.lookup, strict)? {
             state.floor_exactness(Exactness::Lax);
             return Ok(v);
-        } else if let Some(ref missing) = self.missing {
+        } else if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
             state.floor_exactness(Exactness::Lax);
-            let enum_value = missing.bind(py).call1((input.to_object(py),)).map_err(|_| {
-                ValError::new(
-                    ErrorType::Enum {
-                        expected: self.expected_repr.clone(),
-                        context: None,
-                    },
-                    input,
-                )
-            })?;
-            // check enum_value is an instance of the class like
-            // https://github.com/python/cpython/blob/v3.12.2/Lib/enum.py#L1148
-            if enum_value.is_instance(class)? {
-                return Ok(enum_value.into());
-            } else if !enum_value.is(&py.None()) {
-                let type_error = PyTypeError::new_err(format!(
-                    "error in {}._missing_: returned {} instead of None or a valid member",
-                    class
-                        .name()
-                        .and_then(|name| name.extract::<String>())
-                        .unwrap_or_else(|_| "<Unknown>".into()),
-                    safe_repr(&enum_value)
-                ));
-                return Err(type_error.into());
-            }
+            return Ok(res);
         }
+
         Err(ValError::new(
             ErrorType::Enum {
                 expected: self.expected_repr.clone(),

--- a/tests/validators/test_enums.py
+++ b/tests/validators/test_enums.py
@@ -378,7 +378,7 @@ def test_enum_int_validation_should_succeed_for_decimal(value: int):
     assert v_int.validate_python(Decimal(float(value))) is MyIntEnum.VALUE
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     sys.version_info >= (3, 13),
     reason='Python 3.13+ enum initialization is different, see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163',
 )

--- a/tests/validators/test_enums.py
+++ b/tests/validators/test_enums.py
@@ -378,15 +378,17 @@ def test_enum_int_validation_should_succeed_for_decimal(value: int):
     assert v_int.validate_python(Decimal(float(value))) is MyIntEnum.VALUE
 
 
+@pytest.mark.skip(
+    sys.version_info >= (3, 13),
+    reason='Python 3.13+ enum initialization is different, see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163',
+)
 def test_enum_int_validation_should_succeed_for_custom_type():
     class AnyWrapper:
         def __init__(self, value):
             self.value = value
 
         def __eq__(self, other: object) -> bool:
-            if sys.version_info < (3, 13):
-                return self.value == other
-            return self.value == other.value
+            return self.value == other
 
     class MyEnum(Enum):
         VALUE = 999

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1316,6 +1316,10 @@ def test_model_error():
     ]
 
 
+@pytest.mark.skip(
+    sys.version_info >= (3, 13),
+    reason='Python 3.13+ enum initialization is different, see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163',
+)
 def test_model_with_enum_int_field_validation_should_succeed_for_any_type_equality_checks():
     # GIVEN
     from enum import Enum
@@ -1330,12 +1334,7 @@ def test_model_with_enum_int_field_validation_should_succeed_for_any_type_equali
             self.value = value
 
         def __eq__(self, other: object) -> bool:
-            if sys.version_info < (3, 13):
-                return self.value == other
-
-            # in Python 3.13+, comparison is done against a list of enum members rather than raw values
-            # see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163
-            return self.value == other.value
+            return self.value == other
 
     class MyModel:
         __slots__ = (

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1,5 +1,6 @@
 import re
 from copy import deepcopy
+from decimal import Decimal
 from typing import Any, Callable, Dict, List, Set, Tuple
 
 import pytest
@@ -1312,3 +1313,62 @@ def test_model_error():
             'ctx': {'class_name': 'MyModel'},
         }
     ]
+
+
+def test_model_with_enum_int_field_validation_should_succeed_for_any_type_equality_checks():
+    # GIVEN
+    from enum import Enum
+
+    class EnumClass(Enum):
+        enum_value = 1
+        enum_value_2 = 2
+        enum_value_3 = 3
+
+    class IntWrappable:
+        def __init__(self, value: int):
+            self.value = value
+
+        def __eq__(self, value: object) -> bool:
+            return self.value == value
+
+    class MyModel:
+        __slots__ = (
+            '__dict__',
+            '__pydantic_fields_set__',
+            '__pydantic_extra__',
+            '__pydantic_private__',
+        )
+        enum_field: EnumClass
+
+    # WHEN
+    v = SchemaValidator(
+        core_schema.model_schema(
+            MyModel,
+            core_schema.model_fields_schema(
+                {
+                    'enum_field': core_schema.model_field(
+                        core_schema.enum_schema(EnumClass, list(EnumClass.__members__.values()))
+                    ),
+                    'enum_field_2': core_schema.model_field(
+                        core_schema.enum_schema(EnumClass, list(EnumClass.__members__.values()))
+                    ),
+                    'enum_field_3': core_schema.model_field(
+                        core_schema.enum_schema(EnumClass, list(EnumClass.__members__.values()))
+                    ),
+                }
+            ),
+        )
+    )
+
+    # THEN
+    v.validate_json('{"enum_field": 1, "enum_field_2": 2, "enum_field_3": 3}')
+    m = v.validate_python(
+        {
+            'enum_field': Decimal(1),
+            'enum_field_2': Decimal(2),
+            'enum_field_3': IntWrappable(3),
+        }
+    )
+    v.validate_assignment(m, 'enum_field', Decimal(1))
+    v.validate_assignment(m, 'enum_field_2', Decimal(2))
+    v.validate_assignment(m, 'enum_field_3', IntWrappable(3))

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from copy import deepcopy
 from decimal import Decimal
 from typing import Any, Callable, Dict, List, Set, Tuple
@@ -1328,8 +1329,13 @@ def test_model_with_enum_int_field_validation_should_succeed_for_any_type_equali
         def __init__(self, value: int):
             self.value = value
 
-        def __eq__(self, value: object) -> bool:
-            return self.value == value
+        def __eq__(self, other: object) -> bool:
+            if sys.version_info < (3, 13):
+                return self.value == other
+
+            # in Python 3.13+, comparison is done against a list of enum members rather than raw values
+            # see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163
+            return self.value == other.value
 
     class MyModel:
         __slots__ = (

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1316,7 +1316,7 @@ def test_model_error():
     ]
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     sys.version_info >= (3, 13),
     reason='Python 3.13+ enum initialization is different, see https://github.com/python/cpython/blob/ec610069637d56101896803a70d418a89afe0b4b/Lib/enum.py#L1159-L1163',
 )


### PR DESCRIPTION
Alternative to https://github.com/pydantic/pydantic-core/pull/1324, thanks @mikeleppane for some of the tests here! Basically, fall back to trying to `SomeEnum(input_value)`, and if that's valid, then return that value. This enables the use of custom `__new__` functions as well :).

Fix https://github.com/pydantic/pydantic/issues/9559
Fix https://github.com/pydantic/pydantic/issues/9572
Fix https://github.com/pydantic/pydantic/issues/9248

These to be addressed separately, in another PR soon that deals with the `Literal` validator:
* https://github.com/pydantic/pydantic/issues/9989
* https://github.com/pydantic/pydantic/issues/9791
* https://github.com/pydantic/pydantic/issues/9437