### PR TITLE
limit windows builds to Rust 1.77 (to keep Windows 7 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,9 +557,7 @@ jobs:
             --release
             --out pgo-wheel
             --interpreter ${{ matrix.interpreter }}
-          # Limit windows builds to 1.77 to keep Windows 7 support.
-          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
-          rust-toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
+          rust-toolchain: ${{ steps.rust-toolchain.outputs.name }}
           docker-options: -e CI
         env:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/profdata"
@@ -574,7 +572,7 @@ jobs:
           pip install -r tests/requirements.txt
           pip install pydantic-core --no-index --no-deps --find-links pgo-wheel --force-reinstall
           pytest tests/benchmarks
-          rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
+          rustup run ${{ steps.rust-toolchain.outputs.name }} bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       - name: merge pgo data
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/profdata
@@ -587,9 +585,7 @@ jobs:
             --release
             --out dist
             --interpreter ${{ matrix.interpreter }}
-          # Limit windows builds to 1.77 to keep Windows 7 support.
-          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
-          rust-toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
+          rust-toolchain: ${{steps.rust-toolchain.outputs.name}}
           docker-options: -e CI
         env:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,9 +537,12 @@ jobs:
 
       - name: install rust stable
         id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           components: llvm-tools
+          # Limit windows builds to 1.77 to keep Windows 7 support.
+          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
+          toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
 
       - run: pip install -U 'ruff==0.5.0' typing_extensions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,9 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
           args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10' }}
-          rust-toolchain: stable
+          # Limit windows builds to 1.77 to keep Windows 7 support.
+          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
+          rust-toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
           docker-options: -e CI
 
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
@@ -544,8 +546,6 @@ jobs:
       # generate self-schema now, so we don't have to do so inside docker in maturin build
       - run: python generate_self_schema.py
 
-      - run: rustc --version --verbose
-
       - name: build initial wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -554,7 +554,9 @@ jobs:
             --release
             --out pgo-wheel
             --interpreter ${{ matrix.interpreter }}
-          rust-toolchain: stable
+          # Limit windows builds to 1.77 to keep Windows 7 support.
+          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
+          rust-toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
           docker-options: -e CI
         env:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/profdata"
@@ -582,7 +584,9 @@ jobs:
             --release
             --out dist
             --interpreter ${{ matrix.interpreter }}
-          rust-toolchain: stable
+          # Limit windows builds to 1.77 to keep Windows 7 support.
+          # FIXME: Unpin when Python 3.8 support is dropped. (3.9 requires Windows 10)
+          rust-toolchain: ${{ (matrix.os == 'windows' && '1.77') || 'stable' }}
           docker-options: -e CI
         env:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"


### PR DESCRIPTION
## Change Summary

Rust 1.78 targets Windows 10. Python 3.9 requires Windows 10.

Until we drop Python 3.8 support, we should build for Windows on Rust 1.77.

## Related issue number

Fixes #1418 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
