### PR TITLE
fix wasteful `to_python()` calls checking for undefined

### DIFF
--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -263,7 +263,7 @@ impl ModelValidator {
         let output = self.validator.validate(py, input, state)?;
 
         if self.root_model {
-            let fields_set = if input.to_object(py).is(&self.undefined) {
+            let fields_set = if input.as_python().is_some_and(|py_input| py_input.is(&self.undefined)) {
                 PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?
@@ -304,7 +304,7 @@ impl ModelValidator {
         let instance = create_class(self.class.bind(py))?;
 
         if self.root_model {
-            let fields_set = if input.to_object(py).is(&self.undefined) {
+            let fields_set = if input.as_python().is_some_and(|py_input| py_input.is(&self.undefined)) {
                 PySet::empty(py)?
             } else {
                 PySet::new(py, [&String::from(ROOT_FIELD)])?

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -157,7 +157,7 @@ impl Validator for WithDefaultValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
-        if input.to_object(py).is(&self.undefined) {
+        if input.as_python().is_some_and(|py_input| py_input.is(&self.undefined)) {
             Ok(self.default_value(py, None::<usize>, state)?.unwrap())
         } else {
             match self.validator.validate(py, input, state) {


### PR DESCRIPTION
## Change Summary

Calling `.to_object()` on JSON inputs is potentially expensive and they will NEVER be `PydanticUndefined`, so this is potentially a massive performance win on JSON validation...

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
