### PR TITLE
Fix lint errors with toolchain 1.83

### DIFF
--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -582,7 +582,7 @@ struct ValidationErrorSerializer<'py> {
     input_type: &'py InputType,
 }
 
-impl<'py> Serialize for ValidationErrorSerializer<'py> {
+impl Serialize for ValidationErrorSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -614,7 +614,7 @@ struct PyLineErrorSerializer<'py> {
     input_type: &'py InputType,
 }
 
-impl<'py> Serialize for PyLineErrorSerializer<'py> {
+impl Serialize for PyLineErrorSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -24,7 +24,7 @@ pub enum EitherDate<'a> {
     Py(Bound<'a, PyDate>),
 }
 
-impl<'a> From<Date> for EitherDate<'a> {
+impl From<Date> for EitherDate<'_> {
     fn from(date: Date) -> Self {
         Self::Raw(date)
     }
@@ -45,7 +45,7 @@ pub fn pydate_as_date(py_date: &Bound<'_, PyAny>) -> PyResult<Date> {
     })
 }
 
-impl<'a> EitherDate<'a> {
+impl EitherDate<'_> {
     pub fn as_raw(&self) -> PyResult<Date> {
         match self {
             Self::Raw(date) => Ok(date.clone()),
@@ -68,7 +68,7 @@ pub enum EitherTime<'a> {
     Py(Bound<'a, PyTime>),
 }
 
-impl<'a> From<Time> for EitherTime<'a> {
+impl From<Time> for EitherTime<'_> {
     fn from(time: Time) -> Self {
         Self::Raw(time)
     }
@@ -87,7 +87,7 @@ pub enum EitherTimedelta<'a> {
     PySubclass(Bound<'a, PyDelta>),
 }
 
-impl<'a> From<Duration> for EitherTimedelta<'a> {
+impl From<Duration> for EitherTimedelta<'_> {
     fn from(timedelta: Duration) -> Self {
         Self::Raw(timedelta)
     }
@@ -200,7 +200,7 @@ pub fn pytime_as_time(py_time: &Bound<'_, PyAny>, py_dt: Option<&Bound<'_, PyAny
     })
 }
 
-impl<'a> EitherTime<'a> {
+impl EitherTime<'_> {
     pub fn as_raw(&self) -> PyResult<Time> {
         match self {
             Self::Raw(time) => Ok(time.clone()),
@@ -240,7 +240,7 @@ pub enum EitherDateTime<'a> {
     Py(Bound<'a, PyDateTime>),
 }
 
-impl<'a> From<DateTime> for EitherDateTime<'a> {
+impl From<DateTime> for EitherDateTime<'_> {
     fn from(dt: DateTime) -> Self {
         Self::Raw(dt)
     }

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -268,7 +268,6 @@ pub trait ValidatedSet<'py> {
 
 /// This type is used for inputs which don't support certain types.
 /// It implements all the associated traits, but never actually gets called.
-
 pub enum Never {}
 
 impl<'py> ValidatedDict<'py> for Never {
@@ -330,7 +329,10 @@ impl Arguments<'_> for Never {
 }
 
 impl<'py> PositionalArgs<'py> for Never {
-    type Item<'a> = Bound<'py, PyAny> where Self: 'a;
+    type Item<'a>
+        = Bound<'py, PyAny>
+    where
+        Self: 'a;
     fn len(&self) -> usize {
         unreachable!()
     }
@@ -343,8 +345,14 @@ impl<'py> PositionalArgs<'py> for Never {
 }
 
 impl<'py> KeywordArgs<'py> for Never {
-    type Key<'a> = Bound<'py, PyAny> where Self: 'a;
-    type Item<'a> = Bound<'py, PyAny> where Self: 'a;
+    type Key<'a>
+        = Bound<'py, PyAny>
+    where
+        Self: 'a;
+    type Item<'a>
+        = Bound<'py, PyAny>
+    where
+        Self: 'a;
     fn len(&self) -> usize {
         unreachable!()
     }

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -66,9 +66,10 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    type Arguments<'a> = JsonArgs<'a, 'data>
+    type Arguments<'a>
+        = JsonArgs<'a, 'data>
     where
-        Self: 'a,;
+        Self: 'a;
 
     fn validate_args(&self) -> ValResult<JsonArgs<'_, 'data>> {
         match self {
@@ -179,7 +180,10 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    type Dict<'a> = &'a JsonObject<'data> where Self: 'a;
+    type Dict<'a>
+        = &'a JsonObject<'data>
+    where
+        Self: 'a;
 
     fn validate_dict(&self, _strict: bool) -> ValResult<Self::Dict<'_>> {
         match self {
@@ -192,7 +196,10 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         self.validate_dict(false)
     }
 
-    type List<'a> = &'a JsonArray<'data> where Self: 'a;
+    type List<'a>
+        = &'a JsonArray<'data>
+    where
+        Self: 'a;
 
     fn validate_list(&self, _strict: bool) -> ValMatch<&JsonArray<'data>> {
         match self {
@@ -201,7 +208,10 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    type Tuple<'a> = &'a JsonArray<'data> where Self: 'a;
+    type Tuple<'a>
+        = &'a JsonArray<'data>
+    where
+        Self: 'a;
 
     fn validate_tuple(&self, _strict: bool) -> ValMatch<&JsonArray<'data>> {
         // just as in set's case, List has to be allowed
@@ -211,7 +221,10 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    type Set<'a> = &'a JsonArray<'data> where Self: 'a;
+    type Set<'a>
+        = &'a JsonArray<'data>
+    where
+        Self: 'a;
 
     fn validate_set(&self, _strict: bool) -> ValMatch<&JsonArray<'data>> {
         // we allow a list here since otherwise it would be impossible to create a set from JSON
@@ -501,10 +514,16 @@ fn string_to_vec(s: &str) -> JsonArray<'static> {
     JsonArray::new(s.chars().map(|c| JsonValue::Str(c.to_string().into())).collect())
 }
 
-impl<'py, 'data> ValidatedDict<'py> for &'_ JsonObject<'data> {
-    type Key<'a> = &'a str where Self: 'a;
+impl<'data> ValidatedDict<'_> for &'_ JsonObject<'data> {
+    type Key<'a>
+        = &'a str
+    where
+        Self: 'a;
 
-    type Item<'a> = &'a JsonValue<'data> where Self: 'a;
+    type Item<'a>
+        = &'a JsonValue<'data>
+    where
+        Self: 'a;
 
     fn get_item<'k>(&self, key: &'k LookupKey) -> ValResult<Option<(&'k LookupPath, Self::Item<'_>)>> {
         key.json_get(self)
@@ -567,7 +586,7 @@ impl<'a, 'data> JsonArgs<'a, 'data> {
     }
 }
 
-impl<'a, 'data> Arguments<'_> for JsonArgs<'a, 'data> {
+impl<'data> Arguments<'_> for JsonArgs<'_, 'data> {
     type Args = [JsonValue<'data>];
     type Kwargs = JsonObject<'data>;
 
@@ -581,7 +600,10 @@ impl<'a, 'data> Arguments<'_> for JsonArgs<'a, 'data> {
 }
 
 impl<'data> PositionalArgs<'_> for [JsonValue<'data>] {
-    type Item<'a> = &'a JsonValue<'data> where Self: 'a;
+    type Item<'a>
+        = &'a JsonValue<'data>
+    where
+        Self: 'a;
 
     fn len(&self) -> usize {
         <[JsonValue]>::len(self)
@@ -595,8 +617,14 @@ impl<'data> PositionalArgs<'_> for [JsonValue<'data>] {
 }
 
 impl<'data> KeywordArgs<'_> for JsonObject<'data> {
-    type Key<'a> = &'a str where Self: 'a;
-    type Item<'a> = &'a JsonValue<'data> where Self: 'a;
+    type Key<'a>
+        = &'a str
+    where
+        Self: 'a;
+    type Item<'a>
+        = &'a JsonValue<'data>
+    where
+        Self: 'a;
 
     fn len(&self) -> usize {
         LazyIndexMap::len(self)

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -93,7 +93,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
             .map(|dict| dict.to_owned().unbind().into_bound(py))
     }
 
-    type Arguments<'a> = PyArgs<'py> where Self: 'a;
+    type Arguments<'a>
+        = PyArgs<'py>
+    where
+        Self: 'a;
 
     fn validate_args(&self) -> ValResult<PyArgs<'py>> {
         if let Ok(dict) = self.downcast::<PyDict>() {
@@ -350,7 +353,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(error_type, self))
     }
 
-    type Dict<'a> = GenericPyMapping<'a, 'py> where Self: 'a;
+    type Dict<'a>
+        = GenericPyMapping<'a, 'py>
+    where
+        Self: 'a;
 
     fn strict_dict<'a>(&'a self) -> ValResult<GenericPyMapping<'a, 'py>> {
         if let Ok(dict) = self.downcast::<PyDict>() {
@@ -404,7 +410,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
     }
 
-    type List<'a> = PySequenceIterable<'a, 'py> where Self: 'a;
+    type List<'a>
+        = PySequenceIterable<'a, 'py>
+    where
+        Self: 'a;
 
     fn validate_list<'a>(&'a self, strict: bool) -> ValMatch<PySequenceIterable<'a, 'py>> {
         if let Ok(list) = self.downcast::<PyList>() {
@@ -418,7 +427,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::ListType, self))
     }
 
-    type Tuple<'a> = PySequenceIterable<'a, 'py> where Self: 'a;
+    type Tuple<'a>
+        = PySequenceIterable<'a, 'py>
+    where
+        Self: 'a;
 
     fn validate_tuple<'a>(&'a self, strict: bool) -> ValMatch<PySequenceIterable<'a, 'py>> {
         if let Ok(tup) = self.downcast::<PyTuple>() {
@@ -432,7 +444,10 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Err(ValError::new(ErrorTypeDefaults::TupleType, self))
     }
 
-    type Set<'a> = PySequenceIterable<'a, 'py> where Self: 'a;
+    type Set<'a>
+        = PySequenceIterable<'a, 'py>
+    where
+        Self: 'a;
 
     fn validate_set<'a>(&'a self, strict: bool) -> ValMatch<PySequenceIterable<'a, 'py>> {
         if let Ok(set) = self.downcast::<PySet>() {
@@ -742,7 +757,10 @@ impl<'py> Arguments<'py> for PyArgs<'py> {
 }
 
 impl<'py> PositionalArgs<'py> for PyPosArgs<'py> {
-    type Item<'a> = Borrowed<'a, 'py, PyAny> where Self: 'a;
+    type Item<'a>
+        = Borrowed<'a, 'py, PyAny>
+    where
+        Self: 'a;
 
     fn len(&self) -> usize {
         self.0.len()
@@ -758,11 +776,13 @@ impl<'py> PositionalArgs<'py> for PyPosArgs<'py> {
 }
 
 impl<'py> KeywordArgs<'py> for PyKwargs<'py> {
-    type Key<'a> = Bound<'py, PyAny>
+    type Key<'a>
+        = Bound<'py, PyAny>
     where
         Self: 'a;
 
-    type Item<'a> = Bound<'py, PyAny>
+    type Item<'a>
+        = Bound<'py, PyAny>
     where
         Self: 'a;
 
@@ -790,11 +810,13 @@ pub enum GenericPyMapping<'a, 'py> {
 }
 
 impl<'py> ValidatedDict<'py> for GenericPyMapping<'_, 'py> {
-    type Key<'a> = Bound<'py, PyAny>
+    type Key<'a>
+        = Bound<'py, PyAny>
     where
         Self: 'a;
 
-    type Item<'a> = Bound<'py, PyAny>
+    type Item<'a>
+        = Bound<'py, PyAny>
     where
         Self: 'a;
 

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -28,7 +28,7 @@ pub enum StringMapping<'py> {
     Mapping(Bound<'py, PyDict>),
 }
 
-impl<'py> ToPyObject for StringMapping<'py> {
+impl ToPyObject for StringMapping<'_> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         match self {
             Self::String(s) => s.to_object(py),
@@ -83,7 +83,10 @@ impl<'py> Input<'py> for StringMapping<'py> {
         None
     }
 
-    type Arguments<'a> = StringMappingDict<'py> where Self: 'a;
+    type Arguments<'a>
+        = StringMappingDict<'py>
+    where
+        Self: 'a;
 
     fn validate_args(&self) -> ValResult<StringMappingDict<'py>> {
         // do we want to support this?
@@ -150,7 +153,10 @@ impl<'py> Input<'py> for StringMapping<'py> {
         }
     }
 
-    type Dict<'a> = StringMappingDict<'py> where Self: 'a;
+    type Dict<'a>
+        = StringMappingDict<'py>
+    where
+        Self: 'a;
 
     fn strict_dict(&self) -> ValResult<StringMappingDict<'py>> {
         match self {
@@ -159,19 +165,28 @@ impl<'py> Input<'py> for StringMapping<'py> {
         }
     }
 
-    type List<'a> = Never where Self: 'a;
+    type List<'a>
+        = Never
+    where
+        Self: 'a;
 
     fn validate_list(&self, _strict: bool) -> ValMatch<Never> {
         Err(ValError::new(ErrorTypeDefaults::ListType, self))
     }
 
-    type Tuple<'a> = Never where Self: 'a;
+    type Tuple<'a>
+        = Never
+    where
+        Self: 'a;
 
     fn validate_tuple(&self, _strict: bool) -> ValMatch<Never> {
         Err(ValError::new(ErrorTypeDefaults::TupleType, self))
     }
 
-    type Set<'a> = Never where Self: 'a;
+    type Set<'a>
+        = Never
+    where
+        Self: 'a;
 
     fn validate_set(&self, _strict: bool) -> ValMatch<Never> {
         Err(ValError::new(ErrorTypeDefaults::SetType, self))
@@ -259,11 +274,13 @@ impl<'py> Arguments<'py> for StringMappingDict<'py> {
 }
 
 impl<'py> KeywordArgs<'py> for StringMappingDict<'py> {
-    type Key<'a> = StringMapping<'py>
+    type Key<'a>
+        = StringMapping<'py>
     where
         Self: 'a;
 
-    type Item<'a> = StringMapping<'py>
+    type Item<'a>
+        = StringMapping<'py>
     where
         Self: 'a;
 
@@ -283,11 +300,13 @@ impl<'py> KeywordArgs<'py> for StringMappingDict<'py> {
 }
 
 impl<'py> ValidatedDict<'py> for StringMappingDict<'py> {
-    type Key<'a> = StringMapping<'py>
+    type Key<'a>
+        = StringMapping<'py>
     where
         Self: 'a;
 
-    type Item<'a> = StringMapping<'py>
+    type Item<'a>
+        = StringMapping<'py>
     where
         Self: 'a;
     fn get_item<'k>(&self, key: &'k LookupKey) -> ValResult<Option<(&'k LookupPath, Self::Item<'_>)>> {

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -484,7 +484,7 @@ impl<'a> From<&'a str> for EitherString<'a> {
     }
 }
 
-impl<'a> From<String> for EitherString<'a> {
+impl From<String> for EitherString<'_> {
     fn from(data: String) -> Self {
         Self::Cow(Cow::Owned(data))
     }
@@ -511,7 +511,7 @@ pub enum EitherBytes<'a, 'py> {
     Py(Bound<'py, PyBytes>),
 }
 
-impl<'a> From<Vec<u8>> for EitherBytes<'a, '_> {
+impl From<Vec<u8>> for EitherBytes<'_, '_> {
     fn from(bytes: Vec<u8>) -> Self {
         Self::Cow(Cow::Owned(bytes))
     }
@@ -633,7 +633,7 @@ impl<'a> EitherInt<'a> {
     }
 }
 
-impl<'a> IntoPy<PyObject> for EitherInt<'a> {
+impl IntoPy<PyObject> for EitherInt<'_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
             Self::I64(int) => int.into_py(py),
@@ -651,7 +651,7 @@ pub enum EitherFloat<'a> {
     Py(Bound<'a, PyFloat>),
 }
 
-impl<'a> EitherFloat<'a> {
+impl EitherFloat<'_> {
     pub fn as_f64(&self) -> f64 {
         match self {
             EitherFloat::F64(f) => *f,
@@ -660,7 +660,7 @@ impl<'a> EitherFloat<'a> {
     }
 }
 
-impl<'a> IntoPy<PyObject> for EitherFloat<'a> {
+impl IntoPy<PyObject> for EitherFloat<'_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
             Self::F64(float) => float.into_py(py),
@@ -715,7 +715,7 @@ impl PartialEq for Int {
     }
 }
 
-impl<'a> Rem for &'a Int {
+impl Rem for &Int {
     type Output = Int;
 
     fn rem(self, rhs: Self) -> Self::Output {
@@ -752,7 +752,7 @@ pub enum EitherComplex<'a> {
     Py(Bound<'a, PyComplex>),
 }
 
-impl<'a> IntoPy<PyObject> for EitherComplex<'a> {
+impl IntoPy<PyObject> for EitherComplex<'_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
             Self::Complex(c) => PyComplex::from_doubles_bound(py, c[0], c[1]).into_py(py),
@@ -761,7 +761,7 @@ impl<'a> IntoPy<PyObject> for EitherComplex<'a> {
     }
 }
 
-impl<'a> EitherComplex<'a> {
+impl EitherComplex<'_> {
     pub fn as_f64(&self, py: Python<'_>) -> [f64; 2] {
         match self {
             EitherComplex::Complex(f) => *f,

--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -191,7 +191,7 @@ impl PyGcTraverse for ComputedFields {
 
 impl_py_gc_traverse!(ComputedFieldSerializer<'_> { computed_field });
 
-impl<'py> Serialize for ComputedFieldSerializer<'py> {
+impl Serialize for ComputedFieldSerializer<'_> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let py = self.model.py();
         let property_name_py = self.computed_field.property_name_py.bind(py);

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -389,7 +389,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        self._invalid_as_json_key(key, extra, "fields")
+        self.invalid_as_json_key(key, extra, "fields")
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -324,7 +324,7 @@ impl<'py> SerializeInfer<'py> {
     }
 }
 
-impl<'py> Serialize for SerializeInfer<'py> {
+impl Serialize for SerializeInfer<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let ob_type = self.extra.ob_type_lookup.get_type(self.value);
         infer_serialize_known(ob_type, self.value, serializer, self.include, self.exclude, self.extra)

--- a/src/serializers/ser.rs
+++ b/src/serializers/ser.rs
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<'a, W> PythonSerializer<W, PrettyFormatter<'a>>
+impl<W> PythonSerializer<W, PrettyFormatter<'_>>
 where
     W: io::Write,
 {
@@ -388,7 +388,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeSeq for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeSeq for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -436,7 +436,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeTuple for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeTuple for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -458,7 +458,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeTupleStruct for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeTupleStruct for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -480,7 +480,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeTupleVariant for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeTupleVariant for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -522,7 +522,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeMap for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeMap for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -595,7 +595,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeStruct for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeStruct for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -630,7 +630,7 @@ where
     }
 }
 
-impl<'a, W, F> serde::ser::SerializeStructVariant for Compound<'a, W, F>
+impl<W, F> serde::ser::SerializeStructVariant for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -794,7 +794,7 @@ fn invalid_number() -> PythonSerializerError {
     }
 }
 
-impl<'a, W, F> serde::ser::Serializer for MapKeySerializer<'a, W, F>
+impl<W, F> serde::ser::Serializer for MapKeySerializer<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -1124,7 +1124,7 @@ where
 
 struct NumberStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut PythonSerializer<W, F>);
 
-impl<'a, W: io::Write, F: Formatter> serde::ser::Serializer for NumberStrEmitter<'a, W, F> {
+impl<W: io::Write, F: Formatter> serde::ser::Serializer for NumberStrEmitter<'_, W, F> {
     type Ok = ();
     type Error = PythonSerializerError;
 

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -270,7 +270,7 @@ pub(crate) trait TypeSerializer: Send + Sync + Debug {
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>>;
 
-    fn _invalid_as_json_key<'a>(
+    fn invalid_as_json_key<'a>(
         &self,
         key: &'a Bound<'_, PyAny>,
         extra: &Extra,
@@ -332,7 +332,7 @@ impl<'py> PydanticSerializer<'py> {
     }
 }
 
-impl<'py> Serialize for PydanticSerializer<'py> {
+impl Serialize for PydanticSerializer<'_> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.serializer
             .serde_serialize(self.value, serializer, self.include, self.exclude, self.extra)
@@ -369,6 +369,7 @@ pub(crate) fn to_json_bytes(
     Ok(bytes)
 }
 
+#[allow(clippy::type_complexity)]
 pub(super) fn any_dataclass_iter<'a, 'py>(
     dataclass: &'a Bound<'py, PyAny>,
 ) -> PyResult<(

--- a/src/serializers/type_serializers/complex.rs
+++ b/src/serializers/type_serializers/complex.rs
@@ -45,7 +45,7 @@ impl TypeSerializer for ComplexSerializer {
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        self._invalid_as_json_key(key, extra, "complex")
+        self.invalid_as_json_key(key, extra, "complex")
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/type_serializers/dict.rs
+++ b/src/serializers/type_serializers/dict.rs
@@ -106,7 +106,7 @@ impl TypeSerializer for DictSerializer {
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+        self.invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -101,7 +101,7 @@ impl TypeSerializer for GeneratorSerializer {
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+        self.invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/type_serializers/list.rs
+++ b/src/serializers/type_serializers/list.rs
@@ -82,7 +82,7 @@ impl TypeSerializer for ListSerializer {
     }
 
     fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-        self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+        self.invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
     }
 
     fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/type_serializers/set_frozenset.rs
+++ b/src/serializers/type_serializers/set_frozenset.rs
@@ -77,7 +77,7 @@ macro_rules! build_serializer {
             }
 
             fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, extra: &Extra) -> PyResult<Cow<'a, str>> {
-                self._invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
+                self.invalid_as_json_key(key, extra, Self::EXPECTED_TYPE)
             }
 
             fn serde_serialize<S: serde::ser::Serializer>(

--- a/src/serializers/type_serializers/union.rs
+++ b/src/serializers/type_serializers/union.rs
@@ -158,7 +158,7 @@ impl TypeSerializer for UnionSerializer {
             &self.choices,
             self.retry_with_lax_check(),
         ) {
-            Ok(Some(v)) => return infer_serialize(v.bind(value.py()), serializer, None, None, extra),
+            Ok(Some(v)) => infer_serialize(v.bind(value.py()), serializer, None, None, extra),
             Ok(None) => infer_serialize(value, serializer, include, exclude, extra),
             Err(err) => Err(serde::ser::Error::custom(err.to_string())),
         }
@@ -263,7 +263,7 @@ impl TypeSerializer for TaggedUnionSerializer {
             },
             extra,
         ) {
-            Ok(Some(v)) => return infer_serialize(v.bind(value.py()), serializer, None, None, extra),
+            Ok(Some(v)) => infer_serialize(v.bind(value.py()), serializer, None, None, extra),
             Ok(None) => infer_serialize(value, serializer, include, exclude, extra),
             Err(err) => Err(serde::ser::Error::custom(err.to_string())),
         }

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -78,7 +78,7 @@ impl TypeSerializer for WithDefaultSerializer {
             Ok(None)
         } else {
             self.default.default_value(
-                py, &None, // Won't be used.
+                py, None, // Won't be used.
             )
         }
     }

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -124,6 +124,7 @@ impl Validator for FunctionBeforeValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let validate = |v, s: &mut ValidationState<'_, 'py>| self.validator.validate(py, &v, s);
+        #[allow(clippy::used_underscore_items)]
         self._validate(validate, py, input, state)
     }
     fn validate_assignment<'py>(
@@ -137,6 +138,7 @@ impl Validator for FunctionBeforeValidator {
         let validate = move |v, s: &mut ValidationState<'_, 'py>| {
             self.validator.validate_assignment(py, &v, field_name, field_value, s)
         };
+        #[allow(clippy::used_underscore_items)]
         self._validate(validate, py, obj, state)
     }
 
@@ -190,6 +192,7 @@ impl Validator for FunctionAfterValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let validate = |v: &_, s: &mut ValidationState<'_, 'py>| self.validator.validate(py, v, s);
+        #[allow(clippy::used_underscore_items)]
         self._validate(validate, py, input, state)
     }
     fn validate_assignment<'py>(
@@ -203,6 +206,7 @@ impl Validator for FunctionAfterValidator {
         let validate = move |v: &Bound<'py, PyAny>, s: &mut ValidationState<'_, 'py>| {
             self.validator.validate_assignment(py, v, field_name, field_value, s)
         };
+        #[allow(clippy::used_underscore_items)]
         self._validate(validate, py, obj, state)
     }
 
@@ -351,6 +355,7 @@ impl Validator for FunctionWrapValidator {
             ),
         };
         let handler = Bound::new(py, handler)?;
+        #[allow(clippy::used_underscore_items)]
         let result = self._validate(handler.as_any(), py, input, state);
         state.exactness = handler.borrow_mut().validator.exactness;
         result
@@ -376,6 +381,7 @@ impl Validator for FunctionWrapValidator {
             updated_field_name: field_name.to_string(),
             updated_field_value: field_value.to_object(py),
         };
+        #[allow(clippy::used_underscore_items)]
         self._validate(Bound::new(py, handler)?.as_any(), py, obj, state)
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -176,6 +176,7 @@ impl SchemaValidator {
         self_instance: Option<&Bound<'_, PyAny>>,
         allow_partial: PartialMode,
     ) -> PyResult<PyObject> {
+        #[allow(clippy::used_underscore_items)]
         self._validate(
             py,
             input,
@@ -199,6 +200,7 @@ impl SchemaValidator {
         context: Option<&Bound<'_, PyAny>>,
         self_instance: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<bool> {
+        #[allow(clippy::used_underscore_items)]
         match self._validate(
             py,
             input,
@@ -228,6 +230,7 @@ impl SchemaValidator {
         allow_partial: PartialMode,
     ) -> PyResult<PyObject> {
         let r = match json::validate_json_bytes(input) {
+            #[allow(clippy::used_underscore_items)]
             Ok(v_match) => self._validate_json(
                 py,
                 input,
@@ -254,6 +257,7 @@ impl SchemaValidator {
         let t = InputType::String;
         let string_mapping = StringMapping::new_value(input).map_err(|e| self.prepare_validation_err(py, e, t))?;
 
+        #[allow(clippy::used_underscore_items)]
         match self._validate(py, &string_mapping, t, strict, None, context, None, allow_partial) {
             Ok(r) => Ok(r),
             Err(e) => Err(self.prepare_validation_err(py, e, t)),
@@ -383,6 +387,7 @@ impl SchemaValidator {
     ) -> ValResult<PyObject> {
         let json_value = jiter::JsonValue::parse_with_config(json_data, true, allow_partial)
             .map_err(|e| json::map_json_err(input, e, json_data))?;
+        #[allow(clippy::used_underscore_items)]
         self._validate(
             py,
             &json_value,

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -86,9 +86,9 @@ impl Validator for UrlValidator {
         match check_sub_defaults(
             &mut either_url,
             self.host_required,
-            &self.default_host,
+            self.default_host.as_ref(),
             self.default_port,
-            &self.default_path,
+            self.default_path.as_ref(),
         ) {
             Ok(()) => {
                 // Lax rather than strict to preserve V2.4 semantic that str wins over url in union
@@ -251,9 +251,9 @@ impl Validator for MultiHostUrlValidator {
         match check_sub_defaults(
             &mut multi_url,
             self.host_required,
-            &self.default_host,
+            self.default_host.as_ref(),
             self.default_port,
-            &self.default_path,
+            self.default_path.as_ref(),
         ) {
             Ok(()) => {
                 // Lax rather than strict to preserve V2.4 semantic that str wins over url in union
@@ -536,9 +536,9 @@ fn parse_url(url_str: &str, input: impl ToErrorValue, strict: bool) -> ValResult
 fn check_sub_defaults(
     url: &mut impl CopyFromPyUrl,
     host_required: bool,
-    default_host: &Option<String>,
+    default_host: Option<&String>,
     default_port: Option<u16>,
-    default_path: &Option<String>,
+    default_path: Option<&String>,
 ) -> Result<(), ErrorType> {
     let map_parse_err = |e: ParseError| ErrorType::UrlParsing {
         error: e.to_string(),
@@ -546,7 +546,7 @@ fn check_sub_defaults(
     };
 
     if !url.url().has_host() {
-        if let Some(ref default_host) = default_host {
+        if let Some(default_host) = default_host {
             url.url_mut().set_host(Some(default_host)).map_err(map_parse_err)?;
         } else if host_required {
             return Err(ErrorType::UrlParsing {
@@ -562,7 +562,7 @@ fn check_sub_defaults(
                 .map_err(|()| map_parse_err(ParseError::EmptyHost))?;
         }
     }
-    if let Some(ref default_path) = default_path {
+    if let Some(default_path) = default_path {
         let path = url.url().path();
         if path.is_empty() || path == "/" {
             url.url_mut().set_path(default_path);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes lint errors that came up with the new stable toolchain version 1.83. Simply followed the tools' suggestions. Specifically for `clippy::used_underscore_items` though,
* for `_invalid_as_json_key`, I removed the prefix underscore because that was rather simple and there was no conflict in naming.
* for others, I applied `#[allow(clippy::used_underscore_items)]` to suppress the warning because there would be a collision and I cannot really decide on naming. Perhaps someone can revisit that later on.

Same for `clippy::type_complexity` in `src/serializers/shared.rs`.

## Related issue number

Fixes #1560.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
