### PR TITLE
 More union serialization tidying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	pip install -U pip wheel pre-commit
 	pip install -r tests/requirements.txt
 	pip install -r tests/requirements-linting.txt
-	pip install -e .
+	pip install -v -e .
 	pre-commit install
 
 .PHONY: install-rust-coverage


### PR DESCRIPTION
1. Try `value[discriminator_key]` or `value.key` depending on the type of `value`
2. Only raise discriminator not found warnings if we're at the top level of a union, following up on https://github.com/pydantic/pydantic/issues/10657

1 fixes this issue that @Kludex reported, the following now runs with no warnings

```py
from typing import Literal, Annotated
from pydantic import TypeAdapter, Discriminator
from typing_extensions import TypedDict

class ModelA(TypedDict):
    a: str
    state: Literal['ModelA']

class ModelB(TypedDict):
    b: str
    state: Literal['ModelB']

ta = TypeAdapter(Annotated[ModelA | ModelB, Discriminator('state')])
model_a = ta.validate_python({'a': 'a', 'state': 'ModelA'})
model_b = ta.validate_python({'b': 'b', 'state': 'ModelB'})
ta.dump_python(model_a)
ta.dump_python(model_b)
```

2 fixes https://github.com/pydantic/pydantic/issues/10657

I've given some thought to how we might want to do a refactor here to minimize shared logic. I'm a bit held up on conflicting function signatures, so perhaps we could chat about that on Monday @davidhewitt :).