### PR TITLE
fix `wrap` serializer breaking union serialization in presence of extra fields

### DIFF
--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -198,6 +198,10 @@ impl<'a> Extra<'a> {
     pub fn serialize_infer<'py>(&'py self, value: &'py Bound<'py, PyAny>) -> super::infer::SerializeInfer<'py> {
         super::infer::SerializeInfer::new(value, None, None, self)
     }
+
+    pub(crate) fn model_type_name(&self) -> Option<Bound<'a, PyString>> {
+        self.model.and_then(|model| model.get_type().name().ok())
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -179,6 +179,13 @@ impl FunctionPlainSerializer {
             .expect("fallback_serializer unexpectedly none")
             .as_ref()
     }
+
+    fn retry_with_lax_check(&self) -> bool {
+        self.fallback_serializer
+            .as_ref()
+            .map_or(false, |f| f.retry_with_lax_check())
+            || self.return_serializer.retry_with_lax_check()
+    }
 }
 
 fn on_error(py: Python, err: PyErr, function_name: &str, extra: &Extra) -> PyResult<()> {
@@ -270,6 +277,10 @@ macro_rules! function_type_serializer {
 
             fn get_name(&self) -> &str {
                 &self.name
+            }
+
+            fn retry_with_lax_check(&self) -> bool {
+                self.retry_with_lax_check()
             }
         }
     };
@@ -408,6 +419,10 @@ impl FunctionWrapSerializer {
 
     fn get_fallback_serializer(&self) -> &CombinedSerializer {
         self.serializer.as_ref()
+    }
+
+    fn retry_with_lax_check(&self) -> bool {
+        self.serializer.retry_with_lax_check() || self.return_serializer.retry_with_lax_check()
     }
 }
 

--- a/tests/serializers/test_union.py
+++ b/tests/serializers/test_union.py
@@ -60,53 +60,36 @@ class ModelB:
 @pytest.fixture(scope='module')
 def model_serializer() -> SchemaSerializer:
     return SchemaSerializer(
-        {
-            'type': 'union',
-            'choices': [
-                {
-                    'type': 'model',
-                    'cls': ModelA,
-                    'schema': {
-                        'type': 'model-fields',
-                        'fields': {
-                            'a': {'type': 'model-field', 'schema': {'type': 'bytes'}},
-                            'b': {
-                                'type': 'model-field',
-                                'schema': {
-                                    'type': 'float',
-                                    'serialization': {
-                                        'type': 'format',
-                                        'formatting_string': '0.1f',
-                                        'when_used': 'unless-none',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-                {
-                    'type': 'model',
-                    'cls': ModelB,
-                    'schema': {
-                        'type': 'model-fields',
-                        'fields': {
-                            'c': {'type': 'model-field', 'schema': {'type': 'bytes'}},
-                            'd': {
-                                'type': 'model-field',
-                                'schema': {
-                                    'type': 'float',
-                                    'serialization': {
-                                        'type': 'format',
-                                        'formatting_string': '0.2f',
-                                        'when_used': 'unless-none',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
+        core_schema.union_schema(
+            [
+                core_schema.model_schema(
+                    ModelA,
+                    core_schema.model_fields_schema(
+                        {
+                            'a': core_schema.model_field(core_schema.bytes_schema()),
+                            'b': core_schema.model_field(
+                                core_schema.float_schema(
+                                    serialization=core_schema.format_ser_schema('0.1f', when_used='unless-none')
+                                )
+                            ),
+                        }
+                    ),
+                ),
+                core_schema.model_schema(
+                    ModelB,
+                    core_schema.model_fields_schema(
+                        {
+                            'c': core_schema.model_field(core_schema.bytes_schema()),
+                            'd': core_schema.model_field(
+                                core_schema.float_schema(
+                                    serialization=core_schema.format_ser_schema('0.2f', when_used='unless-none')
+                                )
+                            ),
+                        }
+                    ),
+                ),
             ],
-        }
+        )
     )
 
 
@@ -778,3 +761,67 @@ def test_tagged_union_with_aliases() -> None:
     model_b = ModelB(field=1)
     assert s.to_python(model_a) == {'field': 1, 'TAG': 'a'}
     assert s.to_python(model_b) == {'field': 1, 'TAG': 'b'}
+
+
+def test_union_model_wrap_serializer():
+    def wrap_serializer(value, handler):
+        return handler(value)
+
+    class Data:
+        pass
+
+    class ModelA:
+        a: Data
+
+    class ModelB:
+        a: Data
+
+    model_serializer = SchemaSerializer(
+        core_schema.union_schema(
+            [
+                core_schema.model_schema(
+                    ModelA,
+                    core_schema.model_fields_schema(
+                        {
+                            'a': core_schema.model_field(
+                                core_schema.model_schema(
+                                    Data,
+                                    core_schema.model_fields_schema({}),
+                                )
+                            ),
+                        },
+                    ),
+                    serialization=core_schema.wrap_serializer_function_ser_schema(wrap_serializer),
+                ),
+                core_schema.model_schema(
+                    ModelB,
+                    core_schema.model_fields_schema(
+                        {
+                            'a': core_schema.model_field(
+                                core_schema.model_schema(
+                                    Data,
+                                    core_schema.model_fields_schema({}),
+                                )
+                            ),
+                        },
+                    ),
+                    serialization=core_schema.wrap_serializer_function_ser_schema(wrap_serializer),
+                ),
+            ],
+        )
+    )
+
+    input_value = ModelA()
+    input_value.a = Data()
+
+    assert model_serializer.to_python(input_value) == {'a': {}}
+    assert model_serializer.to_python(input_value, mode='json') == {'a': {}}
+    assert model_serializer.to_json(input_value) == b'{"a":{}}'
+
+    # add some additional attribute, should be ignored & not break serialization
+
+    input_value.a._a = 'foo'
+
+    assert model_serializer.to_python(input_value) == {'a': {}}
+    assert model_serializer.to_python(input_value, mode='json') == {'a': {}}
+    assert model_serializer.to_json(input_value) == b'{"a":{}}'


### PR DESCRIPTION
## Change Summary

It turns out that `wrap` serializers can potentially need "retrying" in lax mode (as per the union logic), but this was not currently handled. This is necessary when a model contains unexpected extra fields; the `Strict` mode will fail.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10682

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
