### PR TITLE
Remove `Url` and `MultiHostUrl` docstrings, we moved them to pydantic

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -492,104 +492,29 @@ class Url(SupportsAllComparisons):
     by Mozilla.
     """
 
-    def __init__(self, url: str) -> None:
-        """Initializes the `Url`.
-
-        Args:
-            url: String representation of a URL.
-
-        Returns:
-            A new `Url` instance.
-
-        Raises:
-            ValidationError: If the URL is invalid.
-        """
-
+    def __init__(self, url: str) -> None: ...
     def __new__(cls, url: str) -> Self: ...
     @property
-    def scheme(self) -> str:
-        """
-        The scheme part of the URL.
-
-        e.g. `https` in `https://user:pass@host:port/path?query#fragment`
-        """
+    def scheme(self) -> str: ...
     @property
-    def username(self) -> str | None:
-        """
-        The username part of the URL, or `None`.
-
-        e.g. `user` in `https://user:pass@host:port/path?query#fragment`
-        """
+    def username(self) -> str | None: ...
     @property
-    def password(self) -> str | None:
-        """
-        The password part of the URL, or `None`.
-
-        e.g. `pass` in `https://user:pass@host:port/path?query#fragment`
-        """
+    def password(self) -> str | None: ...
     @property
-    def host(self) -> str | None:
-        """
-        The host part of the URL, or `None`.
-
-        If the URL must be punycode encoded, this is the encoded host, e.g if the input URL is `https://£££.com`,
-        `host` will be `xn--9aaa.com`
-        """
-    def unicode_host(self) -> str | None:
-        """
-        The host part of the URL as a unicode string, or `None`.
-
-        e.g. `host` in `https://user:pass@host:port/path?query#fragment`
-
-        If the URL must be punycode encoded, this is the decoded host, e.g if the input URL is `https://£££.com`,
-        `unicode_host()` will be `£££.com`
-        """
+    def host(self) -> str | None: ...
+    def unicode_host(self) -> str | None: ...
     @property
-    def port(self) -> int | None:
-        """
-        The port part of the URL, or `None`.
-
-        e.g. `port` in `https://user:pass@host:port/path?query#fragment`
-        """
+    def port(self) -> int | None: ...
     @property
-    def path(self) -> str | None:
-        """
-        The path part of the URL, or `None`.
-
-        e.g. `/path` in `https://user:pass@host:port/path?query#fragment`
-        """
+    def path(self) -> str | None: ...
     @property
-    def query(self) -> str | None:
-        """
-        The query part of the URL, or `None`.
-
-        e.g. `query` in `https://user:pass@host:port/path?query#fragment`
-        """
-    def query_params(self) -> list[tuple[str, str]]:
-        """
-        The query part of the URL as a list of key-value pairs.
-
-        e.g. `[('foo', 'bar')]` in `https://user:pass@host:port/path?foo=bar#fragment`
-        """
+    def query(self) -> str | None: ...
+    def query_params(self) -> list[tuple[str, str]]: ...
     @property
-    def fragment(self) -> str | None:
-        """
-        The fragment part of the URL, or `None`.
-
-        e.g. `fragment` in `https://user:pass@host:port/path?query#fragment`
-        """
-    def unicode_string(self) -> str:
-        """
-        The URL as a unicode string, unlike `__str__()` this will not punycode encode the host.
-
-        If the URL must be punycode encoded, this is the decoded string, e.g if the input URL is `https://£££.com`,
-        `unicode_string()` will be `https://£££.com`
-        """
+    def fragment(self) -> str | None: ...
+    def unicode_string(self) -> str: ...
     def __repr__(self) -> str: ...
-    def __str__(self) -> str:
-        """
-        The URL as a string, this will punycode encode the host if required.
-        """
+    def __str__(self) -> str: ...
     def __deepcopy__(self, memo: dict) -> str: ...
     @classmethod
     def build(
@@ -603,23 +528,7 @@ class Url(SupportsAllComparisons):
         path: str | None = None,
         query: str | None = None,
         fragment: str | None = None,
-    ) -> Self:
-        """
-        Build a new `Url` instance from its component parts.
-
-        Args:
-            scheme: The scheme part of the URL.
-            username: The username part of the URL, or omit for no username.
-            password: The password part of the URL, or omit for no password.
-            host: The host part of the URL.
-            port: The port part of the URL, or omit for no port.
-            path: The path part of the URL, or omit for no path.
-            query: The query part of the URL, or omit for no query.
-            fragment: The fragment part of the URL, or omit for no fragment.
-
-        Returns:
-            An instance of URL
-        """
+    ) -> Self: ...
 
 class MultiHostUrl(SupportsAllComparisons):
     """
@@ -629,82 +538,21 @@ class MultiHostUrl(SupportsAllComparisons):
     by Mozilla.
     """
 
-    def __init__(self, url: str) -> None:
-        """Initializes the `MultiHostUrl`.
-
-        Args:
-            url: String representation of a URL.
-
-        Returns:
-            A new `MultiHostUrl` instance.
-
-        Raises:
-            ValidationError: If the URL is invalid.
-        """
-
+    def __init__(self, url: str) -> None: ...
     def __new__(cls, url: str) -> Self: ...
     @property
-    def scheme(self) -> str:
-        """
-        The scheme part of the URL.
-
-        e.g. `https` in `https://foo.com,bar.com/path?query#fragment`
-        """
+    def scheme(self) -> str: ...
     @property
-    def path(self) -> str | None:
-        """
-        The path part of the URL, or `None`.
-
-        e.g. `/path` in `https://foo.com,bar.com/path?query#fragment`
-        """
+    def path(self) -> str | None: ...
     @property
-    def query(self) -> str | None:
-        """
-        The query part of the URL, or `None`.
-
-        e.g. `query` in `https://foo.com,bar.com/path?query#fragment`
-        """
-    def query_params(self) -> list[tuple[str, str]]:
-        """
-        The query part of the URL as a list of key-value pairs.
-
-        e.g. `[('foo', 'bar')]` in `https://foo.com,bar.com/path?query#fragment`
-        """
+    def query(self) -> str | None: ...
+    def query_params(self) -> list[tuple[str, str]]: ...
     @property
-    def fragment(self) -> str | None:
-        """
-        The fragment part of the URL, or `None`.
-
-        e.g. `fragment` in `https://foo.com,bar.com/path?query#fragment`
-        """
-    def hosts(self) -> list[MultiHostHost]:
-        '''
-
-        The hosts of the `MultiHostUrl` as [`MultiHostHost`][pydantic_core.MultiHostHost] typed dicts.
-
-        ```py
-        from pydantic_core import MultiHostUrl
-
-        mhu = MultiHostUrl('https://foo.com:123,foo:bar@bar.com/path')
-        print(mhu.hosts())
-        """
-        [
-            {'username': None, 'password': None, 'host': 'foo.com', 'port': 123},
-            {'username': 'foo', 'password': 'bar', 'host': 'bar.com', 'port': 443}
-        ]
-        ```
-        Returns:
-            A list of dicts, each representing a host.
-        '''
-    def unicode_string(self) -> str:
-        """
-        The URL as a unicode string, unlike `__str__()` this will not punycode encode the hosts.
-        """
+    def fragment(self) -> str | None: ...
+    def hosts(self) -> list[MultiHostHost]: ...
+    def unicode_string(self) -> str: ...
     def __repr__(self) -> str: ...
-    def __str__(self) -> str:
-        """
-        The URL as a string, this will punycode encode the hosts if required.
-        """
+    def __str__(self) -> str: ...
     def __deepcopy__(self, memo: dict) -> Self: ...
     @classmethod
     def build(
@@ -719,27 +567,7 @@ class MultiHostUrl(SupportsAllComparisons):
         path: str | None = None,
         query: str | None = None,
         fragment: str | None = None,
-    ) -> Self:
-        """
-        Build a new `MultiHostUrl` instance from its component parts.
-
-        This method takes either `hosts` - a list of `MultiHostHost` typed dicts, or the individual components
-        `username`, `password`, `host` and `port`.
-
-        Args:
-            scheme: The scheme part of the URL.
-            hosts: Multiple hosts to build the URL from.
-            username: The username part of the URL.
-            password: The password part of the URL.
-            host: The host part of the URL.
-            port: The port part of the URL.
-            path: The path part of the URL.
-            query: The query part of the URL, or omit for no query.
-            fragment: The fragment part of the URL, or omit for no fragment.
-
-        Returns:
-            An instance of `MultiHostUrl`
-        """
+    ) -> Self: ...
 
 @final
 class SchemaError(Exception):


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/pull/10766 counterpart in `pydantic`