### PR TITLE
Add support for descriptors as model fields

### DIFF
--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -136,7 +136,7 @@ impl ModelSerializer {
             let descriptor_fields = try_descriptor_fields?.downcast_into::<PySet>()?;
             for f in descriptor_fields {
                 let field = f.downcast_into::<PyString>()?;
-                attrs.set_item(&field, model.getattr(&field)?)?
+                attrs.set_item(&field, model.getattr(&field)?)?;
             }
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,8 @@
 version = 1
 requires-python = ">=3.8"
 resolution-markers = [
-    "python_full_version < '3.9' or (python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.12' and platform_machine != 'x86_64')",
-    "(python_full_version == '3.12.*' and implementation_name != 'cpython') or (python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.13.*' and implementation_name != 'cpython') or python_full_version >= '3.14'",
+    "(python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.9' and implementation_name == 'cpython' and platform_machine == 'x86_64') or (python_full_version < '3.12' and platform_machine != 'x86_64')",
+    "(python_full_version >= '3.12' and implementation_name != 'cpython') or (python_full_version >= '3.14' and implementation_name == 'cpython') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'x86_64')",
     "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "python_full_version >= '3.9' and python_full_version < '3.11' and implementation_name == 'cpython' and platform_machine == 'x86_64'",
     "python_full_version == '3.11.*' and implementation_name == 'cpython' and platform_machine == 'x86_64'",
@@ -26,8 +26,8 @@ name = "astunparse"
 version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "python_full_version < '3.9' or (python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.12' and platform_machine != 'x86_64')" },
-    { name = "wheel", marker = "python_full_version < '3.9' or (python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.12' and platform_machine != 'x86_64')" },
+    { name = "six", marker = "(python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.9' and implementation_name == 'cpython' and platform_machine == 'x86_64') or (python_full_version < '3.12' and platform_machine != 'x86_64')" },
+    { name = "wheel", marker = "(python_full_version < '3.12' and implementation_name != 'cpython') or (python_full_version < '3.9' and implementation_name == 'cpython' and platform_machine == 'x86_64') or (python_full_version < '3.12' and platform_machine != 'x86_64')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290 }
 wheels = [
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.27.1"
 source = { virtual = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
## Change Summary

Add support for descriptors as model fields. Check newly-introduced `__pydantic_descriptor_fields__` to determine whether to get/set fields via `__dict__` or `__getattribute__`/`__setattr__`

- Introduce `get_model_dict()` and `set_model_dict()`, which get/set descriptor fields which handling `__dict__`
- Change `get_inner_value()` to supplement `attrs` with descriptor values, if present

Note that this change can be released standalone, but will not on its own enable all the functionality to fix [the pydantic/pydantic issue](https://github.com/pydantic/pydantic/issues/11148). That also requires [this pydantic/pydantic change](https://github.com/pydantic/pydantic/pull/11176).

## Related issue number

[pydantic/pydantic Issue](https://github.com/pydantic/pydantic/issues/11148)
[pydantic/pydantic Pull Request](https://github.com/pydantic/pydantic/pull/11176)

## Checklist

* [X] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [X] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle