### PR TITLE
Relax intensity of error for `issubclass` and `isinstance` schemas from json

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3964,7 +3964,7 @@ ErrorType = Literal[
     'no_such_attribute',
     'json_invalid',
     'json_type',
-    'cannot_validate_from_json',
+    'needs_python_object',
     'recursion_loop',
     'missing',
     'frozen_field',

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3964,6 +3964,7 @@ ErrorType = Literal[
     'no_such_attribute',
     'json_invalid',
     'json_type',
+    'cannot_validate_from_json',
     'recursion_loop',
     'missing',
     'frozen_field',

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -167,7 +167,7 @@ error_types! {
         error: {ctx_type: String, ctx_fn: field_from_context},
     },
     JsonType {},
-    CannotValidateFromJson { method_name: {ctx_type: String, ctx_fn: field_from_context} },
+    NeedsPythonObject { method_name: {ctx_type: String, ctx_fn: field_from_context} },
     // ---------------------
     // recursion error
     RecursionLoop {},
@@ -478,7 +478,7 @@ impl ErrorType {
             Self::NoSuchAttribute {..} => "Object has no attribute '{attribute}'",
             Self::JsonInvalid {..} => "Invalid JSON: {error}",
             Self::JsonType {..} => "JSON input should be string, bytes or bytearray",
-            Self::CannotValidateFromJson {..} => "Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead",
+            Self::NeedsPythonObject {..} => "Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead",
             Self::RecursionLoop {..} => "Recursion error - cyclic reference detected",
             Self::Missing {..} => "Field required",
             Self::FrozenField {..} => "Field is frozen",
@@ -628,7 +628,7 @@ impl ErrorType {
         match self {
             Self::NoSuchAttribute { attribute, .. } => render!(tmpl, attribute),
             Self::JsonInvalid { error, .. } => render!(tmpl, error),
-            Self::CannotValidateFromJson { method_name, .. } => render!(tmpl, method_name),
+            Self::NeedsPythonObject { method_name, .. } => render!(tmpl, method_name),
             Self::GetAttributeError { error, .. } => render!(tmpl, error),
             Self::ModelType { class_name, .. } => render!(tmpl, class_name),
             Self::DataclassType { class_name, .. } => render!(tmpl, class_name),

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -167,6 +167,7 @@ error_types! {
         error: {ctx_type: String, ctx_fn: field_from_context},
     },
     JsonType {},
+    CannotValidateFromJson { method_name: {ctx_type: String, ctx_fn: field_from_context} },
     // ---------------------
     // recursion error
     RecursionLoop {},
@@ -477,6 +478,7 @@ impl ErrorType {
             Self::NoSuchAttribute {..} => "Object has no attribute '{attribute}'",
             Self::JsonInvalid {..} => "Invalid JSON: {error}",
             Self::JsonType {..} => "JSON input should be string, bytes or bytearray",
+            Self::CannotValidateFromJson {..} => "Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead",
             Self::RecursionLoop {..} => "Recursion error - cyclic reference detected",
             Self::Missing {..} => "Field required",
             Self::FrozenField {..} => "Field is frozen",
@@ -626,6 +628,7 @@ impl ErrorType {
         match self {
             Self::NoSuchAttribute { attribute, .. } => render!(tmpl, attribute),
             Self::JsonInvalid { error, .. } => render!(tmpl, error),
+            Self::CannotValidateFromJson { method_name, .. } => render!(tmpl, method_name),
             Self::GetAttributeError { error, .. } => render!(tmpl, error),
             Self::ModelType { class_name, .. } => render!(tmpl, class_name),
             Self::DataclassType { class_name, .. } => render!(tmpl, class_name),

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
@@ -56,10 +55,14 @@ impl Validator for IsInstanceValidator {
         _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let Some(obj) = input.as_python() else {
-            return Err(ValError::InternalErr(PyNotImplementedError::new_err(
-                "Cannot check isinstance when validating from json, \
-                            use a JsonOrPython validator instead.",
-            )));
+            let method_name = "isinstance".to_string();
+            return Err(ValError::new(
+                ErrorType::CannotValidateFromJson {
+                    context: None,
+                    method_name,
+                },
+                input,
+            ));
         };
         match obj.is_instance(self.class.bind(py))? {
             true => Ok(obj.clone().unbind()),

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -57,7 +57,7 @@ impl Validator for IsInstanceValidator {
         let Some(obj) = input.as_python() else {
             let method_name = "isinstance".to_string();
             return Err(ValError::new(
-                ErrorType::CannotValidateFromJson {
+                ErrorType::NeedsPythonObject {
                     context: None,
                     method_name,
                 },

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -52,7 +52,7 @@ impl Validator for IsSubclassValidator {
         let Some(obj) = input.as_python() else {
             let method_name = "issubclass".to_string();
             return Err(ValError::new(
-                ErrorType::CannotValidateFromJson {
+                ErrorType::NeedsPythonObject {
                     context: None,
                     method_name,
                 },

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
@@ -51,10 +50,14 @@ impl Validator for IsSubclassValidator {
         _state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let Some(obj) = input.as_python() else {
-            return Err(ValError::InternalErr(PyNotImplementedError::new_err(
-                "Cannot check issubclass when validating from json, \
-                            use a JsonOrPython validator instead.",
-            )));
+            let method_name = "issubclass".to_string();
+            return Err(ValError::new(
+                ErrorType::CannotValidateFromJson {
+                    context: None,
+                    method_name,
+                },
+                input,
+            ));
         };
         match obj.downcast::<PyType>() {
             Ok(py_type) if py_type.is_subclass(self.class.bind(py))? => Ok(obj.clone().unbind()),

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -258,7 +258,7 @@ all_errors = [
     ('json_invalid', 'Invalid JSON: foobar', {'error': 'foobar'}),
     ('json_type', 'JSON input should be string, bytes or bytearray', None),
     (
-        'cannot_validate_from_json',
+        'needs_python_object',
         'Cannot check `isinstance` when validating from json, use a JsonOrPython validator instead',
         {'method_name': 'isinstance'},
     ),
@@ -511,7 +511,7 @@ def test_all_errors():
             'example_context': None,
         },
         {
-            'type': 'cannot_validate_from_json',
+            'type': 'needs_python_object',
             'message_template_python': 'Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead',
             'example_message_python': 'Cannot check `` when validating from json, use a JsonOrPython validator instead',
             'example_context': {'method_name': ''},

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -257,6 +257,11 @@ all_errors = [
     ('no_such_attribute', "Object has no attribute 'wrong_name'", {'attribute': 'wrong_name'}),
     ('json_invalid', 'Invalid JSON: foobar', {'error': 'foobar'}),
     ('json_type', 'JSON input should be string, bytes or bytearray', None),
+    (
+        'cannot_validate_from_json',
+        'Cannot check `isinstance` when validating from json, use a JsonOrPython validator instead',
+        {'method_name': 'isinstance'},
+    ),
     ('recursion_loop', 'Recursion error - cyclic reference detected', None),
     ('model_type', 'Input should be a valid dictionary or instance of Foobar', {'class_name': 'Foobar'}),
     ('model_attributes_type', 'Input should be a valid dictionary or object to extract fields from', None),
@@ -506,10 +511,10 @@ def test_all_errors():
             'example_context': None,
         },
         {
-            'type': 'recursion_loop',
-            'message_template_python': 'Recursion error - cyclic reference detected',
-            'example_message_python': 'Recursion error - cyclic reference detected',
-            'example_context': None,
+            'type': 'cannot_validate_from_json',
+            'message_template_python': 'Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead',
+            'example_message_python': 'Cannot check `` when validating from json, use a JsonOrPython validator instead',
+            'example_context': {'method_name': ''},
         },
     ]
 

--- a/tests/validators/test_is_instance.py
+++ b/tests/validators/test_is_instance.py
@@ -21,7 +21,7 @@ def test_validate_json() -> None:
     v = SchemaValidator({'type': 'is-instance', 'cls': Foo})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json('"foo"')
-        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'
+        assert exc_info.value.errors()[0]['type'] == 'needs_python_object'
 
 
 def test_is_instance():
@@ -178,7 +178,7 @@ def test_is_instance_json_type_before_validator():
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json('null')
-        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'
+        assert exc_info.value.errors()[0]['type'] == 'needs_python_object'
 
     # now wrap in a before validator
     def set_type_to_int(input: None) -> type:

--- a/tests/validators/test_is_instance.py
+++ b/tests/validators/test_is_instance.py
@@ -19,8 +19,9 @@ class Spam:
 
 def test_validate_json() -> None:
     v = SchemaValidator({'type': 'is-instance', 'cls': Foo})
-    with pytest.raises(NotImplementedError, match='use a JsonOrPython validator instead'):
+    with pytest.raises(ValidationError) as exc_info:
         v.validate_json('"foo"')
+        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'
 
 
 def test_is_instance():
@@ -175,11 +176,9 @@ def test_is_instance_json_type_before_validator():
     schema = core_schema.is_instance_schema(type)
     v = SchemaValidator(schema)
 
-    with pytest.raises(
-        NotImplementedError,
-        match='Cannot check isinstance when validating from json, use a JsonOrPython validator instead.',
-    ):
+    with pytest.raises(ValidationError) as exc_info:
         v.validate_json('null')
+        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'
 
     # now wrap in a before validator
     def set_type_to_int(input: None) -> type:

--- a/tests/validators/test_is_subclass.py
+++ b/tests/validators/test_is_subclass.py
@@ -77,3 +77,10 @@ def test_custom_repr():
             'ctx': {'class': 'Spam'},
         }
     ]
+
+
+def test_is_subclass_json() -> None:
+    v = SchemaValidator(core_schema.is_subclass_schema(Foo))
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_json("'Foo'")
+        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'

--- a/tests/validators/test_is_subclass.py
+++ b/tests/validators/test_is_subclass.py
@@ -83,4 +83,4 @@ def test_is_subclass_json() -> None:
     v = SchemaValidator(core_schema.is_subclass_schema(Foo))
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json("'Foo'")
-        assert exc_info.value.errors()[0]['type'] == 'cannot_validate_from_json'
+        assert exc_info.value.errors()[0]['type'] == 'needs_python_object'


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/8890

Makes these more compatible with validation in unions.