### PR TITLE
Validate default values at schema definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +444,7 @@ version = "2.27.2"
 dependencies = [
  "ahash",
  "base64",
+ "bitflags",
  "enum_dispatch",
  "hex",
  "idna 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ num-bigint = "0.4.6"
 uuid = "1.11.0"
 jiter = { version = "0.8.2", features = ["python"] }
 hex = "0.4.3"
+bitflags = "2.6.0"
 
 [lib]
 name = "_pydantic_core"

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -57,7 +57,7 @@ class CoreConfig(TypedDict, total=False):
         loc_by_alias: Whether to use the used alias (or first alias for "field required" errors) instead of
             `field_names` to construct error `loc`s. Default is `True`.
         revalidate_instances: Whether instances of models and dataclasses should re-validate. Default is 'never'.
-        validate_default: Whether to validate default values during validation. Default is `False`.
+        validate_default: Whether to validate default values during validation. Default is `never`.
         populate_by_name: Whether an aliased field may be populated by its name as given by the model attribute,
             as well as the alias. (Replaces 'allow_population_by_field_name' in Pydantic v1.) Default is `False`.
         str_max_length: The maximum length for string fields.
@@ -92,8 +92,8 @@ class CoreConfig(TypedDict, total=False):
     loc_by_alias: bool
     # whether instances of models and dataclasses (including subclass instances) should re-validate, default 'never'
     revalidate_instances: Literal['always', 'never', 'subclass-instances']
-    # whether to validate default values during validation, default False
-    validate_default: bool
+    # whether to validate default values during validation, default 'never'
+    validate_default: Union[bool, Literal['never', 'definition', 'init']]
     # used on typed-dicts and arguments
     populate_by_name: bool  # replaces `allow_population_by_field_name` in pydantic v1
     # fields related to string fields only
@@ -2403,7 +2403,7 @@ class WithDefaultSchema(TypedDict, total=False):
     default_factory: Union[Callable[[], Any], Callable[[Dict[str, Any]], Any]]
     default_factory_takes_data: bool
     on_error: Literal['raise', 'omit', 'default']  # default: 'raise'
-    validate_default: bool  # default: False
+    validate_default: Union[bool, Literal['never', 'definition', 'init']]  # default: 'never'
     strict: bool
     ref: str
     metadata: Dict[str, Any]
@@ -2417,7 +2417,7 @@ def with_default_schema(
     default_factory: Union[Callable[[], Any], Callable[[Dict[str, Any]], Any], None] = None,
     default_factory_takes_data: bool | None = None,
     on_error: Literal['raise', 'omit', 'default'] | None = None,
-    validate_default: bool | None = None,
+    validate_default: bool | Literal['never', 'definition', 'init'] | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: Dict[str, Any] | None = None,
@@ -2443,7 +2443,7 @@ def with_default_schema(
         default_factory: A callable that returns the default value to use
         default_factory_takes_data: Whether the default factory takes a validated data argument
         on_error: What to do if the schema validation fails. One of 'raise', 'omit', 'default'
-        validate_default: Whether the default value should be validated
+        validate_default: Whether the default value should be validated. One of 'never', 'definition', 'init' or True/False
         strict: Whether the underlying schema should be validated with strict mode
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -894,18 +894,3 @@ def test_validate_default_raises_dataclass(input_value: dict, expected: Any) -> 
         v.validate_python(input_value)
 
     assert exc_info.value.errors(include_url=False, include_context=False) == expected
-
-
-def test_validate_default_on_validator_creation():
-    SchemaValidator(
-        {
-            'type': 'typed-dict',
-            'fields': {
-                'x': {'type': 'typed-dict-field', 'schema': {'type': 'str'}},
-                'y': {
-                    'type': 'typed-dict-field',
-                    'schema': {'type': 'default', 'schema': {'type': 'str'}, 'default': 1},
-                },
-            },
-        }
-    )

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -386,8 +386,8 @@ def test_validate_default(
     ],
 )
 def test_validate_default_flags(
-    config_validate_default: None | Literal['never', 'definition', 'init'],
-    schema_validate_default: None | Literal['never', 'definition', 'init'],
+    config_validate_default: Union[None, Literal['never', 'definition', 'init']],
+    schema_validate_default: Union[None, Literal['never', 'definition', 'init']],
 ):
     def create_schema():
         if config_validate_default is not None:

--- a/tests/validators/test_with_default.py
+++ b/tests/validators/test_with_default.py
@@ -443,6 +443,13 @@ def test_validate_default_flags_strict():
             ),
         )
 
+    with pytest.raises(SchemaError, match='Input should be a valid integer'):
+        SchemaValidator(
+            core_schema.with_default_schema(
+                core_schema.int_schema(), default='1', validate_default='definition', strict=True
+            )
+        )
+
 
 def test_validate_default_factory():
     v = SchemaValidator(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Extended option `validate_default` so that it's possible to validate default values when a model schema is being built.

This option now can be a boolean or 3 possible string values: `'never'`, `'definition'`, or `'init'`.

* `never`: no validation for default values at all. This is the same as `False`.
* `init`: validation at model instantiation. This is the same as `True`.
* `definition`: validation at model definition.

The behaviour of `True`/`False` does not change with this PR.

Note that even though `init` and `definition` are not mutually exclusive and I implemented these as flags that can co-exist, I decided not to add another option, e.g. `always`, that cover both flags because if a validation is raised at model definition, it's pretty much impossible to trigger such error at model instantiation because the model does not built at all and therefore we don't really need `always`.

## Related issue number

Part of https://github.com/pydantic/pydantic/issues/8722

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt