### PR TITLE
Validate enum values against other possible forms of expected values

### DIFF
--- a/tests/validators/test_enums.py
+++ b/tests/validators/test_enums.py
@@ -262,6 +262,22 @@ def test_plain_enum_lists():
     assert v.validate_python([2]) is MyEnum.b
 
 
+def test_plain_enum_tuple():
+    from pydantic import RootModel
+
+    class MyEnum(Enum):
+        a = 1, 2
+        b = 2, 3
+
+    assert MyEnum((1, 2)) is MyEnum.a
+    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())))
+    assert v.validate_python((1, 2)) is MyEnum.a
+    assert v.validate_python((2, 3)) is MyEnum.b
+    serialised = RootModel[MyEnum](MyEnum.a).model_dump_json()
+    parsed = RootModel[MyEnum].model_validate_json(serialised)
+    assert parsed.root is MyEnum.a
+
+
 def test_plain_enum_empty():
     class MyEnum(Enum):
         pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Validate enum values against other possible forms of expected values, specifically tuples. The problem is actually bigger than what the initial commit solves. Please see my comment.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10629

## Checklist

* [-] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
