### PR TITLE
Fix equality checks for primitives in literals

### DIFF
--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -36,7 +36,8 @@ pub struct LiteralLookup<T: Debug> {
     // Catch all for unhashable types like list
     expected_py_values: Option<Vec<(Py<PyAny>, usize)>>,
     // Fallback for ints, bools, and strings to use Python hash and equality checks
-    // which we can't mix with `expected_py_dict`, see tests/test_validators/test_literal.py::test_mix_int_enum_with_int
+    // which we can't mix with `expected_py_dict`, as there may be conflicts
+    // for an example, see tests/test_validators/test_literal.py::test_mix_int_enum_with_int
     expected_py_primitives: Option<Py<PyDict>>,
 
     pub values: Vec<T>,

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -53,13 +53,13 @@ impl<T: Debug> LiteralLookup<T> {
         for (k, v) in expected {
             let id = values.len();
             values.push(v);
-            if let Ok(bool) = k.validate_bool(true) {
-                if bool.into_inner() {
+
+            if let Ok(bool_value) = k.validate_bool(true) {
+                if bool_value.into_inner() {
                     expected_bool.true_id = Some(id);
                 } else {
                     expected_bool.false_id = Some(id);
                 }
-
                 expected_py_primitives.push((k.as_unbound().clone_ref(py), id));
             }
             if k.is_exact_instance_of::<PyInt>() {
@@ -82,30 +82,13 @@ impl<T: Debug> LiteralLookup<T> {
         }
 
         Ok(Self {
-            expected_bool: match expected_bool.true_id.is_some() || expected_bool.false_id.is_some() {
-                true => Some(expected_bool),
-                false => None,
-            },
-            expected_int: match expected_int.is_empty() {
-                true => None,
-                false => Some(expected_int),
-            },
-            expected_str: match expected_str.is_empty() {
-                true => None,
-                false => Some(expected_str),
-            },
-            expected_py_dict: match expected_py_dict.is_empty() {
-                true => None,
-                false => Some(expected_py_dict.into()),
-            },
-            expected_py_values: match expected_py_values.is_empty() {
-                true => None,
-                false => Some(expected_py_values),
-            },
-            expected_py_primitives: match expected_py_primitives.is_empty() {
-                true => None,
-                false => Some(expected_py_primitives),
-            },
+            expected_bool: (expected_bool.true_id.is_some() || expected_bool.false_id.is_some())
+                .then_some(expected_bool),
+            expected_int: (!expected_int.is_empty()).then_some(expected_int),
+            expected_str: (!expected_str.is_empty()).then_some(expected_str),
+            expected_py_dict: (!expected_py_dict.is_empty()).then_some(expected_py_dict.into()),
+            expected_py_values: (!expected_py_values.is_empty()).then_some(expected_py_values),
+            expected_py_primitives: (!expected_py_primitives.is_empty()).then_some(expected_py_primitives),
             values,
         })
     }

--- a/tests/validators/test_literal.py
+++ b/tests/validators/test_literal.py
@@ -389,3 +389,15 @@ def test_big_int():
     m = r'Input should be 18446744073709551617 or 340282366920938463463374607431768211457 \[type=literal_error'
     with pytest.raises(ValidationError, match=m):
         v.validate_python(37)
+
+
+def test_enum_for_str() -> None:
+    class S(str, Enum):
+        a = 'a'
+
+    val_enum = SchemaValidator(core_schema.literal_schema([S.a]))
+    val_str = SchemaValidator(core_schema.literal_schema(['a']))
+
+    for val in [val_enum, val_str]:
+        assert val.validate_python('a') == 'a'
+        assert val.validate_python(S.a) == 'a'


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9989

Also just some minor tidying of the surrounding code.

Maybe we don't want this change - this could be a bit dangerous with custom types that implement `__eq__`. I'm not opposed to closing the above issue and closing this PR, but this at least presents a solution if we do want to move forward.