### PR TITLE
Use UserWarning from pyo3

### DIFF
--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::sync::Mutex;
 
-use pyo3::exceptions::{PyTypeError, PyValueError};
-use pyo3::intern;
+use pyo3::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyString};
+use pyo3::{intern, PyTypeInfo};
 
 use serde::ser::Error;
 
@@ -471,7 +471,7 @@ impl CollectWarnings {
 
         let message = format!("Pydantic serializer warnings:\n  {}", warnings.join("\n  "));
         if self.mode == WarningsMode::Warn {
-            let user_warning_type = py.import_bound("builtins")?.getattr("UserWarning")?;
+            let user_warning_type = PyUserWarning::type_object(py);
             PyErr::warn_bound(py, &user_warning_type, &message, 0)
         } else {
             Err(PydanticSerializationError::new_err(message))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Following David's comment: https://github.com/pydantic/pydantic-core/pull/1551#pullrequestreview-2461749957

Replacing the explicitly imported python `UserWarning` with `PyUserWarning` from pyo3. This might slightly improve performance in this case, depending on how pyo3 actually raises warnings. In the worst case it should be the same as the current implementation, so there's no harm doing this.

## Related issue number

None.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle