### PR TITLE
Support revalidation of parametrized generics

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2857,7 +2857,6 @@ class TypedDictSchema(TypedDict, total=False):
     type: Required[Literal['typed-dict']]
     fields: Required[Dict[str, TypedDictField]]
     cls: Type[TypedDict]
-    generic_origin: Type[TypedDict]
     computed_fields: List[ComputedField]
     strict: bool
     extras_schema: CoreSchema
@@ -2875,7 +2874,6 @@ def typed_dict_schema(
     fields: Dict[str, TypedDictField],
     *,
     cls: Type[TypedDict] | None = None,
-    generic_origin: Type[TypedDict] | None = None,
     computed_fields: list[ComputedField] | None = None,
     strict: bool | None = None,
     extras_schema: CoreSchema | None = None,
@@ -2922,7 +2920,6 @@ def typed_dict_schema(
         type='typed-dict',
         fields=fields,
         cls=cls,
-        generic_origin=generic_origin,
         computed_fields=computed_fields,
         strict=strict,
         extras_schema=extras_schema,
@@ -3125,6 +3122,8 @@ def model_schema(
     Args:
         cls: The class to use for the model
         schema: The schema to use for the model
+        generic_origin: The origin type used for this model, if it's a parametrized generic. Ex,
+            if this model schema represents `SomeModel[int]`, generic_origin is `SomeModel`
         custom_init: Whether the model has a custom init method
         root_model: Whether the model is a `RootModel`
         post_init: The call after init to use for the model
@@ -3336,6 +3335,8 @@ def dataclass_schema(
         schema: The schema to use for the dataclass fields
         fields: Fields of the dataclass, this is used in serialization and in validation during re-validation
             and while validating assignment
+        generic_origin: The origin type used for this dataclass, if it's a parametrized generic. Ex,
+            if this model schema represents `SomeDataclass[int]`, generic_origin is `SomeDataclass`
         cls_name: The name to use in error locs, etc; this is useful for generics (default: `cls.__name__`)
         post_init: Whether to call `__post_init__` after validation
         revalidate_instances: whether instances of models and dataclasses (including subclass instances)

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2857,6 +2857,7 @@ class TypedDictSchema(TypedDict, total=False):
     type: Required[Literal['typed-dict']]
     fields: Required[Dict[str, TypedDictField]]
     cls: Type[TypedDict]
+    generic_origin: Type[TypedDict]
     computed_fields: List[ComputedField]
     strict: bool
     extras_schema: CoreSchema
@@ -2874,6 +2875,7 @@ def typed_dict_schema(
     fields: Dict[str, TypedDictField],
     *,
     cls: Type[TypedDict] | None = None,
+    generic_origin: Type[TypedDict] | None = None,
     computed_fields: list[ComputedField] | None = None,
     strict: bool | None = None,
     extras_schema: CoreSchema | None = None,
@@ -2920,6 +2922,7 @@ def typed_dict_schema(
         type='typed-dict',
         fields=fields,
         cls=cls,
+        generic_origin=generic_origin,
         computed_fields=computed_fields,
         strict=strict,
         extras_schema=extras_schema,
@@ -3056,6 +3059,7 @@ def model_fields_schema(
 class ModelSchema(TypedDict, total=False):
     type: Required[Literal['model']]
     cls: Required[Type[Any]]
+    generic_origin: Type[Any]
     schema: Required[CoreSchema]
     custom_init: bool
     root_model: bool
@@ -3074,6 +3078,7 @@ def model_schema(
     cls: Type[Any],
     schema: CoreSchema,
     *,
+    generic_origin: Type[Any] | None = None,
     custom_init: bool | None = None,
     root_model: bool | None = None,
     post_init: str | None = None,
@@ -3136,6 +3141,7 @@ def model_schema(
     return _dict_not_none(
         type='model',
         cls=cls,
+        generic_origin=generic_origin,
         schema=schema,
         custom_init=custom_init,
         root_model=root_model,
@@ -3289,6 +3295,7 @@ def dataclass_args_schema(
 class DataclassSchema(TypedDict, total=False):
     type: Required[Literal['dataclass']]
     cls: Required[Type[Any]]
+    generic_origin: Type[Any]
     schema: Required[CoreSchema]
     fields: Required[List[str]]
     cls_name: str
@@ -3308,6 +3315,7 @@ def dataclass_schema(
     schema: CoreSchema,
     fields: List[str],
     *,
+    generic_origin: Type[Any] | None = None,
     cls_name: str | None = None,
     post_init: bool | None = None,
     revalidate_instances: Literal['always', 'never', 'subclass-instances'] | None = None,
@@ -3343,6 +3351,7 @@ def dataclass_schema(
     return _dict_not_none(
         type='dataclass',
         cls=cls,
+        generic_origin=generic_origin,
         fields=fields,
         cls_name=cls_name,
         schema=schema,


### PR DESCRIPTION
Getting started on https://github.com/pydantic/pydantic/issues/9414 by adding a `generic_origin` attribute to model like schemas.

This makes it such that data validated against a parametrized generic type is revalidated IF said data is an instance of a type that is a subclass of the `generic_origin` associated with the model.

So, if you have `Model[Any]` as a type and pass in `ModelSubclass[int](...)`, this will be revalidated because `ModelSubclass` is a subclass of `Model`. Similarly, if you had `Model[int](...)`, this would be revalidated as well.

Pydantic companion PR to this one is [#10666](https://github.com/pydantic/pydantic/pull/10666)