### PR TITLE
remove `python3-dll-a` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,6 @@ dependencies = [
  "num-bigint",
  "pyo3",
  "pyo3-build-config",
- "python3-dll-a",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ url = "2.5.0"
 idna = "1.0.2"
 base64 = "0.22.1"
 num-bigint = "0.4.6"
-python3-dll-a = "0.2.10"
 uuid = "1.11.0"
 jiter = { version = "0.8.0", features = ["python"] }
 hex = "0.4.3"


### PR DESCRIPTION
## Change Summary

`python3-dll-a` is a build dependency used internally by PyO3, we don't need to specify it here at all.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
