### PR TITLE
Consistent validation with complex number to float type coercion

### DIFF
--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -291,6 +291,18 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
             return Ok(ValidationMatch::exact(EitherFloat::Py(float.clone())));
         }
 
+        if self.is_instance_of::<PyComplex>() {
+            if !strict {
+                if let Ok(real) = self.getattr(intern!(self.py(), "real")) {
+                    if let Ok(float) = real.extract::<f64>() {
+                        return Ok(ValidationMatch::lax(EitherFloat::F64(float)));
+                    }
+                }
+            } else {
+                return Err(ValError::new(ErrorTypeDefaults::FloatType, self));
+            }
+        }
+
         if !strict {
             if let Some(s) = maybe_as_string(self, ErrorTypeDefaults::FloatParsing)? {
                 // checking for bytes and string is fast, so do this before isinstance(float)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

When validating floats in non-strict mode, this PR adds support for properly handling complex to float coercion by 
by extracting their real component, this behavior is prohibited in strict mode and returns ValidationError. Appropriate unit tests are added to `test_float` and `test_float_strict` .

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Fixes https://github.com/pydantic/pydantic/issues/10430

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

