### PR TITLE
begin refactoring `ValLineError` collection

### DIFF
--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -162,3 +162,108 @@ impl ToPyObject for InputValue {
         }
     }
 }
+
+pub struct LineErrorCollector {
+    errors: Vec<ValLineError>,
+    capacity: usize,
+}
+
+impl LineErrorCollector {
+    pub fn new() -> Self {
+        Self {
+            errors: Vec::new(),
+            capacity: 0,
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            // as this is used on the error pathway, avoid allocating until the first error
+            errors: Vec::new(),
+            capacity,
+        }
+    }
+
+    pub fn ensure_empty(self) -> ValResult<()> {
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ValError::LineErrors(self.errors))
+        }
+    }
+
+    pub fn push(&mut self, error: ValLineError) {
+        self.allocate_if_needed();
+        self.errors.push(error);
+    }
+
+    fn collect(&mut self, errors: Vec<ValLineError>) {
+        self.allocate_if_needed();
+        self.errors.extend(errors);
+    }
+
+    fn allocate_if_needed(&mut self) {
+        if self.errors.is_empty() && self.capacity > 0 {
+            self.errors.reserve(self.capacity);
+        }
+    }
+}
+
+/// Helper trait only implemented for `ValResult` to allow chaining of `collect_line_error`
+pub trait ValResultExt<T> {
+    /// If `self` is an `Err`, collect the line errors into the `collector` and return the error.
+    fn collect_line_errors(
+        self,
+        collector: &mut LineErrorCollector,
+        location: impl Into<LocItem>,
+    ) -> Result<Option<T>, ValidationControlFlow>;
+}
+
+impl<T> ValResultExt<T> for ValResult<T> {
+    #[inline]
+    fn collect_line_errors(
+        self,
+        collector: &mut LineErrorCollector,
+        location: impl Into<LocItem>,
+    ) -> Result<Option<T>, ValidationControlFlow> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(ValError::LineErrors(line_errors)) => {
+                extend_collector(line_errors, collector, location.into());
+                Ok(None)
+            }
+            Err(ValError::InternalErr(err)) => Err(ValidationControlFlow::InternalErr(err)),
+            Err(ValError::Omit) => Err(ValidationControlFlow::Omit),
+            Err(ValError::UseDefault) => Err(ValidationControlFlow::UseDefault),
+        }
+    }
+}
+
+#[cold]
+fn extend_collector(line_errors: Vec<ValLineError>, collector: &mut LineErrorCollector, location: LocItem) {
+    collector.collect(
+        line_errors
+            .into_iter()
+            .map(|line_error| line_error.with_outer_location(location.clone()))
+            .collect(),
+    );
+}
+
+/// ValError, minus the LineErrors variant.
+///
+/// TODO: maybe rework ValError to contain this.
+pub enum ValidationControlFlow {
+    InternalErr(PyErr),
+    Omit,
+    UseDefault,
+}
+
+impl From<ValidationControlFlow> for ValError {
+    fn from(control_flow: ValidationControlFlow) -> Self {
+        match control_flow {
+            ValidationControlFlow::InternalErr(err) => ValError::InternalErr(err),
+            ValidationControlFlow::Omit => ValError::Omit,
+            ValidationControlFlow::UseDefault => ValError::UseDefault,
+        }
+    }
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,7 +6,10 @@ mod types;
 mod validation_exception;
 mod value_exception;
 
-pub use self::line_error::{InputValue, ToErrorValue, ValError, ValLineError, ValResult};
+pub use self::line_error::{
+    InputValue, LineErrorCollector, ToErrorValue, ValError, ValLineError, ValResult, ValResultExt,
+    ValidationControlFlow,
+};
 pub use self::location::LocItem;
 pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
 pub use self::validation_exception::ValidationError;


### PR DESCRIPTION
## Change Summary

Motivated by #1512. 

Our error handling code is getting complicated at each callsite. This begins an attempt to refactor it to move repetition into common code, by adding a `.collect_line_errors()` helper to take `LineErrors` and collect them up.

This only touches a few of the _many_ code paths which collect line errors; they have a variety of different ways to build up locations. If we think we want to proceed with this, I'll follow up with further refactorings another day.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
