### PR TITLE
Forward `default_value` calls to the underlying schema for `DefinitionRefValidator`

### DIFF
--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -92,6 +92,18 @@ impl Validator for DefinitionRefValidator {
         })
     }
 
+    fn default_value<'py>(
+        &self,
+        _py: Python<'py>,
+        _outer_loc: Option<impl Into<crate::errors::LocItem>>,
+        _state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Option<PyObject>> {
+        self.definition.read(|validator| {
+            let validator = validator.unwrap();
+            validator.default_value(_py, _outer_loc, _state)
+        })
+    }
+
     fn validate_assignment<'py>(
         &self,
         py: Python<'py>,

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -150,3 +150,17 @@ def test_definition_chain():
         ),
     )
     assert v.validate_python('1') == 1
+
+
+def test_forwards_get_default_value():
+    v = SchemaValidator(
+        core_schema.definitions_schema(
+            core_schema.definition_reference_schema('foo'),
+            [core_schema.with_default_schema(core_schema.int_schema(), default=1, ref='foo')],
+        )
+    )
+
+    default = v.get_default_value()
+
+    assert default is not None
+    assert default.value == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11051.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
