### PR TITLE
Move from `_bound` suffixed APIs as part of PyO3 0.23 update

### DIFF
--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -90,7 +90,7 @@ impl SchemaError {
                     ValidationError::new(line_errors, "Schema".to_object(py), InputType::Python, false);
                 let schema_error = SchemaError(SchemaErrorEnum::ValidationError(validation_error));
                 match Py::new(py, schema_error) {
-                    Ok(err) => PyErr::from_value_bound(err.into_bound(py).into_any()),
+                    Ok(err) => PyErr::from_value(err.into_bound(py).into_any()),
                     Err(err) => err,
                 }
             }

--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -124,7 +124,7 @@ impl SchemaError {
 
     fn errors(&self, py: Python) -> PyResult<Py<PyList>> {
         match &self.0 {
-            SchemaErrorEnum::Message(_) => Ok(PyList::empty_bound(py).unbind()),
+            SchemaErrorEnum::Message(_) => Ok(PyList::empty(py).unbind()),
             SchemaErrorEnum::ValidationError(error) => error.errors(py, false, false, true),
         }
     }

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -12,7 +12,7 @@ use crate::lookup_key::{LookupPath, PathItem};
 
 /// Used to store individual items of the error location, e.g. a string for key/field names
 /// or a number for array indices.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, IntoPyObjectRef)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum LocItem {
     /// string type key, used to identify items from a dict or anything that implements `__getitem__`
@@ -133,7 +133,7 @@ static EMPTY_TUPLE: GILOnceCell<PyObject> = GILOnceCell::new();
 impl ToPyObject for Location {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         match self {
-            Self::List(loc) => PyTuple::new_bound(py, loc.iter().rev()).to_object(py),
+            Self::List(loc) => PyTuple::new(py, loc.iter().rev()).unwrap().to_object(py),
             Self::Empty => EMPTY_TUPLE
                 .get_or_init(py, || PyTuple::empty_bound(py).to_object(py))
                 .clone_ref(py),

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -135,7 +135,7 @@ impl ToPyObject for Location {
         match self {
             Self::List(loc) => PyTuple::new(py, loc.iter().rev()).unwrap().to_object(py),
             Self::Empty => EMPTY_TUPLE
-                .get_or_init(py, || PyTuple::empty_bound(py).to_object(py))
+                .get_or_init(py, || PyTuple::empty(py).to_object(py))
                 .clone_ref(py),
         }
     }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -13,7 +13,7 @@ pub use self::validation_exception::ValidationError;
 pub use self::value_exception::{PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault};
 
 pub fn py_err_string(py: Python, err: PyErr) -> String {
-    let value = err.value_bound(py);
+    let value = err.value(py);
     match value.get_type().qualname() {
         Ok(type_name) => match value.str() {
             Ok(py_str) => {

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -22,7 +22,7 @@ pub fn list_all_errors(py: Python) -> PyResult<Bound<'_, PyList>> {
     let mut errors: Vec<Bound<'_, PyDict>> = Vec::with_capacity(100);
     for error_type in ErrorType::iter() {
         if !matches!(error_type, ErrorType::CustomError { .. }) {
-            let d = PyDict::new_bound(py);
+            let d = PyDict::new(py);
             d.set_item("type", error_type.to_string())?;
             let message_template_python = error_type.message_template_python();
             d.set_item("message_template_python", message_template_python)?;
@@ -39,7 +39,7 @@ pub fn list_all_errors(py: Python) -> PyResult<Bound<'_, PyList>> {
             errors.push(d);
         }
     }
-    Ok(PyList::new_bound(py, errors))
+    PyList::new(py, errors)
 }
 
 fn field_from_context<'py, T: FromPyObject<'py>>(
@@ -745,7 +745,7 @@ impl ErrorType {
     }
 
     pub fn py_dict(&self, py: Python) -> PyResult<Option<Py<PyDict>>> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         let custom_ctx_used = self.py_dict_update_ctx(py, &dict)?;
 
         if let Self::CustomError { .. } = self {

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -167,7 +167,7 @@ impl ValidationError {
             #[cfg(not(Py_3_11))]
             let cause = {
                 use pyo3::exceptions::PyImportError;
-                match py.import_bound("exceptiongroup") {
+                match py.import("exceptiongroup") {
                     Ok(py_mod) => match py_mod.getattr("ExceptionGroup") {
                         Ok(group_cls) => match group_cls.call1((title, user_py_errs)) {
                             Ok(group_instance) => Some(group_instance.into_py(py)),

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -298,7 +298,7 @@ impl ValidationError {
     ) -> PyResult<Py<PyList>> {
         let url_prefix = get_url_prefix(py, include_url);
         let mut iteration_error = None;
-        let list = PyList::new_bound(
+        let list = PyList::new(
             py,
             // PyList::new takes ExactSizeIterator, so if an error occurs during iteration we
             // fill the list with None before returning the error; the list will then be thrown
@@ -313,7 +313,7 @@ impl ValidationError {
                         py.None()
                     })
             }),
-        );
+        )?;
         if let Some(err) = iteration_error {
             Err(err)
         } else {
@@ -368,7 +368,7 @@ impl ValidationError {
             }
         };
         let s = from_utf8(&bytes).map_err(json_py_err)?;
-        Ok(PyString::new_bound(py, s))
+        Ok(PyString::new(py, s))
     }
 
     fn __repr__(&self, py: Python) -> String {
@@ -489,7 +489,7 @@ impl PyLineError {
         input_type: InputType,
         include_input: bool,
     ) -> PyResult<PyObject> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         dict.set_item("type", self.error_type.type_string())?;
         dict.set_item("loc", self.location.to_object(py))?;
         dict.set_item("msg", self.error_type.render_message(py, input_type)?)?;

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Write};
 use std::str::from_utf8;
 
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
-use pyo3::ffi;
+use pyo3::ffi::{self, c_str};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
@@ -73,7 +73,7 @@ impl ValidationError {
                                 return cause_problem;
                             }
                         }
-                        PyErr::from_value_bound(err.into_bound(py).into_any())
+                        PyErr::from_value(err.into_bound(py).into_any())
                     }
                     Err(err) => err,
                 }
@@ -145,7 +145,7 @@ impl ValidationError {
                     use pyo3::exceptions::PyUserWarning;
 
                     let wrapped = PyUserWarning::new_err((note,));
-                    wrapped.set_cause(py, Some(PyErr::from_value_bound(err.clone_ref(py).into_bound(py))));
+                    wrapped.set_cause(py, Some(PyErr::from_value(err.clone_ref(py).into_bound(py))));
                     user_py_errs.push(wrapped);
                 }
             }
@@ -202,10 +202,10 @@ fn include_url_env(py: Python) -> bool {
         match std::env::var_os("PYDANTIC_ERRORS_OMIT_URL") {
             Some(val) => {
                 // We don't care whether warning succeeded or not, hence the assignment
-                let _ = PyErr::warn_bound(
+                let _ = PyErr::warn(
                     py,
-                    &py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                    "PYDANTIC_ERRORS_OMIT_URL is deprecated, use PYDANTIC_ERRORS_INCLUDE_URL instead",
+                    &py.get_type::<pyo3::exceptions::PyDeprecationWarning>(),
+                    c_str!("PYDANTIC_ERRORS_OMIT_URL is deprecated, use PYDANTIC_ERRORS_INCLUDE_URL instead"),
                     1,
                 );
                 // If OMIT_URL exists but is empty, we include the URL:

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -56,7 +56,7 @@ impl EitherDate<'_> {
     pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
         let date = match self {
             Self::Py(date) => Ok(date),
-            Self::Raw(date) => PyDate::new_bound(py, date.year.into(), date.month, date.day),
+            Self::Raw(date) => PyDate::new(py, date.year.into(), date.month, date.day),
         }?;
         Ok(date.into_py(py))
     }
@@ -165,7 +165,7 @@ pub fn pytimedelta_subclass_as_duration(py_timedelta: &Bound<'_, PyDelta>) -> Py
 
 pub fn duration_as_pytimedelta<'py>(py: Python<'py>, duration: &Duration) -> PyResult<Bound<'py, PyDelta>> {
     let sign = if duration.positive { 1 } else { -1 };
-    PyDelta::new_bound(
+    PyDelta::new(
         py,
         sign * duration.day as i32,
         sign * duration.second as i32,
@@ -211,7 +211,7 @@ impl EitherTime<'_> {
     pub fn try_into_py(self, py: Python<'_>) -> PyResult<PyObject> {
         let time = match self {
             Self::Py(time) => Ok(time),
-            Self::Raw(time) => PyTime::new_bound(
+            Self::Raw(time) => PyTime::new(
                 py,
                 time.hour,
                 time.minute,
@@ -269,7 +269,7 @@ impl<'a> EitherDateTime<'a> {
 
     pub fn try_into_py(self, py: Python<'a>) -> PyResult<PyObject> {
         let dt = match self {
-            Self::Raw(datetime) => PyDateTime::new_bound(
+            Self::Raw(datetime) => PyDateTime::new(
                 py,
                 datetime.date.year.into(),
                 datetime.date.month,
@@ -393,7 +393,7 @@ pub fn float_as_datetime<'py>(input: &(impl Input<'py> + ?Sized), timestamp: f64
 
 pub fn date_as_datetime<'py>(date: &Bound<'py, PyDate>) -> PyResult<EitherDateTime<'py>> {
     let py = date.py();
-    let dt = PyDateTime::new_bound(
+    let dt = PyDateTime::new(
         py,
         date.getattr(intern!(py, "year"))?.extract()?,
         date.getattr(intern!(py, "month"))?.extract()?,
@@ -518,7 +518,7 @@ impl TzInfo {
 
     #[allow(unused_variables)]
     fn utcoffset<'py>(&self, py: Python<'py>, dt: &Bound<'_, PyAny>) -> PyResult<Bound<'py, PyDelta>> {
-        PyDelta::new_bound(py, 0, self.seconds, 0, true)
+        PyDelta::new(py, 0, self.seconds, 0, true)
     }
 
     #[allow(unused_variables)]

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -56,7 +56,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
     fn as_kwargs(&self, py: Python<'py>) -> Option<Bound<'py, PyDict>> {
         match self {
             JsonValue::Object(object) => {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 for (k, v) in LazyIndexMap::iter(object) {
                     dict.set_item(k, v.to_object(py)).unwrap();
                 }
@@ -171,7 +171,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
     fn validate_decimal(&self, _strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
             JsonValue::Float(f) => {
-                create_decimal(&PyString::new_bound(py, &f.to_string()), self).map(ValidationMatch::strict)
+                create_decimal(&PyString::new(py, &f.to_string()), self).map(ValidationMatch::strict)
             }
             JsonValue::Str(..) | JsonValue::Int(..) | JsonValue::BigInt(..) => {
                 create_decimal(self.to_object(py).bind(py), self).map(ValidationMatch::strict)
@@ -324,7 +324,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
     fn validate_complex(&self, strict: bool, py: Python<'py>) -> ValResult<ValidationMatch<EitherComplex<'py>>> {
         match self {
             JsonValue::Str(s) => Ok(ValidationMatch::strict(EitherComplex::Py(string_to_complex(
-                &PyString::new_bound(py, s),
+                &PyString::new(py, s),
                 self,
             )?))),
             JsonValue::Float(f) => {

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -87,10 +87,8 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         Some(self)
     }
 
-    fn as_kwargs(&self, py: Python<'py>) -> Option<Bound<'py, PyDict>> {
-        self.downcast::<PyDict>()
-            .ok()
-            .map(|dict| dict.to_owned().unbind().into_bound(py))
+    fn as_kwargs(&self, _py: Python<'py>) -> Option<Bound<'py, PyDict>> {
+        self.downcast::<PyDict>().ok().map(Bound::to_owned)
     }
 
     type Arguments<'a>
@@ -620,7 +618,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         if strict {
             return Err(ValError::new(
                 ErrorType::IsInstanceOf {
-                    class: PyComplex::type_object_bound(py)
+                    class: PyComplex::type_object(py)
                         .qualname()
                         .and_then(|name| name.extract())
                         .unwrap_or_else(|_| "complex".to_owned()),

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -548,7 +548,7 @@ impl EitherBytes<'_, '_> {
 impl IntoPy<PyObject> for EitherBytes<'_, '_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
-            EitherBytes::Cow(bytes) => PyBytes::new_bound(py, &bytes).into_py(py),
+            EitherBytes::Cow(bytes) => PyBytes::new(py, &bytes).into_py(py),
             EitherBytes::Py(py_bytes) => py_bytes.into_py(py),
         }
     }

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -755,7 +755,7 @@ pub enum EitherComplex<'a> {
 impl IntoPy<PyObject> for EitherComplex<'_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self {
-            Self::Complex(c) => PyComplex::from_doubles_bound(py, c[0], c[1]).into_py(py),
+            Self::Complex(c) => PyComplex::from_doubles(py, c[0], c[1]).into_py(py),
             Self::Py(c) => c.into_py(py),
         }
     }

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -14,7 +14,7 @@ static ENUM_META_OBJECT: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
 pub fn get_enum_meta_object(py: Python) -> &Bound<'_, PyAny> {
     ENUM_META_OBJECT
         .get_or_init(py, || {
-            py.import_bound(intern!(py, "enum"))
+            py.import(intern!(py, "enum"))
                 .and_then(|enum_module| enum_module.getattr(intern!(py, "EnumMeta")))
                 .unwrap()
                 .into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ fn get_pydantic_version(py: Python<'_>) -> Option<&'static str> {
 
     PYDANTIC_VERSION
         .get_or_init(py, || {
-            py.import_bound("pydantic")
+            py.import("pydantic")
                 .and_then(|pydantic| pydantic.getattr("__version__")?.extract())
                 .ok()
         })

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -511,7 +511,7 @@ fn py_get_attrs<'py>(obj: &Bound<'py, PyAny>, attr_name: &Py<PyString>) -> PyRes
     match obj.getattr(attr_name) {
         Ok(attr) => Ok(Some(attr)),
         Err(err) => {
-            if err.get_type_bound(obj.py()).is_subclass_of::<PyAttributeError>()? {
+            if err.get_type(obj.py()).is_subclass_of::<PyAttributeError>()? {
                 Ok(None)
             } else {
                 Err(err)

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -63,7 +63,7 @@ impl LookupKey {
                     py_key1: alias_py.clone().into(),
                     path1,
                     key2: alt_alias.to_string(),
-                    py_key2: PyString::new_bound(py, alt_alias).into(),
+                    py_key2: PyString::new(py, alt_alias).into(),
                     path2: LookupPath::from_str(py, alt_alias, None),
                 }),
                 None => Ok(Self::simple(py, &alias, Some(alias_py.clone()))),
@@ -97,7 +97,7 @@ impl LookupKey {
     fn simple(py: Python, key: &str, opt_py_key: Option<Bound<'_, PyString>>) -> Self {
         let py_key = match &opt_py_key {
             Some(py_key) => py_key.clone(),
-            None => PyString::new_bound(py, key),
+            None => PyString::new(py, key),
         };
         Self::Simple {
             key: key.to_string(),
@@ -346,7 +346,7 @@ impl LookupPath {
     fn from_str(py: Python, key: &str, py_key: Option<Bound<'_, PyString>>) -> Self {
         let py_key = match py_key {
             Some(py_key) => py_key,
-            None => PyString::new_bound(py, key),
+            None => PyString::new(py, key),
         };
         Self(vec![PathItem::S(key.to_string(), py_key.into())])
     }

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -189,8 +189,8 @@ impl BytesMode {
 }
 
 pub fn utf8_py_error(py: Python, err: Utf8Error, data: &[u8]) -> PyErr {
-    match pyo3::exceptions::PyUnicodeDecodeError::new_utf8_bound(py, data, err) {
-        Ok(decode_err) => PyErr::from_value_bound(decode_err.into_any()),
+    match pyo3::exceptions::PyUnicodeDecodeError::new_utf8(py, data, err) {
+        Ok(decode_err) => PyErr::from_value(decode_err.into_any()),
         Err(err) => err,
     }
 }

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -408,7 +408,7 @@ impl CollectWarnings {
             let type_name = value
                 .get_type()
                 .qualname()
-                .unwrap_or_else(|_| PyString::new_bound(value.py(), "<unknown python object>"));
+                .unwrap_or_else(|_| PyString::new(value.py(), "<unknown python object>"));
 
             let value_str = truncate_safe_repr(value, None);
             Err(PydanticSerializationUnexpectedValue::new_err(Some(format!(
@@ -445,7 +445,7 @@ impl CollectWarnings {
             let type_name = value
                 .get_type()
                 .qualname()
-                .unwrap_or_else(|_| PyString::new_bound(value.py(), "<unknown python object>"));
+                .unwrap_or_else(|_| PyString::new(value.py(), "<unknown python object>"));
 
             let value_str = truncate_safe_repr(value, None);
 

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -1,3 +1,4 @@
+use std::ffi::CString;
 use std::fmt;
 use std::sync::Mutex;
 
@@ -472,7 +473,7 @@ impl CollectWarnings {
         let message = format!("Pydantic serializer warnings:\n  {}", warnings.join("\n  "));
         if self.mode == WarningsMode::Warn {
             let user_warning_type = PyUserWarning::type_object(py);
-            PyErr::warn_bound(py, &user_warning_type, &message, 0)
+            PyErr::warn(py, &user_warning_type, &CString::new(message)?, 0)
         } else {
             Err(PydanticSerializationError::new_err(message))
         }

--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -41,9 +41,7 @@ impl SerField {
         serializer: Option<CombinedSerializer>,
         required: bool,
     ) -> Self {
-        let alias_py = alias
-            .as_ref()
-            .map(|alias| PyString::new_bound(py, alias.as_str()).into());
+        let alias_py = alias.as_ref().map(|alias| PyString::new(py, alias.as_str()).into());
         Self {
             key_py,
             alias,
@@ -153,7 +151,7 @@ impl GeneralFieldsSerializer {
         exclude: Option<&Bound<'py, PyAny>>,
         extra: Extra,
     ) -> PyResult<Bound<'py, PyDict>> {
-        let output_dict = PyDict::new_bound(py);
+        let output_dict = PyDict::new(py);
         let mut used_req_fields: usize = 0;
 
         // NOTE! we maintain the order of the input dict assuming that's right

--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -40,7 +40,7 @@ fn map_negative_indices<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     let py = include_or_exclude.py();
     if let Ok(exclude_dict) = include_or_exclude.downcast::<PyDict>() {
-        let out = PyDict::new_bound(py);
+        let out = PyDict::new(py);
         for (k, v) in exclude_dict.iter() {
             out.set_item(map_negative_index(&k, len)?, v)?;
         }
@@ -50,7 +50,7 @@ fn map_negative_indices<'py>(
         for v in exclude_set.iter() {
             values.push(map_negative_index(&v, len)?);
         }
-        Ok(PySet::new_bound(py, &values)?.into_any())
+        Ok(PySet::new(py, &values)?.into_any())
     } else {
         // return as is and deal with the error later
         Ok(include_or_exclude.clone())
@@ -356,7 +356,7 @@ fn as_dict<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
         dict.copy()
     } else if let Ok(set) = value.downcast::<PySet>() {
         let py = value.py();
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for item in set.iter() {
             dict.set_item(item, py.Ellipsis())?;
         }

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -131,7 +131,7 @@ pub(crate) fn infer_to_python_known(
                 v.into_py(py)
             }
             ObType::Decimal => value.to_string().into_py(py),
-            ObType::StrSubclass => PyString::new_bound(py, value.downcast::<PyString>()?.to_str()?).into(),
+            ObType::StrSubclass => PyString::new(py, value.downcast::<PyString>()?.to_str()?).into(),
             ObType::Bytes => extra
                 .config
                 .bytes_mode
@@ -150,24 +150,24 @@ pub(crate) fn infer_to_python_known(
             }
             ObType::Tuple => {
                 let elements = serialize_seq_filter!(PyTuple);
-                PyList::new_bound(py, elements).into_py(py)
+                PyList::new(py, elements)?.into_py(py)
             }
             ObType::List => {
                 let elements = serialize_seq_filter!(PyList);
-                PyList::new_bound(py, elements).into_py(py)
+                PyList::new(py, elements)?.into_py(py)
             }
             ObType::Set => {
                 let elements = serialize_seq!(PySet);
-                PyList::new_bound(py, elements).into_py(py)
+                PyList::new(py, elements)?.into_py(py)
             }
             ObType::Frozenset => {
                 let elements = serialize_seq!(PyFrozenSet);
-                PyList::new_bound(py, elements).into_py(py)
+                PyList::new(py, elements)?.into_py(py)
             }
             ObType::Dict => {
                 let dict = value.downcast::<PyDict>()?;
                 serialize_pairs_python(py, dict.iter().map(Ok), include, exclude, extra, |k| {
-                    Ok(PyString::new_bound(py, &infer_json_key(&k, extra)?).into_any())
+                    Ok(PyString::new(py, &infer_json_key(&k, extra)?).into_any())
                 })?
             }
             ObType::Datetime => {
@@ -204,7 +204,7 @@ pub(crate) fn infer_to_python_known(
             ObType::PydanticSerializable => serialize_with_serializer()?,
             ObType::Dataclass => {
                 serialize_pairs_python(py, any_dataclass_iter(value)?.0, include, exclude, extra, |k| {
-                    Ok(PyString::new_bound(py, &infer_json_key(&k, extra)?).into_any())
+                    Ok(PyString::new(py, &infer_json_key(&k, extra)?).into_any())
                 })?
             }
             ObType::Enum => {
@@ -228,7 +228,7 @@ pub(crate) fn infer_to_python_known(
                         )?);
                     }
                 }
-                PyList::new_bound(py, items).into_py(py)
+                PyList::new(py, items)?.into_py(py)
             }
             ObType::Complex => {
                 let v = value.downcast::<PyComplex>()?;
@@ -252,19 +252,19 @@ pub(crate) fn infer_to_python_known(
         _ => match ob_type {
             ObType::Tuple => {
                 let elements = serialize_seq_filter!(PyTuple);
-                PyTuple::new_bound(py, elements).into_py(py)
+                PyTuple::new(py, elements)?.into_py(py)
             }
             ObType::List => {
                 let elements = serialize_seq_filter!(PyList);
-                PyList::new_bound(py, elements).into_py(py)
+                PyList::new(py, elements)?.into_py(py)
             }
             ObType::Set => {
                 let elements = serialize_seq!(PySet);
-                PySet::new_bound(py, &elements)?.into_py(py)
+                PySet::new(py, &elements)?.into_py(py)
             }
             ObType::Frozenset => {
                 let elements = serialize_seq!(PyFrozenSet);
-                PyFrozenSet::new_bound(py, &elements)?.into_py(py)
+                PyFrozenSet::new(py, &elements)?.into_py(py)
             }
             ObType::Dict => {
                 let dict = value.downcast::<PyDict>()?;
@@ -708,7 +708,7 @@ fn serialize_pairs_python<'py>(
     extra: &Extra,
     key_transform: impl Fn(Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>>,
 ) -> PyResult<PyObject> {
-    let new_dict = PyDict::new_bound(py);
+    let new_dict = PyDict::new(py);
     let filter = AnyFilter::new();
 
     for result in pairs_iter {

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -209,7 +209,7 @@ impl SchemaSerializer {
         warnings.final_check(py)?;
 
         self.expected_json_size.store(bytes.len(), Ordering::Relaxed);
-        let py_bytes = PyBytes::new_bound(py, &bytes);
+        let py_bytes = PyBytes::new(py, &bytes);
         Ok(py_bytes.into())
     }
 
@@ -278,7 +278,7 @@ pub fn to_json(
     let serializer = type_serializers::any::AnySerializer.into();
     let bytes = to_json_bytes(value, &serializer, include, exclude, &extra, indent, 1024)?;
     state.final_check(py)?;
-    let py_bytes = PyBytes::new_bound(py, &bytes);
+    let py_bytes = PyBytes::new(py, &bytes);
     Ok(py_bytes.into())
 }
 

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -69,12 +69,7 @@ impl ObTypeLookup {
             float: PyFloat::type_object_raw(py) as usize,
             list: PyList::type_object_raw(py) as usize,
             dict: PyDict::type_object_raw(py) as usize,
-            decimal_object: py
-                .import_bound("decimal")
-                .unwrap()
-                .getattr("Decimal")
-                .unwrap()
-                .to_object(py),
+            decimal_object: py.import("decimal").unwrap().getattr("Decimal").unwrap().to_object(py),
             string: PyString::type_object_raw(py) as usize,
             bytes: PyBytes::type_object_raw(py) as usize,
             bytearray: PyByteArray::type_object_raw(py) as usize,
@@ -87,21 +82,16 @@ impl ObTypeLookup {
             timedelta: PyDelta::type_object_raw(py) as usize,
             url: PyUrl::type_object_raw(py) as usize,
             multi_host_url: PyMultiHostUrl::type_object_raw(py) as usize,
-            enum_object: py.import_bound("enum").unwrap().getattr("Enum").unwrap().to_object(py),
+            enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().to_object(py),
             generator_object: py
-                .import_bound("types")
+                .import("types")
                 .unwrap()
                 .getattr("GeneratorType")
                 .unwrap()
                 .to_object(py),
-            path_object: py
-                .import_bound("pathlib")
-                .unwrap()
-                .getattr("Path")
-                .unwrap()
-                .to_object(py),
-            pattern_object: py.import_bound("re").unwrap().getattr("Pattern").unwrap().to_object(py),
-            uuid_object: py.import_bound("uuid").unwrap().getattr("UUID").unwrap().to_object(py),
+            path_object: py.import("pathlib").unwrap().getattr("Path").unwrap().to_object(py),
+            pattern_object: py.import("re").unwrap().getattr("Pattern").unwrap().to_object(py),
+            uuid_object: py.import("uuid").unwrap().getattr("UUID").unwrap().to_object(py),
             complex: PyComplex::type_object_raw(py) as usize,
         }
     }

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -403,7 +403,7 @@ static DC_FIELD_MARKER: GILOnceCell<PyObject> = GILOnceCell::new();
 /// needed to match the logic from dataclasses.fields `tuple(f for f in fields.values() if f._field_type is _FIELD)`
 fn get_field_marker(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
     let field_type_marker_obj = DC_FIELD_MARKER.get_or_try_init(py, || {
-        py.import_bound("dataclasses")?.getattr("_FIELD").map(|f| f.into_py(py))
+        py.import("dataclasses")?.getattr("_FIELD").map(|f| f.into_py(py))
     })?;
     Ok(field_type_marker_obj.bind(py).clone())
 }

--- a/src/serializers/type_serializers/dataclass.rs
+++ b/src/serializers/type_serializers/dataclass.rs
@@ -41,7 +41,7 @@ impl BuildSerializer for DataclassArgsBuilder {
             let field_info = item.downcast::<PyDict>()?;
             let name: String = field_info.get_as_req(intern!(py, "name"))?;
 
-            let key_py: Py<PyString> = PyString::new_bound(py, &name).into();
+            let key_py: Py<PyString> = PyString::new(py, &name).into();
 
             if field_info.get_as(intern!(py, "serialization_exclude"))? == Some(true) {
                 fields.insert(name, SerField::new(py, key_py, None, None, true));
@@ -113,7 +113,7 @@ impl DataclassSerializer {
 
     fn get_inner_value<'py>(&self, value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
         let py = value.py();
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
 
         for field_name in &self.fields {
             let field_name = field_name.bind(py);

--- a/src/serializers/type_serializers/dict.rs
+++ b/src/serializers/type_serializers/dict.rs
@@ -83,7 +83,7 @@ impl TypeSerializer for DictSerializer {
             Ok(py_dict) => {
                 let value_serializer = self.value_serializer.as_ref();
 
-                let new_dict = PyDict::new_bound(py);
+                let new_dict = PyDict::new(py);
                 for (key, value) in py_dict.iter() {
                     let op_next = self.filter.key_filter(&key, include, exclude)?;
                     if let Some((next_include, next_exclude)) = op_next {

--- a/src/serializers/type_serializers/format.rs
+++ b/src/serializers/type_serializers/format.rs
@@ -75,7 +75,7 @@ impl BuildSerializer for FormatSerializer {
         } else {
             Ok(Self {
                 format_func: py
-                    .import_bound(intern!(py, "builtins"))?
+                    .import(intern!(py, "builtins"))?
                     .getattr(intern!(py, "format"))?
                     .into_py(py),
                 formatting_string: formatting_string.unbind(),

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -189,7 +189,7 @@ impl FunctionPlainSerializer {
 }
 
 fn on_error(py: Python, err: PyErr, function_name: &str, extra: &Extra) -> PyResult<()> {
-    let exception = err.value_bound(py);
+    let exception = err.value(py);
     if let Ok(ser_err) = exception.extract::<PydanticSerializationUnexpectedValue>() {
         if extra.check.enabled() {
             Err(err)

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -638,7 +638,7 @@ impl SerializationInfo {
 
     #[getter]
     fn __dict__<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         if let Some(ref include) = self.include {
             d.set_item("include", include)?;
         }
@@ -689,7 +689,7 @@ impl SerializationInfo {
     #[getter]
     fn get_field_name<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
         match self.field_name {
-            Some(ref field_name) => Ok(PyString::new_bound(py, field_name)),
+            Some(ref field_name) => Ok(PyString::new(py, field_name)),
             None => Err(PyAttributeError::new_err("No attribute named 'field_name'")),
         }
     }

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -40,7 +40,7 @@ impl BuildSerializer for LiteralSerializer {
         let mut expected_int = AHashSet::new();
         let mut expected_str = AHashSet::new();
         let py = expected.py();
-        let expected_py = PyList::empty_bound(py);
+        let expected_py = PyList::empty(py);
         let mut repr_args: Vec<String> = Vec::new();
         for item in expected {
             repr_args.push(item.repr()?.extract()?);

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -89,7 +89,7 @@ impl LiteralSerializer {
                 if let Ok(py_str) = value.downcast::<PyString>() {
                     let s = py_str.to_str()?;
                     if self.expected_str.contains(s) {
-                        return Ok(OutputValue::OkStr(PyString::new_bound(value.py(), s)));
+                        return Ok(OutputValue::OkStr(PyString::new(value.py(), s)));
                     }
                 }
             }

--- a/src/serializers/type_serializers/set_frozenset.rs
+++ b/src/serializers/type_serializers/set_frozenset.rs
@@ -65,8 +65,8 @@ macro_rules! build_serializer {
                             items.push(item_serializer.to_python(&element, include, exclude, extra)?);
                         }
                         match extra.mode {
-                            SerMode::Json => Ok(PyList::new_bound(py, items).into_py(py)),
-                            _ => Ok(<$py_type>::new_bound(py, &items)?.into_py(py)),
+                            SerMode::Json => Ok(PyList::new(py, items)?.into_py(py)),
+                            _ => Ok(<$py_type>::new(py, &items)?.into_py(py)),
                         }
                     }
                     Err(_) => {

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -82,8 +82,8 @@ impl TypeSerializer for TupleSerializer {
                 })??;
 
                 match extra.mode {
-                    SerMode::Json => Ok(PyList::new_bound(py, items).into_py(py)),
-                    _ => Ok(PyTuple::new_bound(py, items).into_py(py)),
+                    SerMode::Json => Ok(PyList::new(py, items)?.into_py(py)),
+                    _ => Ok(PyTuple::new(py, items)?.into_py(py)),
                 }
             }
             Err(_) => {

--- a/src/url.rs
+++ b/src/url.rs
@@ -34,7 +34,7 @@ impl PyUrl {
 }
 
 fn build_schema_validator(py: Python, schema_type: &str) -> SchemaValidator {
-    let schema = PyDict::new_bound(py);
+    let schema = PyDict::new(py);
     schema.set_item("type", schema_type).unwrap();
     SchemaValidator::py_new(py, &schema, None).unwrap()
 }
@@ -468,7 +468,7 @@ impl fmt::Display for UrlHostParts {
 }
 
 fn host_to_dict<'a>(py: Python<'a>, lib_url: &Url) -> PyResult<Bound<'a, PyDict>> {
-    let dict = PyDict::new_bound(py);
+    let dict = PyDict::new(py);
     dict.set_item(
         "username",
         match lib_url.username() {

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -142,7 +142,7 @@ impl BuildValidator for ArgumentsValidator {
 
         let py_var_kwargs_mode: Bound<PyString> = schema
             .get_as(intern!(py, "var_kwargs_mode"))?
-            .unwrap_or_else(|| PyString::new_bound(py, "uniform"));
+            .unwrap_or_else(|| PyString::new(py, "uniform"));
 
         let var_kwargs_mode = VarKwargsMode::from_str(py_var_kwargs_mode.to_str()?)?;
         let var_kwargs_validator = match schema.get_item(intern!(py, "var_kwargs_schema"))? {
@@ -193,7 +193,7 @@ impl Validator for ArgumentsValidator {
         let args = input.validate_args()?;
 
         let mut output_args: Vec<PyObject> = Vec::with_capacity(self.positional_params_count);
-        let output_kwargs = PyDict::new_bound(py);
+        let output_kwargs = PyDict::new(py);
         let mut errors: Vec<ValLineError> = Vec::new();
         let mut used_kwargs: AHashSet<&str> = AHashSet::with_capacity(self.parameters.len());
 
@@ -296,7 +296,7 @@ impl Validator for ArgumentsValidator {
             }
         }
 
-        let remaining_kwargs = PyDict::new_bound(py);
+        let remaining_kwargs = PyDict::new(py);
 
         // if there are kwargs check any that haven't been processed yet
         if let Some(kwargs) = args.kwargs() {
@@ -377,7 +377,7 @@ impl Validator for ArgumentsValidator {
         if !errors.is_empty() {
             Err(ValError::LineErrors(errors))
         } else {
-            Ok((PyTuple::new_bound(py, output_args), output_kwargs).to_object(py))
+            Ok((PyTuple::new(py, output_args)?, output_kwargs).to_object(py))
         }
     }
 

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -84,9 +84,9 @@ impl Validator for CallValidator {
         let args = self.arguments_validator.validate(py, input, state)?.into_bound(py);
 
         let return_value = if let Ok((args, kwargs)) = args.extract::<(Bound<PyTuple>, Bound<PyDict>)>() {
-            self.function.call_bound(py, args, Some(&kwargs))?
+            self.function.call(py, args, Some(&kwargs))?
         } else if let Ok(kwargs) = args.downcast::<PyDict>() {
-            self.function.call_bound(py, (), Some(kwargs))?
+            self.function.call(py, (), Some(kwargs))?
         } else {
             let msg = "Arguments validator should return a tuple of (args, kwargs) or a dict of kwargs";
             return Err(PyTypeError::new_err(msg).into());

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -393,7 +393,7 @@ impl Validator for DataclassArgsValidator {
             let data_dict = dict.copy()?;
             if let Err(err) = data_dict.del_item(field_name) {
                 // KeyError is fine here as the field might not be in the dict
-                if !err.get_type_bound(py).is(&PyType::new::<PyKeyError>(py)) {
+                if !err.get_type(py).is(&PyType::new::<PyKeyError>(py)) {
                     return Err(err.into());
                 }
             }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -150,7 +150,7 @@ impl Validator for DataclassArgsValidator {
 
         let args = input.validate_dataclass_args(&self.dataclass_name)?;
 
-        let output_dict = PyDict::new_bound(py);
+        let output_dict = PyDict::new(py);
         let mut init_only_args = self.init_only_count.map(Vec::with_capacity);
 
         let mut errors: Vec<ValLineError> = Vec::new();
@@ -353,7 +353,7 @@ impl Validator for DataclassArgsValidator {
 
         if errors.is_empty() {
             if let Some(init_only_args) = init_only_args {
-                Ok((output_dict, PyTuple::new_bound(py, init_only_args)).to_object(py))
+                Ok((output_dict, PyTuple::new(py, init_only_args)?).to_object(py))
             } else {
                 Ok((output_dict, py.None()).to_object(py))
             }
@@ -378,7 +378,7 @@ impl Validator for DataclassArgsValidator {
             // which doesn't make much sense in this context but we need to put something there
             // so that function validators that sit between DataclassValidator and DataclassArgsValidator
             // always get called the same shape of data.
-            Ok(PyTuple::new_bound(py, vec![dict.to_object(py), py.None()]).into_py(py))
+            Ok(PyTuple::new(py, vec![dict.to_object(py), py.None()])?.into_py(py))
         };
 
         if let Some(field) = self.fields.iter().find(|f| f.name == field_name) {
@@ -393,7 +393,7 @@ impl Validator for DataclassArgsValidator {
             let data_dict = dict.copy()?;
             if let Err(err) = data_dict.del_item(field_name) {
                 // KeyError is fine here as the field might not be in the dict
-                if !err.get_type_bound(py).is(&PyType::new_bound::<PyKeyError>(py)) {
+                if !err.get_type_bound(py).is(&PyType::new::<PyKeyError>(py)) {
                     return Err(err.into());
                 }
             }
@@ -631,7 +631,7 @@ impl DataclassValidator {
 
     fn dataclass_to_dict<'py>(&self, dc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
         let py = dc.py();
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
 
         for field_name in &self.fields {
             dict.set_item(field_name, dc.getattr(field_name)?)?;

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -248,7 +248,7 @@ pub struct NowConstraint {
 static TIME_LOCALTIME: GILOnceCell<PyObject> = GILOnceCell::new();
 
 fn get_localtime(py: Python) -> PyResult<PyObject> {
-    Ok(py.import_bound("time")?.getattr("localtime")?.into_py(py))
+    Ok(py.import("time")?.getattr("localtime")?.into_py(py))
 }
 
 impl NowConstraint {

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -19,7 +19,7 @@ static DECIMAL_TYPE: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 pub fn get_decimal_type(py: Python) -> &Bound<'_, PyType> {
     DECIMAL_TYPE
         .get_or_init(py, || {
-            py.import_bound("decimal")
+            py.import("decimal")
                 .and_then(|decimal_module| decimal_module.getattr("Decimal"))
                 .unwrap()
                 .extract()
@@ -267,7 +267,7 @@ pub(crate) fn create_decimal<'py>(arg: &Bound<'py, PyAny>, input: impl ToErrorVa
     let py = arg.py();
     get_decimal_type(py).call1((arg,)).map_err(|e| {
         let decimal_exception = match py
-            .import_bound("decimal")
+            .import("decimal")
             .and_then(|decimal_module| decimal_module.getattr("DecimalException"))
         {
             Ok(decimal_exception) => decimal_exception,

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -192,7 +192,7 @@ impl Validator for DecimalValidator {
                 return Err(ValError::new(
                     ErrorType::MultipleOf {
                         multiple_of: multiple_of.to_string().into(),
-                        context: Some([("multiple_of", multiple_of)].into_py_dict_bound(py).into()),
+                        context: Some([("multiple_of", multiple_of)].into_py_dict(py)?.into()),
                     },
                     input,
                 ));
@@ -215,7 +215,7 @@ impl Validator for DecimalValidator {
                 return Err(ValError::new(
                     ErrorType::LessThanEqual {
                         le: Number::String(le.to_string()),
-                        context: Some([("le", le)].into_py_dict_bound(py).into()),
+                        context: Some([("le", le)].into_py_dict(py)?.into()),
                     },
                     input,
                 ));
@@ -226,7 +226,7 @@ impl Validator for DecimalValidator {
                 return Err(ValError::new(
                     ErrorType::LessThan {
                         lt: Number::String(lt.to_string()),
-                        context: Some([("lt", lt)].into_py_dict_bound(py).into()),
+                        context: Some([("lt", lt)].into_py_dict(py)?.into()),
                     },
                     input,
                 ));
@@ -237,7 +237,7 @@ impl Validator for DecimalValidator {
                 return Err(ValError::new(
                     ErrorType::GreaterThanEqual {
                         ge: Number::String(ge.to_string()),
-                        context: Some([("ge", ge)].into_py_dict_bound(py).into()),
+                        context: Some([("ge", ge)].into_py_dict(py)?.into()),
                     },
                     input,
                 ));
@@ -248,7 +248,7 @@ impl Validator for DecimalValidator {
                 return Err(ValError::new(
                     ErrorType::GreaterThan {
                         gt: Number::String(gt.to_string()),
-                        context: Some([("gt", gt)].into_py_dict_bound(py).into()),
+                        context: Some([("gt", gt)].into_py_dict(py)?.into()),
                     },
                     input,
                 ));
@@ -281,7 +281,7 @@ fn handle_decimal_new_error(input: impl ToErrorValue, error: PyErr, decimal_exce
     let py = decimal_exception.py();
     if error.matches(py, decimal_exception).unwrap_or(false) {
         ValError::new(ErrorTypeDefaults::DecimalParsing, input)
-    } else if error.matches(py, PyTypeError::type_object_bound(py)).unwrap_or(false) {
+    } else if error.matches(py, PyTypeError::type_object(py)).unwrap_or(false) {
         ValError::new(ErrorTypeDefaults::DecimalType, input)
     } else {
         ValError::InternalErr(error)

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -107,7 +107,7 @@ where
 {
     type Output = ValResult<PyObject>;
     fn consume_iterator(self, iterator: impl Iterator<Item = ValResult<(Key, Value)>>) -> ValResult<PyObject> {
-        let output = PyDict::new_bound(self.py);
+        let output = PyDict::new(self.py);
         let mut errors: Vec<ValLineError> = Vec::new();
         let allow_partial = self.state.allow_partial;
 

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -35,7 +35,7 @@ impl Validator for FrozenSetValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let collection = input.validate_frozenset(state.strict_or(self.strict))?.unpack(state);
-        let f_set = PyFrozenSet::empty_bound(py)?;
+        let f_set = PyFrozenSet::empty(py)?;
         collection.iterate(ValidateToFrozenSet {
             py,
             input,

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -480,18 +480,18 @@ macro_rules! py_err_string {
 /// as validation errors, `TypeError` is now considered as a runtime error to catch errors in function signatures
 pub fn convert_err(py: Python<'_>, err: PyErr, input: impl ToErrorValue) -> ValError {
     if err.is_instance_of::<PyValueError>(py) {
-        let error_value = err.value_bound(py);
+        let error_value = err.value(py);
         if let Ok(pydantic_value_error) = error_value.extract::<PydanticCustomError>() {
             pydantic_value_error.into_val_error(input)
         } else if let Ok(pydantic_error_type) = error_value.extract::<PydanticKnownError>() {
             pydantic_error_type.into_val_error(input)
-        } else if let Ok(validation_error) = err.value_bound(py).extract::<ValidationError>() {
+        } else if let Ok(validation_error) = err.value(py).extract::<ValidationError>() {
             validation_error.into_val_error()
         } else {
             py_err_string!(py, err, error_value, ValueError, input)
         }
     } else if err.is_instance_of::<PyAssertionError>(py) {
-        py_err_string!(py, err, err.value_bound(py), AssertionError, input)
+        py_err_string!(py, err, err.value(py), AssertionError, input)
     } else if err.is_instance_of::<PydanticOmit>(py) {
         ValError::Omit
     } else if err.is_instance_of::<PydanticUseDefault>(py) {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -48,9 +48,9 @@ impl<T: Debug> LiteralLookup<T> {
         let mut expected_bool = BoolLiteral::default();
         let mut expected_int = AHashMap::new();
         let mut expected_str: AHashMap<String, usize> = AHashMap::new();
-        let expected_py_dict = PyDict::new_bound(py);
+        let expected_py_dict = PyDict::new(py);
         let mut expected_py_values = Vec::new();
-        let expected_py_primitives = PyDict::new_bound(py);
+        let expected_py_primitives = PyDict::new(py);
         let mut values = Vec::new();
         for (k, v) in expected {
             let id = values.len();

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -4,6 +4,7 @@ use enum_dispatch::enum_dispatch;
 use jiter::{PartialMode, StringCacheMode};
 
 use pyo3::exceptions::PyTypeError;
+use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyAny, PyDict, PyString, PyTuple, PyType};
@@ -444,9 +445,9 @@ impl<'py> SelfValidator<'py> {
     }
 
     fn build(py: Python) -> PyResult<SchemaValidator> {
-        let code = include_str!("../self_schema.py");
+        let code = c_str!(include_str!("../self_schema.py"));
         let locals = PyDict::new(py);
-        py.run_bound(code, None, Some(&locals))?;
+        py.run(code, None, Some(&locals))?;
         let self_schema = locals.get_as_req(intern!(py, "self_schema"))?;
 
         let mut definitions_builder = DefinitionsBuilder::new();

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -96,8 +96,8 @@ impl PySome {
     }
 
     #[classattr]
-    fn __match_args__(py: Python) -> Bound<'_, PyTuple> {
-        PyTuple::new_bound(py, vec![intern!(py, "value")])
+    fn __match_args__(py: Python<'_>) -> PyResult<Bound<'_, PyTuple>> {
+        (intern!(py, "value"),).into_pyobject(py)
     }
 }
 
@@ -445,7 +445,7 @@ impl<'py> SelfValidator<'py> {
 
     fn build(py: Python) -> PyResult<SchemaValidator> {
         let code = include_str!("../self_schema.py");
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         py.run_bound(code, None, Some(&locals))?;
         let self_schema = locals.get_as_req(intern!(py, "self_schema"))?;
 

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -264,7 +264,7 @@ impl ModelValidator {
 
         if self.root_model {
             let fields_set = if input.to_object(py).is(&self.undefined) {
-                PySet::empty_bound(py)?
+                PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?
             };
@@ -305,7 +305,7 @@ impl ModelValidator {
 
         if self.root_model {
             let fields_set = if input.to_object(py).is(&self.undefined) {
-                PySet::empty_bound(py)?
+                PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?
             };
@@ -340,7 +340,7 @@ impl ModelValidator {
 /// https://github.com/PyO3/pyo3/blob/d2caa056e9aacc46374139ef491d112cb8af1a25/src/pyclass_init.rs#L35-L77
 pub(super) fn create_class<'py>(class: &Bound<'py, PyType>) -> PyResult<Bound<'py, PyAny>> {
     let py = class.py();
-    let args = PyTuple::empty_bound(py);
+    let args = PyTuple::empty(py);
     let raw_type = class.as_type_ptr();
     unsafe {
         // Safety: raw_type is known to be a non-null type object pointer

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -266,7 +266,7 @@ impl ModelValidator {
             let fields_set = if input.to_object(py).is(&self.undefined) {
                 PySet::empty_bound(py)?
             } else {
-                PySet::new_bound(py, [&String::from(ROOT_FIELD)])?
+                PySet::new(py, [&String::from(ROOT_FIELD)])?
             };
             force_setattr(py, self_instance, intern!(py, DUNDER_FIELDS_SET_KEY), &fields_set)?;
             force_setattr(py, self_instance, intern!(py, ROOT_FIELD), &output)?;
@@ -307,7 +307,7 @@ impl ModelValidator {
             let fields_set = if input.to_object(py).is(&self.undefined) {
                 PySet::empty_bound(py)?
             } else {
-                PySet::new_bound(py, [&String::from(ROOT_FIELD)])?
+                PySet::new(py, [&String::from(ROOT_FIELD)])?
             };
             force_setattr(py, &instance, intern!(py, DUNDER_FIELDS_SET_KEY), &fields_set)?;
             force_setattr(py, &instance, intern!(py, ROOT_FIELD), output)?;

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -294,7 +294,7 @@ impl ModelValidator {
             if let Some(kwargs) = input.as_kwargs(py) {
                 return self
                     .class
-                    .call_bound(py, (), Some(&kwargs))
+                    .call(py, (), Some(&kwargs))
                     .map_err(|e| convert_err(py, e, input));
             }
         }

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -149,7 +149,7 @@ impl Validator for ModelFieldsValidator {
             Err(err) => return Err(err),
         };
 
-        let model_dict = PyDict::new_bound(py);
+        let model_dict = PyDict::new(py);
         let mut model_extra_dict_op: Option<Bound<PyDict>> = None;
         let mut errors: Vec<ValLineError> = Vec::with_capacity(self.fields.len());
         let mut fields_set_vec: Vec<Py<PyString>> = Vec::with_capacity(self.fields.len());
@@ -251,7 +251,7 @@ impl Validator for ModelFieldsValidator {
                     self,
                     iterator: impl Iterator<Item = ValResult<(Key, Value)>>,
                 ) -> ValResult<Bound<'py, PyDict>> {
-                    let model_extra_dict = PyDict::new_bound(self.py);
+                    let model_extra_dict = PyDict::new(self.py);
                     for item_result in iterator {
                         let (raw_key, value) = item_result?;
                         let either_str = match raw_key
@@ -331,13 +331,13 @@ impl Validator for ModelFieldsValidator {
         if !errors.is_empty() {
             Err(ValError::LineErrors(errors))
         } else {
-            let fields_set = PySet::new_bound(py, &fields_set_vec)?;
+            let fields_set = PySet::new(py, &fields_set_vec)?;
             state.add_fields_set(fields_set_count);
 
             // if we have extra=allow, but we didn't create a dict because we were validating
             // from attributes, set it now so __pydantic_extra__ is always a dict if extra=allow
             if matches!(self.extra_behavior, ExtraBehavior::Allow) && model_extra_dict_op.is_none() {
-                model_extra_dict_op = Some(PyDict::new_bound(py));
+                model_extra_dict_op = Some(PyDict::new(py));
             };
 
             Ok((model_dict, model_extra_dict_op, fields_set).to_object(py))
@@ -375,7 +375,7 @@ impl Validator for ModelFieldsValidator {
         let data_dict = dict.copy()?;
         if let Err(err) = data_dict.del_item(field_name) {
             // KeyError is fine here as the field might not be in the dict
-            if !err.get_type_bound(py).is(&PyType::new_bound::<PyKeyError>(py)) {
+            if !err.get_type_bound(py).is(&PyType::new::<PyKeyError>(py)) {
                 return Err(err.into());
             }
         }
@@ -420,7 +420,7 @@ impl Validator for ModelFieldsValidator {
 
         let new_extra = match &self.extra_behavior {
             ExtraBehavior::Allow => {
-                let non_extra_data = PyDict::new_bound(py);
+                let non_extra_data = PyDict::new(py);
                 self.fields.iter().try_for_each(|f| -> PyResult<()> {
                     let Some(popped_value) = new_data.get_item(&f.name)? else {
                         // field not present in __dict__ for some reason; let the rest of the
@@ -439,7 +439,7 @@ impl Validator for ModelFieldsValidator {
             _ => py.None(),
         };
 
-        let fields_set = PySet::new_bound(py, &[field_name.to_string()])?;
+        let fields_set = PySet::new(py, &[field_name.to_string()])?;
         Ok((new_data.to_object(py), new_extra, fields_set.to_object(py)).to_object(py))
     }
 

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -375,7 +375,7 @@ impl Validator for ModelFieldsValidator {
         let data_dict = dict.copy()?;
         if let Err(err) = data_dict.del_item(field_name) {
             // KeyError is fine here as the field might not be in the dict
-            if !err.get_type_bound(py).is(&PyType::new::<PyKeyError>(py)) {
+            if !err.get_type(py).is(&PyType::new::<PyKeyError>(py)) {
                 return Err(err.into());
             }
         }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -66,7 +66,7 @@ impl Validator for SetValidator {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let collection = input.validate_set(state.strict_or(self.strict))?.unpack(state);
-        let set = PySet::empty_bound(py)?;
+        let set = PySet::empty(py)?;
         collection.iterate(ValidateToSet {
             py,
             input,

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -245,7 +245,7 @@ impl Pattern {
 
         let py = pattern.py();
 
-        let re_module = py.import_bound(intern!(py, "re"))?;
+        let re_module = py.import(intern!(py, "re"))?;
         let re_compile = re_module.getattr(intern!(py, "compile"))?;
         let re_pattern = re_module.getattr(intern!(py, "Pattern"))?;
 

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -306,7 +306,7 @@ impl Validator for TupleValidator {
         }
 
         if errors.is_empty() {
-            Ok(PyTuple::new_bound(py, output).into_py(py))
+            Ok(PyTuple::new(py, output)?.into_py(py))
         } else {
             Err(ValError::LineErrors(errors))
         }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -150,7 +150,7 @@ impl Validator for TypedDictValidator {
         let strict = state.strict_or(self.strict);
         let dict = input.validate_dict(strict)?;
 
-        let output_dict = PyDict::new_bound(py);
+        let output_dict = PyDict::new(py);
         let mut errors: Vec<ValLineError> = Vec::with_capacity(self.fields.len());
 
         let partial_last_key = if state.allow_partial.is_active() {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -319,7 +319,7 @@ impl BuildValidator for TaggedUnionValidator {
         let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
         let discriminator_repr = discriminator.to_string_py(py)?;
 
-        let choices = PyDict::new_bound(py);
+        let choices = PyDict::new(py);
         let mut tags_repr = String::with_capacity(50);
         let mut descr = String::with_capacity(50);
         let mut first = true;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -27,7 +27,7 @@ const UUID_IS_SAFE: &str = "is_safe";
 static UUID_TYPE: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 fn import_type(py: Python, module: &str, attr: &str) -> PyResult<Py<PyType>> {
-    py.import_bound(module)?.getattr(attr)?.extract()
+    py.import(module)?.getattr(attr)?.extract()
 }
 
 fn get_uuid_type(py: Python) -> PyResult<&Bound<'_, PyType>> {
@@ -225,7 +225,7 @@ impl UuidValidator {
         let dc = create_class(py_type)?;
         let int = uuid.as_u128();
         let safe = py
-            .import_bound(intern!(py, "uuid"))?
+            .import(intern!(py, "uuid"))?
             .getattr(intern!(py, "SafeUUID"))?
             .get_item("safe")?;
         force_setattr(py, &dc, intern!(py, UUID_INT), int)?;

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -18,7 +18,7 @@ use crate::PydanticUndefinedType;
 static COPY_DEEPCOPY: GILOnceCell<PyObject> = GILOnceCell::new();
 
 fn get_deepcopy(py: Python) -> PyResult<PyObject> {
-    Ok(py.import_bound("copy")?.getattr("deepcopy")?.into_py(py))
+    Ok(py.import("copy")?.getattr("deepcopy")?.into_py(py))
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Change Summary

Followup to #1556 

Updating use of PyO3 APIs as per https://pyo3.rs/v0.23.3/migration.html#gil-refs-feature-removed

There will be a final step to migrate traits to use `IntoPyObject`, which I will send as a follow-up PR.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
