### PR TITLE
bump speedate to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "speedate"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a20480dbd4c693f0b0f3210f2cee5bfa21a176c1fa4df0e65cc0474e7fa557"
+checksum = "9a5e7adf4e07e7de39a64d77962ca14a09165e592d42d0c9f9acadb679f4f937"
 dependencies = [
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ strum_macros = "0.26.4"
 serde_json = {version = "1.0.132", features = ["arbitrary_precision", "preserve_order"]}
 enum_dispatch = "0.3.13"
 serde = { version = "1.0.214", features = ["derive"] }
-speedate = "0.14.4"
+speedate = "0.15.0"
 smallvec = "1.13.2"
 ahash = "0.8.10"
 url = "2.5.0"

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -24,10 +24,8 @@ from ..conftest import Err, PyAndJson
         pytest.param(1654646400.00, date(2022, 6, 8), id='float'),
         pytest.param('1654646400.00', date(2022, 6, 8), id='float-as-str'),
         pytest.param(Decimal('1654646400'), date(2022, 6, 8), id='decimal'),
-        # (253_402_300_800_000, Err('format YYYY-MM-DD, dates after 9999 are not supported as unix timestamps')),
         pytest.param(253_402_300_800_000, Err('Input should be a valid date'), id='int-too-high'),
-        # (-20_000_000_000, Err('format YYYY-MM-DD, dates before 1600 are not supported as unix timestamps')),
-        pytest.param(-20_000_000_000, Err('Input should be a valid date'), id='int-too-low'),
+        pytest.param(-80_000_000_000_000, Err('Input should be a valid date'), id='int-too-low'),
         pytest.param(datetime(2022, 6, 8), date(2022, 6, 8), id='datetime-exact'),
         pytest.param(
             datetime(2022, 6, 8, 12),
@@ -59,7 +57,7 @@ from ..conftest import Err, PyAndJson
         pytest.param(
             float('-inf'),
             Err(
-                'Input should be a valid date or datetime, dates before 1600 are not supported as unix timestamps '
+                'Input should be a valid date or datetime, dates before 0000 are not supported as unix timestamps '
                 '[type=date_from_datetime_parsing,'
             ),
             id='-inf',

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -38,10 +38,13 @@ from ..conftest import Err, PyAndJson
         (Decimal('1654646400.1234568'), datetime(2022, 6, 8, 0, 0, 0, 123457, tzinfo=timezone.utc)),
         ('1654646400.1234568', datetime(2022, 6, 8, 0, 0, 0, 123457, tzinfo=timezone.utc)),
         (253_402_300_800_000, Err('should be a valid datetime, dates after 9999 are not supported as unix timestamps')),
-        (-20_000_000_000, Err('should be a valid datetime, dates before 1600 are not supported as unix timestamps')),
+        (
+            -80_000_000_000_000,
+            Err('should be a valid datetime, dates before 0000 are not supported as unix timestamps'),
+        ),
         (float('nan'), Err('Input should be a valid datetime, NaN values not permitted [type=datetime_parsing,')),
         (float('inf'), Err('Input should be a valid datetime, dates after 9999')),
-        (float('-inf'), Err('Input should be a valid datetime, dates before 1600')),
+        (float('-inf'), Err('Input should be a valid datetime, dates before 0000')),
         ('-', Err('Input should be a valid datetime or date, input is too short [type=datetime_from_date_parsing,')),
         ('+', Err('Input should be a valid datetime or date, input is too short [type=datetime_from_date_parsing,')),
         (


### PR DESCRIPTION
## Change Summary

Among other fixes, this extends the range of supported timestamps all the way back to year 0.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
