### PR TITLE
minimal upgrade to PyO3 0.23 (ignoring deprecations)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,8 +298,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 [[package]]
 name = "jiter"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f69a121b68af57bc10f151f3f67444a64d1d3a0eb48b042801ea917a38dd25"
+source = "git+https://github.com/pydantic/jiter?branch=main#9ad1d5a4c57a75a80c98c3103484281fc882733f"
 dependencies = [
  "ahash",
  "bitvec",
@@ -451,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "f54b3d09cbdd1f8c20650b28e7b09e338881482f4aa908a5f61a00c98fba2690"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -470,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "3015cf985888fe66cfb63ce0e321c603706cd541b7aec7ddd35c281390af45d8"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -481,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "6fca7cd8fd809b5ac4eefb89c1f98f7a7651d3739dfb341ca6980090f554c270"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -491,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "34e657fa5379a79151b6ff5328d9216a84f55dc93b17b08e7c3609a969b73aa0"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -503,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "295548d5ffd95fd1981d2d3cf4458831b21d60af046b729b6fd143b0ba7aee2f"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.75"
 [dependencies]
 # TODO it would be very nice to remove the "py-clone" feature as it can panic,
 # but needs a bit of work to make sure it's not used in the codebase
-pyo3 = { version = "0.22.6", features = ["generate-import-lib", "num-bigint", "py-clone"] }
+pyo3 = { version = "0.23.2", features = ["generate-import-lib", "num-bigint", "py-clone"] }
 regex = "1.11.1"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
@@ -46,7 +46,7 @@ base64 = "0.22.1"
 num-bigint = "0.4.6"
 python3-dll-a = "0.2.10"
 uuid = "1.11.0"
-jiter = { version = "0.7.1", features = ["python"] }
+jiter = { git = "https://github.com/pydantic/jiter", branch = "main", features = ["python"] }
 hex = "0.4.3"
 
 [lib]
@@ -74,12 +74,12 @@ debug = true
 strip = false
 
 [dev-dependencies]
-pyo3 = { version = "0.22.6", features = ["auto-initialize"] }
+pyo3 = { version = "0.23.2", features = ["auto-initialize"] }
 
 [build-dependencies]
 version_check = "0.9.5"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = { version = "0.22.6" }
+pyo3-build-config = { version = "0.23.2" }
 
 [lints.clippy]
 dbg_macro = "warn"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(deprecated)] // FIXME: just used during upgrading PyO3 to 0.23
 
 extern crate test;
 

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -386,7 +386,7 @@ impl ValidationError {
         let args = (
             borrow.title.bind(py),
             borrow.errors(py, include_url_env(py), true, true)?,
-            borrow.input_type.into_py(py),
+            borrow.input_type.into_pyobject(py)?,
             borrow.hide_input,
         )
             .into_py(slf.py());

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -527,7 +527,7 @@ impl TzInfo {
     }
 
     #[allow(unused_variables)]
-    fn dst(&self, dt: &Bound<'_, PyAny>) -> Option<&PyDelta> {
+    fn dst(&self, dt: &Bound<'_, PyAny>) -> Option<Bound<'_, PyDelta>> {
         None
     }
 

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -1,7 +1,8 @@
+use std::convert::Infallible;
 use std::fmt;
 
 use pyo3::exceptions::PyValueError;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyString};
 use pyo3::{intern, prelude::*};
 
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
@@ -20,13 +21,17 @@ pub enum InputType {
     String,
 }
 
-impl IntoPy<PyObject> for InputType {
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        match self {
-            Self::Json => intern!(py, "json").into_py(py),
-            Self::Python => intern!(py, "python").into_py(py),
-            Self::String => intern!(py, "string").into_py(py),
-        }
+impl<'py> IntoPyObject<'py> for InputType {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'_>) -> Result<Bound<'_, PyString>, Infallible> {
+        Ok(match self {
+            Self::Json => intern!(py, "json").clone(),
+            Self::Python => intern!(py, "python").clone(),
+            Self::String => intern!(py, "string").clone(),
+        })
     }
 }
 

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -278,9 +278,8 @@ pub(crate) fn iterate_mapping_items<'a, 'py>(
         .items()
         .map_err(|e| mapping_err(e, py, input))?
         .iter()
-        .map_err(|e| mapping_err(e, py, input))?
-        .map(move |item| match item {
-            Ok(item) => item.extract().map_err(|_| {
+        .map(move |item| {
+            item.extract().map_err(|_| {
                 ValError::new(
                     ErrorType::MappingType {
                         error: MAPPING_TUPLE_ERROR.into(),
@@ -288,8 +287,7 @@ pub(crate) fn iterate_mapping_items<'a, 'py>(
                     },
                     input,
                 )
-            }),
-            Err(e) => Err(mapping_err(e, py, input)),
+            })
         });
     Ok(iterator)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(has_coverage_attribute, feature(coverage_attribute))]
+#![allow(deprecated)] // FIXME: just used during upgrading PyO3 to 0.23
 
 extern crate core;
 

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
 use std::fmt;
+use std::sync::Mutex;
 
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
@@ -370,18 +370,27 @@ impl From<bool> for WarningsMode {
     }
 }
 
-#[derive(Clone)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct CollectWarnings {
     mode: WarningsMode,
-    warnings: RefCell<Option<Vec<String>>>,
+    // FIXME: mutex is to satisfy PyO3 0.23, we should be able to refactor this away
+    warnings: Mutex<Vec<String>>,
+}
+
+impl Clone for CollectWarnings {
+    fn clone(&self) -> Self {
+        Self {
+            mode: self.mode,
+            warnings: Mutex::new(self.warnings.lock().expect("lock poisoned").clone()),
+        }
+    }
 }
 
 impl CollectWarnings {
     pub(crate) fn new(mode: WarningsMode) -> Self {
         Self {
             mode,
-            warnings: RefCell::new(None),
+            warnings: Mutex::new(Vec::new()),
         }
     }
 
@@ -447,41 +456,46 @@ impl CollectWarnings {
     }
 
     fn add_warning(&self, message: String) {
-        let mut op_warnings = self.warnings.borrow_mut();
-        if let Some(ref mut warnings) = *op_warnings {
-            warnings.push(message);
-        } else {
-            *op_warnings = Some(vec![message]);
-        }
+        self.warnings.lock().expect("lock poisoned").push(message);
     }
 
     pub fn final_check(&self, py: Python) -> PyResult<()> {
         if self.mode == WarningsMode::None {
             return Ok(());
         }
-        match *self.warnings.borrow() {
-            Some(ref warnings) => {
-                let message = format!("Pydantic serializer warnings:\n  {}", warnings.join("\n  "));
-                if self.mode == WarningsMode::Warn {
-                    let user_warning_type = py.import_bound("builtins")?.getattr("UserWarning")?;
-                    PyErr::warn_bound(py, &user_warning_type, &message, 0)
-                } else {
-                    Err(PydanticSerializationError::new_err(message))
-                }
-            }
-            _ => Ok(()),
+        let warnings = self.warnings.lock().expect("lock poisoned");
+
+        if warnings.is_empty() {
+            return Ok(());
+        }
+
+        let message = format!("Pydantic serializer warnings:\n  {}", warnings.join("\n  "));
+        if self.mode == WarningsMode::Warn {
+            let user_warning_type = py.import_bound("builtins")?.getattr("UserWarning")?;
+            PyErr::warn_bound(py, &user_warning_type, &message, 0)
+        } else {
+            Err(PydanticSerializationError::new_err(message))
         }
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct SerRecursionState {
-    guard: RefCell<RecursionState>,
+    // FIXME: mutex is to satisfy PyO3 0.23, we should be able to refactor this away
+    guard: Mutex<RecursionState>,
+}
+
+impl Clone for SerRecursionState {
+    fn clone(&self) -> Self {
+        Self {
+            guard: Mutex::new(self.guard.lock().expect("lock poisoned").clone()),
+        }
+    }
 }
 
 impl ContainsRecursionState for &'_ Extra<'_> {
     fn access_recursion_state<R>(&mut self, f: impl FnOnce(&mut RecursionState) -> R) -> R {
-        f(&mut self.rec_guard.guard.borrow_mut())
+        f(&mut self.rec_guard.guard.lock().expect("lock poisoned"))
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -11,17 +11,17 @@ use crate::input::Int;
 use jiter::{cached_py_string, pystring_fast_new, StringCacheMode};
 
 pub trait SchemaDict<'py> {
-    fn get_as<T>(&self, key: &Bound<'_, PyString>) -> PyResult<Option<T>>
+    fn get_as<T>(&self, key: &Bound<'py, PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>;
 
-    fn get_as_req<T>(&self, key: &Bound<'_, PyString>) -> PyResult<T>
+    fn get_as_req<T>(&self, key: &Bound<'py, PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>;
 }
 
 impl<'py> SchemaDict<'py> for Bound<'py, PyDict> {
-    fn get_as<T>(&self, key: &Bound<'_, PyString>) -> PyResult<Option<T>>
+    fn get_as<T>(&self, key: &Bound<'py, PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>,
     {
@@ -31,7 +31,7 @@ impl<'py> SchemaDict<'py> for Bound<'py, PyDict> {
         }
     }
 
-    fn get_as_req<T>(&self, key: &Bound<'_, PyString>) -> PyResult<T>
+    fn get_as_req<T>(&self, key: &Bound<'py, PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>,
     {
@@ -43,7 +43,7 @@ impl<'py> SchemaDict<'py> for Bound<'py, PyDict> {
 }
 
 impl<'py> SchemaDict<'py> for Option<&Bound<'py, PyDict>> {
-    fn get_as<T>(&self, key: &Bound<'_, PyString>) -> PyResult<Option<T>>
+    fn get_as<T>(&self, key: &Bound<'py, PyString>) -> PyResult<Option<T>>
     where
         T: FromPyObject<'py>,
     {
@@ -54,7 +54,7 @@ impl<'py> SchemaDict<'py> for Option<&Bound<'py, PyDict>> {
     }
 
     #[cfg_attr(has_coverage_attribute, coverage(off))]
-    fn get_as_req<T>(&self, key: &Bound<'_, PyString>) -> PyResult<T>
+    fn get_as_req<T>(&self, key: &Bound<'py, PyString>) -> PyResult<T>
     where
         T: FromPyObject<'py>,
     {

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -347,7 +347,8 @@ impl Validator for ArgumentsValidator {
                             },
                             VarKwargsMode::UnpackedTypedDict => {
                                 // Save to the remaining kwargs, we will validate as a single dict:
-                                remaining_kwargs.set_item(either_str.as_py_string(py, state.cache_str()), value)?;
+                                remaining_kwargs
+                                    .set_item(either_str.as_py_string(py, state.cache_str()), value.to_object(py))?;
                             }
                         }
                     }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -326,8 +326,10 @@ impl Validator for DataclassArgsValidator {
                                                 Err(err) => return Err(err),
                                             }
                                         } else {
-                                            output_dict
-                                                .set_item(either_str.as_py_string(py, state.cache_str()), value)?;
+                                            output_dict.set_item(
+                                                either_str.as_py_string(py, state.cache_str()),
+                                                value.to_object(py),
+                                            )?;
                                         }
                                     }
                                 }

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -279,9 +279,9 @@ pub(crate) fn create_decimal<'py>(arg: &Bound<'py, PyAny>, input: impl ToErrorVa
 
 fn handle_decimal_new_error(input: impl ToErrorValue, error: PyErr, decimal_exception: Bound<'_, PyAny>) -> ValError {
     let py = decimal_exception.py();
-    if error.matches(py, decimal_exception) {
+    if error.matches(py, decimal_exception).unwrap_or(false) {
         ValError::new(ErrorTypeDefaults::DecimalParsing, input)
-    } else if error.matches(py, PyTypeError::type_object_bound(py)) {
+    } else if error.matches(py, PyTypeError::type_object_bound(py)).unwrap_or(false) {
         ValError::new(ErrorTypeDefaults::DecimalType, input)
     } else {
         ValError::InternalErr(error)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // FIXME: just used during upgrading PyO3 to 0.23
+
 #[cfg(test)]
 mod tests {
     use _pydantic_core::{SchemaSerializer, SchemaValidator, WarningsArg};


### PR DESCRIPTION
## Change Summary

This updates PyO3 to 0.23. To keep things reviewable, I have started here by ignoring deprecations and just fixing the immediate build failures caused by the version bump.

They fit mostly into two categories:
- PyO3 0.23 introduced a new trait `IntoPyObject` and changed many methods to use it instead of `IntoPy<PyObject>` and `ToPyObject`. This PR tries to avoid switching traits as much as possible, making the changes only where necessary to fix compile failures.
- PyO3 0.23 requires the `#[pyclass]` types to be `Sync` (i.e. thread-safe), so I had to replace `RefCell` with a `Mutex` in a couple of internal places.

Needs `jiter` release pushed before this can be merged.

## Related issue number

Related to #1555 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
