### PR TITLE
fix `ValueError` on year zero

### DIFF
--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -1,7 +1,6 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDict, PyString};
-use pyo3::IntoPyObjectExt;
 use speedate::{Date, Time};
 use strum::EnumMessage;
 
@@ -98,7 +97,7 @@ impl Validator for DateValidator {
                 }
             }
         }
-        Ok(date.into_py_any(py)?)
+        date.try_into_py(py, input)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -2,7 +2,6 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyString};
-use pyo3::IntoPyObjectExt;
 use speedate::{DateTime, Time};
 use std::cmp::Ordering;
 use strum::EnumMessage;
@@ -131,7 +130,7 @@ impl Validator for DateTimeValidator {
                 tz_constraint.tz_check(speedate_dt.time.tz_offset, input)?;
             }
         }
-        Ok(datetime.into_py_any(py)?)
+        datetime.try_into_py(py, input)
     }
 
     fn get_name(&self) -> &str {

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -64,6 +64,12 @@ from ..conftest import Err, PyAndJson
         ),
         pytest.param('-', Err('Input should be a valid date or datetime, input is too short'), id='minus'),
         pytest.param('+', Err('Input should be a valid date or datetime, input is too short'), id='pus'),
+        pytest.param('0001-01-01', date(1, 1, 1), id='min-date'),
+        pytest.param(
+            '0000-12-31',
+            Err('Input should be a valid date in the format YYYY-MM-DD, year 0 is out of range [type=date_parsing,'),
+            id='year-0',
+        ),
     ],
 )
 def test_date(input_value, expected):

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -53,6 +53,14 @@ from ..conftest import Err, PyAndJson
                 'Input should be a valid datetime or date, day value is outside expected range [type=datetime_from_date_parsing,'
             ),
         ),
+        (
+            '0001-01-01T00:00:00.000000Z',
+            datetime(1, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            '0000-12-31T23:59:59.999999Z',
+            Err('Input should be a valid datetime, year 0 is out of range [type=datetime_parsing,'),
+        ),
     ],
 )
 def test_datetime(input_value, expected):


### PR DESCRIPTION
## Change Summary

Makes creation of a Python `date` or `datetime` fail if the year is zero.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10967

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
