### PR TITLE
Add `serialization` key to `InvalidSchema`

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -439,6 +439,9 @@ class InvalidSchema(TypedDict, total=False):
     type: Required[Literal['invalid']]
     ref: str
     metadata: Dict[str, Any]
+    # note, we never plan to use this, but include it for type checking purposes to match
+    # all other CoreSchema union members
+    serialization: SerSchema
 
 
 def invalid_schema(ref: str | None = None, metadata: Dict[str, Any] | None = None) -> InvalidSchema:


### PR DESCRIPTION
Maybe fixes linting issues on https://github.com/pydantic/pydantic/actions/runs/11294630032/job/31415528529?pr=10523

Linting is now working: https://github.com/pydantic/pydantic/pull/10523