### PR TITLE
fix: implemented fallback if inline-snapshot is used with pypy

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 backports.zoneinfo==0.2.1;python_version<"3.9"
 coverage==7.6.1
 dirty-equals==0.8.0
-inline-snapshot==0.13.3
+inline-snapshot==0.13.3 ; implementation_name == "cpython"
 hypothesis==6.111.2
 # pandas doesn't offer prebuilt wheels for all versions and platforms we test in CI e.g. aarch64 musllinux
 pandas==2.1.3; python_version >= "3.9" and python_version < "3.13" and implementation_name == "cpython" and platform_machine == 'x86_64'

--- a/tests/snapshot.py
+++ b/tests/snapshot.py
@@ -1,0 +1,9 @@
+import sys
+
+if sys.implementation.name == 'cpython':
+    from inline_snapshot import snapshot
+else:
+    # inline-snapshot has currently no pypy support.
+    # This fallback allows snapshots to be used during pypy tests.
+    def snapshot(value):
+        return value

--- a/tests/validators/test_allow_partial.py
+++ b/tests/validators/test_allow_partial.py
@@ -2,9 +2,10 @@ from typing import Mapping
 
 import pytest
 from dirty_equals import IsStrictDict
-from inline_snapshot import snapshot
 
 from pydantic_core import SchemaValidator, ValidationError, core_schema
+
+from ..snapshot import snapshot
 
 
 def test_list():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Implemented fallback if inline-snapshot is used with pypy (or any other none cpython implementation of python).
I hope to support pypy in the future but I don't know how long this will take.

## Related issue number

fix #1534 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt