### PR TITLE
Raise warnings when deprecated fields are filled at model instantiation

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2944,6 +2944,7 @@ class ModelField(TypedDict, total=False):
     serialization_alias: str
     serialization_exclude: bool  # default: False
     frozen: bool
+    deprecation_msg: str
     metadata: Dict[str, Any]
 
 
@@ -2954,6 +2955,7 @@ def model_field(
     serialization_alias: str | None = None,
     serialization_exclude: bool | None = None,
     frozen: bool | None = None,
+    deprecation_msg: str | None = None,
     metadata: Dict[str, Any] | None = None,
 ) -> ModelField:
     """
@@ -2971,6 +2973,7 @@ def model_field(
         serialization_alias: The alias to use as a key when serializing
         serialization_exclude: Whether to exclude the field when serializing
         frozen: Whether the field is frozen
+        deprecation_msg: A deprecation message indicating that the field is deprecated. `None` means that the field is not deprecated.
         metadata: Any other information you want to include with the schema, not used by pydantic-core
     """
     return _dict_not_none(
@@ -2980,6 +2983,7 @@ def model_field(
         serialization_alias=serialization_alias,
         serialization_exclude=serialization_exclude,
         frozen=frozen,
+        deprecation_msg=deprecation_msg,
         metadata=metadata,
     )
 

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -125,8 +125,6 @@ impl Validator for ModelFieldsValidator {
         // this validator does not yet support partial validation, disable it to avoid incorrect results
         state.allow_partial = false.into();
 
-        let deprecation_warning_type = py.import_bound("builtins")?.getattr("DeprecationWarning")?;
-
         let strict = state.strict_or(self.strict);
         let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
 
@@ -189,6 +187,7 @@ impl Validator for ModelFieldsValidator {
                         used_keys.insert(lookup_path.first_key());
                     }
                     if let Some(msg) = &field.deprecation_msg {
+                        let deprecation_warning_type = py.import_bound("builtins")?.getattr("DeprecationWarning")?;
                         PyErr::warn_bound(py, &deprecation_warning_type, msg, 2)?;
                     }
                     match field.validator.validate(py, value.borrow_input(), state) {

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -1,7 +1,8 @@
-use pyo3::exceptions::PyKeyError;
+use pyo3::exceptions::{PyDeprecationWarning, PyKeyError};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyType};
+use pyo3::PyTypeInfo;
 
 use ahash::AHashSet;
 
@@ -187,7 +188,7 @@ impl Validator for ModelFieldsValidator {
                         used_keys.insert(lookup_path.first_key());
                     }
                     if let Some(msg) = &field.deprecation_msg {
-                        let deprecation_warning_type = py.import_bound("builtins")?.getattr("DeprecationWarning")?;
+                        let deprecation_warning_type = PyDeprecationWarning::type_object_bound(py);
                         PyErr::warn_bound(py, &deprecation_warning_type, msg, 2)?;
                     }
                     match field.validator.validate(py, value.borrow_input(), state) {

--- a/tests/validators/test_model_fields.py
+++ b/tests/validators/test_model_fields.py
@@ -1792,7 +1792,12 @@ def test_deprecation_msg():
                 'b': {
                     'type': 'model-field',
                     'schema': {'type': 'default', 'schema': {'type': 'int'}, 'default': 2},
-                    'deprecation_msg': 'hi',
+                    'deprecation_msg': 'foo',
+                },
+                'c': {
+                    'type': 'model-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'int'}, 'default': 2},
+                    'deprecation_msg': 'bar',
                 },
             },
         }
@@ -1802,5 +1807,9 @@ def test_deprecation_msg():
     v.validate_python({'a': 1})
 
     # validating the deprecated field: raise warning
-    with pytest.warns(DeprecationWarning, match='hi'):
-        v.validate_python({'a': 1, 'b': 1})
+    # ensure that we get two warnings
+    with pytest.warns(DeprecationWarning) as w:
+        v.validate_python({'a': 1, 'b': 1, 'c': 1})
+        assert len(w) == 2
+        assert str(w[0].message) == 'foo'
+        assert str(w[1].message) == 'bar'

--- a/tests/validators/test_model_fields.py
+++ b/tests/validators/test_model_fields.py
@@ -1781,3 +1781,26 @@ def test_extra_behavior_ignore(config: Union[core_schema.CoreConfig, None], sche
         }
     ]
     assert 'not_f' not in m
+
+
+def test_deprecation_msg():
+    v = SchemaValidator(
+        {
+            'type': 'model-fields',
+            'fields': {
+                'a': {'type': 'model-field', 'schema': {'type': 'int'}},
+                'b': {
+                    'type': 'model-field',
+                    'schema': {'type': 'default', 'schema': {'type': 'int'}, 'default': 2},
+                    'deprecation_msg': 'hi',
+                },
+            },
+        }
+    )
+
+    # not touching the deprecated field: no warning
+    v.validate_python({'a': 1})
+
+    # validating the deprecated field: raise warning
+    with pytest.warns(DeprecationWarning, match='hi'):
+        v.validate_python({'a': 1, 'b': 1})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Raise warnings when deprecated fields receive values at model instantiation. My previous attempt at https://github.com/pydantic/pydantic/pull/10865 was rejected because it led to performance issues, so I'm hoping that by moving the logic to pydantic-core will work better. At least doing it here means that the code won't need to loop over the input values one more time.

One extra config is added to the `model-field` schema: `deprecation_msg` (`Option<String>`). A field is marked as deprecated when this config value is present. The actual deprecation message will be passed in from pydantic; this keeps handling the type of the deprecation message simple, and most importantly, there is already logic over there dealing with possible cases of deprecation messages and thus we should not duplicate the logic here.

Also tested with pydantic and it worked.

## Related issue number

Part of https://github.com/pydantic/pydantic/issues/8922

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle