### PR TITLE
resolve remaining deprecation warnings from PyO3 0.23

### DIFF
--- a/src/build_tools.rs
+++ b/src/build_tools.rs
@@ -93,8 +93,12 @@ impl SchemaError {
                     Ok(errors) => errors,
                     Err(err) => return err,
                 };
-                let validation_error =
-                    ValidationError::new(line_errors, "Schema".to_object(py), InputType::Python, false);
+                let validation_error = ValidationError::new(
+                    line_errors,
+                    PyString::new(py, "Schema").into(),
+                    InputType::Python,
+                    false,
+                );
                 let schema_error = SchemaError(SchemaErrorEnum::ValidationError(validation_error));
                 match Py::new(py, schema_error) {
                     Ok(err) => PyErr::from_value(err.into_bound(py).into_any()),

--- a/src/common/union.rs
+++ b/src/common/union.rs
@@ -15,7 +15,7 @@ pub enum Discriminator {
 impl Discriminator {
     pub fn new(py: Python, raw: &Bound<'_, PyAny>) -> PyResult<Self> {
         if raw.is_callable() {
-            return Ok(Self::Function(raw.to_object(py)));
+            return Ok(Self::Function(raw.clone().unbind()));
         }
 
         let lookup_key = LookupKey::from_py(py, raw, None)?;

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -169,12 +169,3 @@ pub enum InputValue {
     Python(PyObject),
     Json(JsonValue<'static>),
 }
-
-impl ToPyObject for InputValue {
-    fn to_object(&self, py: Python) -> PyObject {
-        match self {
-            Self::Python(input) => input.clone_ref(py),
-            Self::Json(input) => input.to_object(py),
-        }
-    }
-}

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use std::fmt;
 
 use pyo3::exceptions::{PyKeyError, PyTypeError};
+use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{prelude::*, IntoPyObjectExt};
 
 use ahash::AHashMap;
 use num_bigint::BigInt;
@@ -124,7 +124,7 @@ macro_rules! error_types {
                     $(
                         Self::$item { context, $($key,)* } => {
                             $(
-                                dict.set_item::<&str, Py<PyAny>>(stringify!($key), $key.to_object(py))?;
+                                dict.set_item(stringify!($key), $key)?;
                             )*
                             if let Some(ctx) = context {
                                 dict.update(ctx.bind(py).downcast::<PyMapping>()?)?;
@@ -822,10 +822,5 @@ impl fmt::Display for Number {
             Self::BigInt(i) => write!(f, "{i}"),
             Self::String(s) => write!(f, "{s}"),
         }
-    }
-}
-impl ToPyObject for Number {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.into_py_any(py).unwrap()
     }
 }

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -72,15 +72,15 @@ impl ValidationError {
                     Err(err) => return err,
                 };
                 let validation_error = Self::new(line_errors, title, input_type, hide_input);
-                match Py::new(py, validation_error) {
+                match Bound::new(py, validation_error) {
                     Ok(err) => {
                         if validation_error_cause {
                             // Will return an import error if the backport was needed and not installed:
-                            if let Some(cause_problem) = ValidationError::maybe_add_cause(err.borrow(py), py) {
+                            if let Some(cause_problem) = ValidationError::maybe_add_cause(err.borrow(), py) {
                                 return cause_problem;
                             }
                         }
-                        PyErr::from_value(err.into_bound(py).into_any())
+                        PyErr::from_value(err.into_any())
                     }
                     Err(err) => err,
                 }

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::{Display, Write};
 use std::str::from_utf8;
@@ -125,16 +126,13 @@ impl ValidationError {
             } = &line_error.error_type
             {
                 let note = if let Location::Empty = &line_error.location {
-                    PyString::new(py, "Pydantic: cause of loc: root")
+                    Cow::Borrowed("Pydantic: cause of loc: root")
                 } else {
-                    PyString::new(
-                        py,
-                        &format!(
-                            "Pydantic: cause of loc: {}",
-                            // Location formats with a newline at the end, hence the trim()
-                            line_error.location.to_string().trim()
-                        ),
-                    )
+                    Cow::Owned(format!(
+                        "Pydantic: cause of loc: {}",
+                        // Location formats with a newline at the end, hence the trim()
+                        line_error.location.to_string().trim()
+                    ))
                 };
 
                 // Notes only support 3.11 upwards:
@@ -153,7 +151,7 @@ impl ValidationError {
                 {
                     use pyo3::exceptions::PyUserWarning;
 
-                    let wrapped = PyUserWarning::new_err((note.unbind(),));
+                    let wrapped = PyUserWarning::new_err((note,));
                     wrapped.set_cause(py, Some(PyErr::from_value(err.clone_ref(py).into_bound(py))));
                     user_py_errs.push(wrapped);
                 }
@@ -329,7 +327,7 @@ impl ValidationError {
         if let Some(err) = iteration_error {
             Err(err)
         } else {
-            Ok(list.into())
+            Ok(list.unbind())
         }
     }
 
@@ -396,12 +394,12 @@ impl ValidationError {
         let callable = slf.getattr("from_exception_data")?;
         let borrow = slf.try_borrow()?;
         let args = (
-            borrow.title.bind(py),
+            &borrow.title,
             borrow.errors(py, include_url_env(py), true, true)?,
-            borrow.input_type.into_pyobject(py)?,
+            borrow.input_type,
             borrow.hide_input,
         )
-            .into_pyobject(slf.py())?;
+            .into_pyobject(py)?;
         Ok((callable, args))
     }
 }
@@ -501,7 +499,7 @@ impl PyLineError {
     ) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
         dict.set_item("type", self.error_type.type_string())?;
-        dict.set_item("loc", self.location.to_object(py))?;
+        dict.set_item("loc", &self.location)?;
         dict.set_item("msg", self.error_type.render_message(py, input_type)?)?;
         if include_input {
             dict.set_item("input", &self.input_value)?;

--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -23,15 +23,16 @@ pub enum InputType {
 
 impl<'py> IntoPyObject<'py> for InputType {
     type Target = PyString;
-    type Output = Bound<'py, PyString>;
+    type Output = Borrowed<'py, 'py, PyString>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'_>) -> Result<Bound<'_, PyString>, Infallible> {
-        Ok(match self {
-            Self::Json => intern!(py, "json").clone(),
-            Self::Python => intern!(py, "python").clone(),
-            Self::String => intern!(py, "string").clone(),
-        })
+    fn into_pyobject(self, py: Python<'py>) -> Result<Borrowed<'py, 'py, PyString>, Infallible> {
+        let text = match self {
+            Self::Json => intern!(py, "json"),
+            Self::Python => intern!(py, "python"),
+            Self::String => intern!(py, "string"),
+        };
+        Ok(text.as_borrowed())
     }
 }
 
@@ -215,7 +216,7 @@ pub trait KeywordArgs<'py> {
     type Key<'a>: BorrowInput<'py> + Clone + Into<LocItem>
     where
         Self: 'a;
-    type Item<'a>: BorrowInput<'py> + ToPyObject
+    type Item<'a>: BorrowInput<'py>
     where
         Self: 'a;
     fn len(&self) -> usize;

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -477,7 +477,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
     }
 
     fn validate_iter(&self) -> ValResult<GenericIterator<'static>> {
-        if self.iter().is_ok() {
+        if self.try_iter().is_ok() {
             Ok(self.into())
         } else {
             Err(ValError::new(ErrorTypeDefaults::IterableType, self))
@@ -856,7 +856,7 @@ impl<'py> ValidatedDict<'py> for GenericPyMapping<'_, 'py> {
             Self::Mapping(mapping) => mapping
                 .call_method0(intern!(mapping.py(), "keys"))
                 .ok()?
-                .iter()
+                .try_iter()
                 .ok()?
                 .last()?
                 .ok(),
@@ -896,7 +896,7 @@ fn extract_sequence_iterable<'a, 'py>(obj: &'a Bound<'py, PyAny>) -> ValResult<P
             || obj.is_instance_of::<PyDict>()
             || obj.downcast::<PyMapping>().is_ok())
         {
-            if let Ok(iter) = obj.iter() {
+            if let Ok(iter) = obj.try_iter() {
                 return Ok(PySequenceIterable::Iterator(iter));
             }
         }
@@ -925,7 +925,7 @@ impl<'py> PySequenceIterable<'_, 'py> {
             PySequenceIterable::Tuple(iter) => Ok(consumer.consume_iterator(iter.iter().map(Ok))),
             PySequenceIterable::Set(iter) => Ok(consumer.consume_iterator(iter.iter().map(Ok))),
             PySequenceIterable::FrozenSet(iter) => Ok(consumer.consume_iterator(iter.iter().map(Ok))),
-            PySequenceIterable::Iterator(iter) => Ok(consumer.consume_iterator(iter.iter()?)),
+            PySequenceIterable::Iterator(iter) => Ok(consumer.consume_iterator(iter.try_iter()?)),
         }
     }
 }

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -75,6 +75,11 @@ impl From<Bound<'_, PyAny>> for LocItem {
 }
 
 impl<'py> Input<'py> for Bound<'py, PyAny> {
+    #[inline]
+    fn py_converter(&self) -> impl IntoPyObject<'py> + '_ {
+        self
+    }
+
     fn as_error_value(&self) -> InputValue {
         InputValue::Python(self.clone().into())
     }

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -22,7 +22,7 @@ use super::{
     KeywordArgs, ValidatedDict, ValidationMatch,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, IntoPyObject, IntoPyObjectRef)]
 pub enum StringMapping<'py> {
     String(Bound<'py, PyString>),
     Mapping(Bound<'py, PyDict>),
@@ -72,6 +72,11 @@ impl From<StringMapping<'_>> for LocItem {
 }
 
 impl<'py> Input<'py> for StringMapping<'py> {
+    #[inline]
+    fn py_converter(&self) -> impl IntoPyObject<'py> + '_ {
+        self
+    }
+
     fn as_error_value(&self) -> InputValue {
         match self {
             Self::String(s) => s.as_error_value(),

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -28,15 +28,6 @@ pub enum StringMapping<'py> {
     Mapping(Bound<'py, PyDict>),
 }
 
-impl ToPyObject for StringMapping<'_> {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        match self {
-            Self::String(s) => s.to_object(py),
-            Self::Mapping(d) => d.to_object(py),
-        }
-    }
-}
-
 impl<'py> StringMapping<'py> {
     pub fn new_key(py_key: Bound<'py, PyAny>) -> ValResult<Self> {
         match py_key.downcast_into::<PyString>() {

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -185,7 +185,7 @@ impl BuildSet for Bound<'_, PyFrozenSet> {
         py_error_on_minusone(self.py(), unsafe {
             // Safety: self.as_ptr() the _only_ pointer to the `frozenset`, and it's allowed
             // to mutate this via the C API when nothing else can refer to it.
-            ffi::PySet_Add(self.as_ptr(), item.to_object(self.py()).as_ptr())
+            ffi::PySet_Add(self.as_ptr(), item.as_ptr())
         })
     }
 
@@ -382,7 +382,7 @@ impl From<&Bound<'_, PyAny>> for GenericIterator<'_> {
     fn from(obj: &Bound<'_, PyAny>) -> Self {
         let py_iter = GenericPyIterator {
             obj: obj.clone().into(),
-            iter: obj.iter().unwrap().into(),
+            iter: obj.try_iter().unwrap().into(),
             index: 0,
         };
         Self::PyIterator(py_iter)
@@ -702,15 +702,6 @@ impl FromPyObject<'_> for Int {
         match extract_int(obj) {
             Some(i) => Ok(i),
             None => py_err!(PyTypeError; "Expected int, got {}", obj.get_type()),
-        }
-    }
-}
-
-impl ToPyObject for Int {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        match self {
-            Self::I64(i) => i.to_object(py),
-            Self::Big(big_i) => big_i.to_object(py),
         }
     }
 }

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -266,7 +266,7 @@ pub(crate) fn no_validator_iter_to_vec<'py>(
         .map(|(index, result)| {
             let v = result.map_err(|e| any_next_error!(py, e, input, index))?;
             max_length_check.incr()?;
-            Ok(v.borrow_input().to_object(py))
+            Ok(v.borrow_input().to_object(py)?.unbind())
         })
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(has_coverage_attribute, feature(coverage_attribute))]
-#![allow(deprecated)] // FIXME: just used during upgrading PyO3 to 0.23
 
 extern crate core;
 

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::ffi::CString;
 use std::fmt;
 use std::sync::Mutex;
@@ -323,12 +324,16 @@ impl From<Option<&str>> for SerMode {
     }
 }
 
-impl ToPyObject for SerMode {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
+impl<'py> IntoPyObject<'py> for &'_ SerMode {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-            SerMode::Python => intern!(py, "python").to_object(py),
-            SerMode::Json => intern!(py, "json").to_object(py),
-            SerMode::Other(s) => s.to_object(py),
+            SerMode::Python => Ok(intern!(py, "python").clone()),
+            SerMode::Json => Ok(intern!(py, "json").clone()),
+            SerMode::Other(s) => Ok(PyString::new(py, s)),
         }
     }
 }

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -213,7 +213,7 @@ pub(crate) fn infer_to_python_known(
                 let mut items = Vec::new();
                 let filter = AnyFilter::new();
 
-                for (index, r) in py_seq.iter()?.enumerate() {
+                for (index, r) in py_seq.try_iter()?.enumerate() {
                     let element = r?;
                     let op_next = filter.index_filter(index, include, exclude, None)?;
                     if let Some((next_include, next_exclude)) = op_next {
@@ -518,7 +518,7 @@ pub(crate) fn infer_serialize_known<S: Serializer>(
             let py_seq = value.downcast::<PyIterator>().map_err(py_err_se_err)?;
             let mut seq = serializer.serialize_seq(None)?;
             let filter = AnyFilter::new();
-            for (index, r) in py_seq.iter().map_err(py_err_se_err)?.enumerate() {
+            for (index, r) in py_seq.try_iter().map_err(py_err_se_err)?.enumerate() {
                 let element = r.map_err(py_err_se_err)?;
                 let op_next = filter
                     .index_filter(index, include, exclude, None)

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -69,7 +69,7 @@ impl ObTypeLookup {
             float: PyFloat::type_object_raw(py) as usize,
             list: PyList::type_object_raw(py) as usize,
             dict: PyDict::type_object_raw(py) as usize,
-            decimal_object: py.import("decimal").unwrap().getattr("Decimal").unwrap().to_object(py),
+            decimal_object: py.import("decimal").unwrap().getattr("Decimal").unwrap().unbind(),
             string: PyString::type_object_raw(py) as usize,
             bytes: PyBytes::type_object_raw(py) as usize,
             bytearray: PyByteArray::type_object_raw(py) as usize,
@@ -82,16 +82,11 @@ impl ObTypeLookup {
             timedelta: PyDelta::type_object_raw(py) as usize,
             url: PyUrl::type_object_raw(py) as usize,
             multi_host_url: PyMultiHostUrl::type_object_raw(py) as usize,
-            enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().to_object(py),
-            generator_object: py
-                .import("types")
-                .unwrap()
-                .getattr("GeneratorType")
-                .unwrap()
-                .to_object(py),
-            path_object: py.import("pathlib").unwrap().getattr("Path").unwrap().to_object(py),
-            pattern_object: py.import("re").unwrap().getattr("Pattern").unwrap().to_object(py),
-            uuid_object: py.import("uuid").unwrap().getattr("UUID").unwrap().to_object(py),
+            enum_object: py.import("enum").unwrap().getattr("Enum").unwrap().unbind(),
+            generator_object: py.import("types").unwrap().getattr("GeneratorType").unwrap().unbind(),
+            path_object: py.import("pathlib").unwrap().getattr("Path").unwrap().unbind(),
+            pattern_object: py.import("re").unwrap().getattr("Pattern").unwrap().unbind(),
+            uuid_object: py.import("uuid").unwrap().getattr("UUID").unwrap().unbind(),
             complex: PyComplex::type_object_raw(py) as usize,
         }
     }

--- a/src/serializers/type_serializers/float.rs
+++ b/src/serializers/type_serializers/float.rs
@@ -1,5 +1,5 @@
 use pyo3::types::PyDict;
-use pyo3::{intern, prelude::*};
+use pyo3::{intern, prelude::*, IntoPyObjectExt};
 
 use std::borrow::Cow;
 
@@ -77,10 +77,7 @@ impl TypeSerializer for FloatSerializer {
             IsType::Subclass => match extra.check {
                 SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_err(None)),
                 SerCheck::Lax | SerCheck::None => match extra.mode {
-                    SerMode::Json => {
-                        let rust_value = value.extract::<f64>()?;
-                        Ok(rust_value.to_object(py))
-                    }
+                    SerMode::Json => value.extract::<f64>()?.into_py_any(py),
                     _ => infer_to_python(value, include, exclude, extra),
                 },
             },

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -544,6 +544,7 @@ struct SerializationInfo {
     exclude: Option<PyObject>,
     #[pyo3(get)]
     context: Option<PyObject>,
+    #[pyo3(get, name = "mode")]
     _mode: SerMode,
     #[pyo3(get)]
     by_alias: bool,
@@ -625,11 +626,6 @@ impl SerializationInfo {
 
 #[pymethods]
 impl SerializationInfo {
-    #[getter]
-    fn mode(&self, py: Python) -> PyObject {
-        self._mode.to_object(py)
-    }
-
     fn mode_is_json(&self) -> bool {
         self._mode.is_json()
     }
@@ -646,7 +642,7 @@ impl SerializationInfo {
         if let Some(ref context) = self.context {
             d.set_item("context", context)?;
         }
-        d.set_item("mode", self.mode(py))?;
+        d.set_item("mode", &self._mode)?;
         d.set_item("by_alias", self.by_alias)?;
         d.set_item("exclude_unset", self.exclude_unset)?;
         d.set_item("exclude_defaults", self.exclude_defaults)?;

--- a/src/serializers/type_serializers/json.rs
+++ b/src/serializers/type_serializers/json.rs
@@ -5,6 +5,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use pyo3::types::PyString;
 use serde::ser::Error;
 
 use crate::definitions::DefinitionsBuilder;
@@ -56,7 +57,7 @@ impl TypeSerializer for JsonSerializer {
             let bytes = to_json_bytes(value, &self.serializer, include, exclude, extra, None, 0)?;
             let py = value.py();
             let s = from_utf8(&bytes).map_err(|e| utf8_py_error(py, e, &bytes))?;
-            Ok(s.to_object(py))
+            Ok(PyString::new(py, s).into())
         } else {
             self.serializer.to_python(value, include, exclude, extra)
         }

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyList, PyString};
 
 use ahash::AHashSet;
+use pyo3::IntoPyObjectExt;
 use serde::Serialize;
 
 use crate::build_tools::py_schema_err;
@@ -119,12 +120,12 @@ impl TypeSerializer for LiteralSerializer {
         let py = value.py();
         match self.check(value, extra)? {
             OutputValue::OkInt(int) => match extra.mode {
-                SerMode::Json => Ok(int.to_object(py)),
-                _ => Ok(value.to_object(py)),
+                SerMode::Json => int.into_py_any(py),
+                _ => Ok(value.clone().unbind()),
             },
             OutputValue::OkStr(s) => match extra.mode {
-                SerMode::Json => Ok(s.to_object(py)),
-                _ => Ok(value.to_object(py)),
+                SerMode::Json => Ok(s.into()),
+                _ => Ok(value.clone().unbind()),
             },
             OutputValue::Ok => infer_to_python(value, include, exclude, extra),
             OutputValue::Fallback => {

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyType};
 
 use ahash::AHashMap;
+use pyo3::IntoPyObjectExt;
 
 use super::{
     infer_json_key, infer_json_key_known, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer,
@@ -147,8 +148,7 @@ impl ModelSerializer {
 
         if self.has_extra {
             let model_extra = model.getattr(intern!(py, "__pydantic_extra__"))?;
-            let py_tuple = (attrs, model_extra).to_object(py).into_bound(py);
-            Ok(py_tuple)
+            (attrs, model_extra).into_bound_py_any(py)
         } else {
             Ok(attrs.into_any())
         }

--- a/src/serializers/type_serializers/simple.rs
+++ b/src/serializers/type_serializers/simple.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::IntoPyObjectExt;
 
 use std::borrow::Cow;
 
@@ -124,10 +125,7 @@ macro_rules! build_simple_serializer {
                     IsType::Subclass => match extra.check {
                         SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_err(None)),
                         SerCheck::Lax | SerCheck::None => match extra.mode {
-                            SerMode::Json => {
-                                let rust_value = value.extract::<$rust_type>()?;
-                                Ok(rust_value.to_object(py))
-                            }
+                            SerMode::Json => value.extract::<$rust_type>()?.into_py_any(py),
                             _ => infer_to_python(value, include, exclude, extra),
                         },
                     },

--- a/src/url.rs
+++ b/src/url.rs
@@ -469,13 +469,7 @@ impl fmt::Display for UrlHostParts {
 
 fn host_to_dict<'a>(py: Python<'a>, lib_url: &Url) -> PyResult<Bound<'a, PyDict>> {
     let dict = PyDict::new(py);
-    dict.set_item(
-        "username",
-        match lib_url.username() {
-            "" => py.None(),
-            user => user.to_object(py),
-        },
-    )?;
+    dict.set_item("username", Some(lib_url.username()).filter(|s| !s.is_empty()))?;
     dict.set_item("password", lib_url.password())?;
     dict.set_item("host", lib_url.host_str())?;
     dict.set_item("port", lib_url.port_or_known_default())?;

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -35,7 +35,7 @@ impl Validator for AnyValidator {
     ) -> ValResult<PyObject> {
         // in a union, Any should be preferred to doing lax coercions
         state.floor_exactness(Exactness::Strict);
-        Ok(input.to_object(py))
+        Ok(input.to_object(py)?.unbind())
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyTuple};
 
 use ahash::AHashSet;
+use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{schema_or_config_same, ExtraBehavior};
@@ -347,8 +348,10 @@ impl Validator for ArgumentsValidator {
                             },
                             VarKwargsMode::UnpackedTypedDict => {
                                 // Save to the remaining kwargs, we will validate as a single dict:
-                                remaining_kwargs
-                                    .set_item(either_str.as_py_string(py, state.cache_str()), value.to_object(py))?;
+                                remaining_kwargs.set_item(
+                                    either_str.as_py_string(py, state.cache_str()),
+                                    value.borrow_input().to_object(py)?,
+                                )?;
                             }
                         }
                     }
@@ -377,7 +380,7 @@ impl Validator for ArgumentsValidator {
         if !errors.is_empty() {
             Err(ValError::LineErrors(errors))
         } else {
-            Ok((PyTuple::new(py, output_args)?, output_kwargs).to_object(py))
+            Ok((PyTuple::new(py, output_args)?, output_kwargs).into_py_any(py)?)
         }
     }
 

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -97,7 +97,7 @@ impl Validator for CallValidator {
                 .validate(py, return_value.bind(py), state)
                 .map_err(|e| e.with_outer_location("return"))
         } else {
-            Ok(return_value.to_object(py))
+            Ok(return_value)
         }
     }
 

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -59,7 +59,7 @@ impl BuildValidator for CallValidator {
         let name = format!("{}[{function_name}]", Self::EXPECTED_TYPE);
 
         Ok(Self {
-            function: function.to_object(py),
+            function: function.unbind(),
             arguments_validator,
             return_validator,
             name,

--- a/src/validators/complex.rs
+++ b/src/validators/complex.rs
@@ -13,7 +13,7 @@ static COMPLEX_TYPE: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 pub fn get_complex_type(py: Python) -> &Bound<'_, PyType> {
     COMPLEX_TYPE
-        .get_or_init(py, || py.get_type_bound::<PyComplex>().into())
+        .get_or_init(py, || py.get_type::<PyComplex>().into())
         .bind(py)
 }
 

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -420,7 +420,7 @@ impl Validator for DataclassArgsValidator {
             match self.extra_behavior {
                 // For dataclasses we allow assigning unknown fields
                 // to match stdlib dataclass behavior
-                ExtraBehavior::Allow => ok(field_value.to_object(py)),
+                ExtraBehavior::Allow => ok(field_value.clone().unbind()),
                 _ => Err(ValError::new_with_loc(
                     ErrorType::NoSuchAttribute {
                         attribute: field_name.to_string(),
@@ -552,7 +552,7 @@ impl Validator for DataclassValidator {
                 self.set_dict_call(py, &dc, val_output, input)?;
                 Ok(dc.into())
             } else {
-                Ok(input.to_object(py))
+                Ok(input.to_object(py)?.unbind())
             }
         } else if state.strict_or(self.strict) && state.extra().input_type == InputType::Python {
             Err(ValError::new(
@@ -602,7 +602,7 @@ impl Validator for DataclassValidator {
             force_setattr(py, obj, intern!(py, "__dict__"), dc_dict)?;
         }
 
-        Ok(obj.to_object(py))
+        Ok(obj.clone().unbind())
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyTuple, PyType};
 
 use ahash::AHashSet;
+use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
@@ -328,7 +329,7 @@ impl Validator for DataclassArgsValidator {
                                         } else {
                                             output_dict.set_item(
                                                 either_str.as_py_string(py, state.cache_str()),
-                                                value.to_object(py),
+                                                value.borrow_input().to_object(py)?,
                                             )?;
                                         }
                                     }
@@ -353,9 +354,9 @@ impl Validator for DataclassArgsValidator {
 
         if errors.is_empty() {
             if let Some(init_only_args) = init_only_args {
-                Ok((output_dict, PyTuple::new(py, init_only_args)?).to_object(py))
+                Ok((output_dict, PyTuple::new(py, init_only_args)?).into_py_any(py)?)
             } else {
-                Ok((output_dict, py.None()).to_object(py))
+                Ok((output_dict, py.None()).into_py_any(py)?)
             }
         } else {
             Err(ValError::LineErrors(errors))
@@ -378,7 +379,7 @@ impl Validator for DataclassArgsValidator {
             // which doesn't make much sense in this context but we need to put something there
             // so that function validators that sit between DataclassValidator and DataclassArgsValidator
             // always get called the same shape of data.
-            Ok(PyTuple::new(py, vec![dict.to_object(py), py.None()])?.into())
+            Ok(PyTuple::new(py, [Some(dict), None])?.into())
         };
 
         if let Some(field) = self.fields.iter().find(|f| f.name == field_name) {

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -184,10 +184,10 @@ impl Validator for DecimalValidator {
             // fraction = (decimal / multiple_of) % 1
             let fraction = unsafe {
                 let division = decimal.div(multiple_of)?;
-                let one = 1.to_object(py);
+                let one = 1u8.into_pyobject(py)?;
                 Bound::from_owned_ptr_or_err(py, pyo3::ffi::PyNumber_Remainder(division.as_ptr(), one.as_ptr()))?
             };
-            let zero = 0.to_object(py);
+            let zero = 0u8.into_pyobject(py)?;
             if !fraction.eq(&zero)? {
                 return Err(ValError::new(
                     ErrorType::MultipleOf {

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -103,10 +103,8 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let class = self.class.bind(py);
-        if let Some(py_input) = input.as_python() {
-            if py_input.is_instance(class)? {
-                return Ok(py_input.clone().unbind());
-            }
+        if let Some(exact_py_input) = input.as_python().filter(|any| any.is_exact_instance(class)) {
+            return Ok(exact_py_input.clone().unbind());
         }
         let strict = state.strict_or(self.strict);
         if strict && input.as_python().is_some() {

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -103,8 +103,10 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<PyObject> {
         let class = self.class.bind(py);
-        if input.as_python().is_some_and(|any| any.is_exact_instance(class)) {
-            return Ok(input.to_object(py));
+        if let Some(py_input) = input.as_python() {
+            if py_input.is_instance(class)? {
+                return Ok(py_input.clone().unbind());
+            }
         }
         let strict = state.strict_or(self.strict);
         if strict && input.as_python().is_some() {
@@ -125,7 +127,7 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
         } else if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
             return Ok(res);
         } else if let Some(ref missing) = self.missing {
-            let enum_value = missing.bind(py).call1((input.to_object(py),)).map_err(|_| {
+            let enum_value = missing.bind(py).call1((input.to_object(py)?,)).map_err(|_| {
                 ValError::new(
                     ErrorType::Enum {
                         expected: self.expected_repr.clone(),

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -101,9 +101,9 @@ impl FunctionBeforeValidator {
     ) -> ValResult<PyObject> {
         let r = if self.info_arg {
             let info = ValidationInfo::new(py, state.extra(), &self.config, self.field_name.clone());
-            self.func.call1(py, (input.to_object(py), info))
+            self.func.call1(py, (input.to_object(py)?, info))
         } else {
-            self.func.call1(py, (input.to_object(py),))
+            self.func.call1(py, (input.to_object(py)?,))
         };
         let value = r.map_err(|e| convert_err(py, e, input))?;
         call(value.into_bound(py), state)
@@ -259,9 +259,9 @@ impl Validator for FunctionPlainValidator {
     ) -> ValResult<PyObject> {
         let r = if self.info_arg {
             let info = ValidationInfo::new(py, state.extra(), &self.config, self.field_name.clone());
-            self.func.call1(py, (input.to_object(py), info))
+            self.func.call1(py, (input.to_object(py)?, info))
         } else {
-            self.func.call1(py, (input.to_object(py),))
+            self.func.call1(py, (input.to_object(py)?,))
         };
         r.map_err(|e| convert_err(py, e, input))
     }
@@ -323,9 +323,9 @@ impl FunctionWrapValidator {
     ) -> ValResult<PyObject> {
         let r = if self.info_arg {
             let info = ValidationInfo::new(py, state.extra(), &self.config, self.field_name.clone());
-            self.func.call1(py, (input.to_object(py), handler, info))
+            self.func.call1(py, (input.to_object(py)?, handler, info))
         } else {
-            self.func.call1(py, (input.to_object(py), handler))
+            self.func.call1(py, (input.to_object(py)?, handler))
         };
         r.map_err(|e| convert_err(py, e, input))
     }
@@ -377,7 +377,7 @@ impl Validator for FunctionWrapValidator {
                 self.validation_error_cause,
             ),
             updated_field_name: field_name.to_string(),
-            updated_field_value: field_value.to_object(py),
+            updated_field_value: field_value.clone().into(),
         };
         #[allow(clippy::used_underscore_items)]
         self._validate(Bound::new(py, handler)?.as_any(), py, obj, state)

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -170,9 +170,9 @@ impl FunctionAfterValidator {
         let v = call(input, state)?;
         let r = if self.info_arg {
             let info = ValidationInfo::new(py, state.extra(), &self.config, self.field_name.clone());
-            self.func.call1(py, (v.to_object(py), info))
+            self.func.call1(py, (v, info))
         } else {
-            self.func.call1(py, (v.to_object(py),))
+            self.func.call1(py, (v,))
         };
         r.map_err(|e| convert_err(py, e, input))
     }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyString};
 use pyo3::{prelude::*, IntoPyObjectExt, PyTraverseError, PyVisit};
 
 use crate::errors::{ErrorType, LocItem, ValError, ValResult};
@@ -288,7 +288,7 @@ impl InternalValidator {
             .map_err(|e| {
                 ValidationError::from_val_error(
                     py,
-                    self.name.to_object(py),
+                    PyString::new(py, &self.name).into(),
                     InputType::Python,
                     e,
                     outer_location,
@@ -320,7 +320,7 @@ impl InternalValidator {
         let result = self.validator.validate(py, input, &mut state).map_err(|e| {
             ValidationError::from_val_error(
                 py,
-                self.name.to_object(py),
+                PyString::new(py, &self.name).into(),
                 InputType::Python,
                 e,
                 outer_location,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -139,7 +139,7 @@ impl ValidatorIterator {
                                     );
                                     return Err(ValidationError::from_val_error(
                                         py,
-                                        "ValidatorIterator".to_object(py),
+                                        "ValidatorIterator".into_pyobject(py)?.into(),
                                         InputType::Python,
                                         val_error,
                                         None,
@@ -152,7 +152,7 @@ impl ValidatorIterator {
                                 .validate(py, next.borrow_input(), Some(index.into()))
                                 .map(Some)
                         }
-                        None => Ok(Some(next.to_object(py))),
+                        None => Ok(Some(next.into_pyobject(py)?.unbind())),
                     },
                     None => {
                         if let Some(min_length) = min_length {
@@ -168,7 +168,7 @@ impl ValidatorIterator {
                                 );
                                 return Err(ValidationError::from_val_error(
                                     py,
-                                    "ValidatorIterator".to_object(py),
+                                    "ValidatorIterator".into_pyobject(py)?.into(),
                                     InputType::Python,
                                     val_error,
                                     None,

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -224,8 +224,7 @@ impl<T: Debug> LiteralLookup<T> {
         if let Some(expected_py) = &self.expected_py_dict {
             if let Ok(either_float) = input.validate_float(strict) {
                 let f = either_float.into_inner().as_f64();
-                let py_float = f.to_object(py);
-                if let Ok(Some(v)) = expected_py.bind(py).get_item(py_float.bind(py)) {
+                if let Ok(Some(v)) = expected_py.bind(py).get_item(f) {
                     let id: usize = v.extract().unwrap();
                     return Ok(Some(&self.values[id]));
                 }

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -1,6 +1,7 @@
 // Validator for things inside of a typing.Literal[]
 // which can be an int, a string, bytes or an Enum value (including `class Foo(str, Enum)` type enums)
 use core::fmt::Debug;
+use std::cell::OnceCell;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyInt, PyList};
@@ -139,21 +140,29 @@ impl<T: Debug> LiteralLookup<T> {
             }
         }
         // cache py_input if needed, since we might need it for multiple lookups
-        let mut py_input = None;
+        let py_input = OnceCell::new();
+        let get_py_input = || match py_input.get() {
+            Some(py_input) => PyResult::<_>::Ok(py_input),
+            None => {
+                let _ = py_input.set(input.to_object(py)?);
+                Ok(py_input.get().unwrap())
+            }
+        };
+
         if let Some(expected_py_dict) = &self.expected_py_dict {
-            let py_input = py_input.get_or_insert_with(|| input.to_object(py));
+            let py_input = get_py_input()?;
             // We don't use ? to unpack the result of `get_item` in the next line because unhashable
             // inputs will produce a TypeError, which in this case we just want to treat equivalently
             // to a failed lookup
-            if let Ok(Some(v)) = expected_py_dict.bind(py).get_item(&*py_input) {
+            if let Ok(Some(v)) = expected_py_dict.bind(py).get_item(py_input) {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));
             }
         };
         if let Some(expected_py_values) = &self.expected_py_values {
-            let py_input = py_input.get_or_insert_with(|| input.to_object(py));
+            let py_input = get_py_input()?;
             for (k, id) in expected_py_values {
-                if k.bind(py).eq(&*py_input).unwrap_or(false) {
+                if k.bind(py).eq(py_input).unwrap_or(false) {
                     return Ok(Some((input, &self.values[*id])));
                 }
             }
@@ -162,11 +171,11 @@ impl<T: Debug> LiteralLookup<T> {
         // this one must be last to avoid conflicts with the other lookups, think of this
         // almost as a lax fallback
         if let Some(expected_py_primitives) = &self.expected_py_primitives {
-            let py_input = py_input.get_or_insert_with(|| input.to_object(py));
+            let py_input = get_py_input()?;
             // We don't use ? to unpack the result of `get_item` in the next line because unhashable
             // inputs will produce a TypeError, which in this case we just want to treat equivalently
             // to a failed lookup
-            if let Ok(Some(v)) = expected_py_primitives.bind(py).get_item(&*py_input) {
+            if let Ok(Some(v)) = expected_py_primitives.bind(py).get_item(py_input) {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));
             }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -157,12 +157,9 @@ impl SchemaValidator {
         })
     }
 
-    pub fn __reduce__(slf: &Bound<Self>) -> PyResult<(PyObject, (PyObject, PyObject))> {
-        // Enables support for `pickle` serialization.
-        let py = slf.py();
-        let cls = slf.get_type().into();
-        let init_args = (slf.get().py_schema.to_object(py), slf.get().py_config.to_object(py));
-        Ok((cls, init_args))
+    pub fn __reduce__<'py>(slf: &Bound<'py, Self>) -> PyResult<(Bound<'py, PyType>, Bound<'py, PyTuple>)> {
+        let init_args = (&slf.get().py_schema, &slf.get().py_config).into_pyobject(slf.py())?;
+        Ok((slf.get_type(), init_args))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -100,7 +100,7 @@ impl BuildValidator for ModelValidator {
             frozen: schema.get_as(intern!(py, "frozen"))?.unwrap_or(false),
             custom_init: schema.get_as(intern!(py, "custom_init"))?.unwrap_or(false),
             root_model: schema.get_as(intern!(py, "root_model"))?.unwrap_or(false),
-            undefined: PydanticUndefinedType::new(py).to_object(py),
+            undefined: PydanticUndefinedType::new(py).into_any(),
             // Get the class's `__name__`, not using `class.qualname()`
             name,
         }

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PySet, PyString, PyType};
 
 use ahash::AHashSet;
+use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
@@ -340,7 +341,7 @@ impl Validator for ModelFieldsValidator {
                 model_extra_dict_op = Some(PyDict::new(py));
             };
 
-            Ok((model_dict, model_extra_dict_op, fields_set).to_object(py))
+            Ok((model_dict, model_extra_dict_op, fields_set).into_py_any(py)?)
         }
     }
 
@@ -434,13 +435,13 @@ impl Validator for ModelFieldsValidator {
                 let new_extra = new_data.copy()?;
                 new_data.clear();
                 new_data.update(non_extra_data.as_mapping())?;
-                new_extra.to_object(py)
+                new_extra.into()
             }
             _ => py.None(),
         };
 
         let fields_set = PySet::new(py, &[field_name.to_string()])?;
-        Ok((new_data.to_object(py), new_extra, fields_set.to_object(py)).to_object(py))
+        Ok((new_data, new_extra, fields_set).into_py_any(py)?)
     }
 
     fn get_name(&self) -> &str {

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -303,7 +303,7 @@ impl Validator for ModelFieldsValidator {
                                         Err(err) => return Err(err),
                                     }
                                 } else {
-                                    model_extra_dict.set_item(&py_key, value.to_object(self.py))?;
+                                    model_extra_dict.set_item(&py_key, value.to_object(self.py)?)?;
                                     self.fields_set_vec.push(py_key.into());
                                 };
                             }
@@ -354,13 +354,13 @@ impl Validator for ModelFieldsValidator {
     ) -> ValResult<PyObject> {
         let dict = obj.downcast::<PyDict>()?;
 
-        let get_updated_dict = |output: PyObject| {
+        let get_updated_dict = |output: &Bound<'py, PyAny>| {
             dict.set_item(field_name, output)?;
             Ok(dict)
         };
 
         let prepare_result = |result: ValResult<PyObject>| match result {
-            Ok(output) => get_updated_dict(output),
+            Ok(output) => get_updated_dict(&output.into_bound(py)),
             Err(ValError::LineErrors(line_errors)) => {
                 let errors = line_errors
                     .into_iter()
@@ -402,7 +402,7 @@ impl Validator for ModelFieldsValidator {
                 match self.extra_behavior {
                     ExtraBehavior::Allow => match self.extras_validator {
                         Some(ref validator) => prepare_result(validator.validate(py, field_value, state))?,
-                        None => get_updated_dict(field_value.to_object(py))?,
+                        None => get_updated_dict(field_value)?,
                     },
                     ExtraBehavior::Forbid | ExtraBehavior::Ignore => {
                         return Err(ValError::new_with_loc(

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -260,7 +260,7 @@ impl Pattern {
             // so that any flags, etc. are preserved
             Ok(Self {
                 pattern: pattern_str,
-                engine: RegexEngine::PythonRe(pattern.to_object(py)),
+                engine: RegexEngine::PythonRe(pattern.unbind()),
             })
         } else {
             let engine = match engine {

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -334,7 +334,7 @@ impl Validator for TypedDictValidator {
                                         Err(err) => return Err(err),
                                     }
                                 } else {
-                                    self.output_dict.set_item(py_key, value.to_object(self.py))?;
+                                    self.output_dict.set_item(py_key, value.to_object(self.py)?)?;
                                 };
                             }
                         }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -358,7 +358,7 @@ impl Validator for TypedDictValidator {
         }
 
         if errors.is_empty() {
-            Ok(output_dict.to_object(py))
+            Ok(output_dict.into())
         } else {
             Err(ValError::LineErrors(errors))
         }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -378,10 +378,10 @@ impl Validator for TaggedUnionValidator {
                     Some((_, value)) => value,
                     None => return Err(self.tag_not_found(input)),
                 };
-                self.find_call_validator(py, tag.borrow_input().to_object(py).bind(py), input, state)
+                self.find_call_validator(py, &tag.borrow_input().to_object(py)?, input, state)
             }
             Discriminator::Function(func) => {
-                let tag: Py<PyAny> = func.call1(py, (input.to_object(py),))?;
+                let tag: Py<PyAny> = func.call1(py, (input.to_object(py)?,))?;
                 if tag.is_none(py) {
                     Err(self.tag_not_found(input))
                 } else {

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -113,7 +113,7 @@ impl Validator for UuidValidator {
                     ));
                 }
             }
-            Ok(py_input.to_object(py))
+            Ok(py_input.clone().unbind())
         } else if state.strict_or(self.strict) && state.extra().input_type == InputType::Python {
             Err(ValError::new(
                 ErrorType::IsInstanceOf {

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -142,7 +142,7 @@ impl BuildValidator for WithDefaultValidator {
             validate_default: schema_or_config_same(schema, config, intern!(py, "validate_default"))?.unwrap_or(false),
             copy_default,
             name,
-            undefined: PydanticUndefinedType::new(py).to_object(py),
+            undefined: PydanticUndefinedType::new(py).into_any(),
         }
         .into())
     }


### PR DESCRIPTION
## Change Summary

This primarily removes uses of the `ToPyObject` trait in favour of `IntoPyObject`. The hardest bit was in the `Input` trait, which had previously used `ToPyObject` as a super-trait. Instead I now added a defaulted `.to_object` method on `Input` to minimise changes.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
