### PR TITLE
add `model_type` to validators

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -163,6 +163,9 @@ class FieldSerializationInfo(SerializationInfo, Protocol):
     @property
     def field_name(self) -> str: ...
 
+    @property
+    def model_type(self) -> type: ...
+
 
 class ValidationInfo(Protocol):
     """
@@ -193,6 +196,14 @@ class ValidationInfo(Protocol):
     def field_name(self) -> str | None:
         """
         The name of the current field being validated if this validator is
+        attached to a model field.
+        """
+        ...
+
+    @property
+    def model_type(self) -> type | None:
+        """
+        The type of the current model being validated if this validator is
         attached to a model field.
         """
         ...
@@ -1956,6 +1967,7 @@ class WithInfoValidatorFunctionSchema(TypedDict, total=False):
     type: Required[Literal['with-info']]
     function: Required[WithInfoValidatorFunction]
     field_name: str
+    model_type: type
 
 
 ValidationFunction = Union[NoInfoValidatorFunctionSchema, WithInfoValidatorFunctionSchema]
@@ -2025,6 +2037,7 @@ def with_info_before_validator_function(
     schema: CoreSchema,
     *,
     field_name: str | None = None,
+    model_type: type | None = None,
     ref: str | None = None,
     json_schema_input_schema: CoreSchema | None = None,
     metadata: Dict[str, Any] | None = None,
@@ -2062,7 +2075,7 @@ def with_info_before_validator_function(
     """
     return _dict_not_none(
         type='function-before',
-        function=_dict_not_none(type='with-info', function=function, field_name=field_name),
+        function=_dict_not_none(type='with-info', function=function, field_name=field_name, model_type=model_type),
         schema=schema,
         ref=ref,
         json_schema_input_schema=json_schema_input_schema,
@@ -2189,6 +2202,7 @@ class WithInfoWrapValidatorFunctionSchema(TypedDict, total=False):
     type: Required[Literal['with-info']]
     function: Required[WithInfoWrapValidatorFunction]
     field_name: str
+    model_type: type
 
 
 WrapValidatorFunction = Union[NoInfoWrapValidatorFunctionSchema, WithInfoWrapValidatorFunctionSchema]

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -2067,6 +2067,7 @@ def with_info_before_validator_function(
     Args:
         function: The validator function to call
         field_name: The name of the field
+        model_type: The type of the model
         schema: The schema to validate the output of the validator function
         ref: optional unique identifier of the schema, used to reference the schema in other places
         json_schema_input_schema: The core schema to be used to generate the corresponding JSON Schema input type
@@ -2137,6 +2138,7 @@ def with_info_after_validator_function(
     schema: CoreSchema,
     *,
     field_name: str | None = None,
+    model_type: type | None = None,
     ref: str | None = None,
     metadata: Dict[str, Any] | None = None,
     serialization: SerSchema | None = None,
@@ -2165,14 +2167,15 @@ def with_info_after_validator_function(
     Args:
         function: The validator function to call after the schema is validated
         schema: The schema to validate before the validator function
-        field_name: The name of the field this validators is applied to, if any
+        field_name: The name of the field this validator is applied to, if any
+        model_type: The type of the model this validator is applied to, if any
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
     return _dict_not_none(
         type='function-after',
-        function=_dict_not_none(type='with-info', function=function, field_name=field_name),
+        function=_dict_not_none(type='with-info', function=function, field_name=field_name, model_type=model_type),
         schema=schema,
         ref=ref,
         metadata=metadata,
@@ -2272,6 +2275,7 @@ def with_info_wrap_validator_function(
     schema: CoreSchema,
     *,
     field_name: str | None = None,
+    model_type: type | None = None,
     json_schema_input_schema: CoreSchema | None = None,
     ref: str | None = None,
     metadata: Dict[str, Any] | None = None,
@@ -2302,7 +2306,8 @@ def with_info_wrap_validator_function(
     Args:
         function: The validator function to call
         schema: The schema to validate the output of the validator function
-        field_name: The name of the field this validators is applied to, if any
+        field_name: The name of the field this validator is applied to, if any
+        model_type: The type of the model this validator is applied to, if any
         json_schema_input_schema: The core schema to be used to generate the corresponding JSON Schema input type
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -2310,7 +2315,7 @@ def with_info_wrap_validator_function(
     """
     return _dict_not_none(
         type='function-wrap',
-        function=_dict_not_none(type='with-info', function=function, field_name=field_name),
+        function=_dict_not_none(type='with-info', function=function, field_name=field_name, model_type=model_type),
         schema=schema,
         json_schema_input_schema=json_schema_input_schema,
         ref=ref,
@@ -2372,6 +2377,7 @@ def with_info_plain_validator_function(
     function: WithInfoValidatorFunction,
     *,
     field_name: str | None = None,
+    model_type: type | None = None,
     ref: str | None = None,
     json_schema_input_schema: CoreSchema | None = None,
     metadata: Dict[str, Any] | None = None,
@@ -2394,7 +2400,8 @@ def with_info_plain_validator_function(
 
     Args:
         function: The validator function to call
-        field_name: The name of the field this validators is applied to, if any
+        field_name: The name of the field this validator is applied to, if any
+        model_type: The type of the model this validator is applied to, if any
         ref: optional unique identifier of the schema, used to reference the schema in other places
         json_schema_input_schema: The core schema to be used to generate the corresponding JSON Schema input type
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -2402,7 +2409,7 @@ def with_info_plain_validator_function(
     """
     return _dict_not_none(
         type='function-plain',
-        function=_dict_not_none(type='with-info', function=function, field_name=field_name),
+        function=_dict_not_none(type='with-info', function=function, field_name=field_name, model_type=model_type),
         ref=ref,
         json_schema_input_schema=json_schema_input_schema,
         metadata=metadata,

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -555,7 +555,7 @@ impl ValidationInfo {
             config: config.clone_ref(py),
             context: extra.context.map(|ctx| ctx.clone().into()),
             field_name,
-            model_type: model_type.map(|t| t.clone().into()),
+            model_type,
             data: extra.data.as_ref().map(|data| data.clone().into()),
             mode: extra.input_type,
         }

--- a/tests/validators/test_dataclasses.py
+++ b/tests/validators/test_dataclasses.py
@@ -880,7 +880,7 @@ def test_validate_assignment_function():
                     core_schema.dataclass_field(
                         'field_b',
                         core_schema.with_info_after_validator_function(
-                            func, core_schema.int_schema(), field_name='field_b'
+                            func, core_schema.int_schema(), field_name='field_b', model_type=MyDataclass
                         ),
                     ),
                     core_schema.dataclass_field('field_c', core_schema.int_schema()),
@@ -894,14 +894,16 @@ def test_validate_assignment_function():
     assert m.field_a == 'x'
     assert m.field_b == 246
     assert m.field_c == 456
-    assert calls == ["ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b')"]
+    assert calls == [
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b', model_type=<class 'tests.validators.test_dataclasses.test_validate_assignment_function.<locals>.MyDataclass'>)"
+    ]
 
     v.validate_assignment(m, 'field_b', '111')
 
     assert m.field_b == 222
     assert calls == [
-        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b')",
-        "ValidationInfo(config=None, context=None, data={'field_a': 'x', 'field_c': 456}, field_name='field_b')",
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b', model_type=<class 'tests.validators.test_dataclasses.test_validate_assignment_function.<locals>.MyDataclass'>)",
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x', 'field_c': 456}, field_name='field_b', model_type=<class 'tests.validators.test_dataclasses.test_validate_assignment_function.<locals>.MyDataclass'>)",
     ]
 
 

--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -1092,7 +1092,7 @@ def test_validate_assignment_function():
                     'field_a': core_schema.model_field(core_schema.str_schema()),
                     'field_b': core_schema.model_field(
                         core_schema.with_info_after_validator_function(
-                            func, core_schema.int_schema(), field_name='field_b'
+                            func, core_schema.int_schema(), field_name='field_b', model_type=MyModel
                         )
                     ),
                     'field_c': core_schema.model_field(core_schema.int_schema()),
@@ -1106,14 +1106,16 @@ def test_validate_assignment_function():
     assert m.field_b == 246
     assert m.field_c == 456
     assert m.__pydantic_fields_set__ == {'field_a', 'field_b', 'field_c'}
-    assert calls == ["ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b')"]
+    assert calls == [
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b', model_type=<class 'tests.validators.test_model.test_validate_assignment_function.<locals>.MyModel'>)"
+    ]
 
     v.validate_assignment(m, 'field_b', '111')
 
     assert m.field_b == 222
     assert calls == [
-        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b')",
-        "ValidationInfo(config=None, context=None, data={'field_a': 'x', 'field_c': 456}, field_name='field_b')",
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x'}, field_name='field_b', model_type=<class 'tests.validators.test_model.test_validate_assignment_function.<locals>.MyModel'>)",
+        "ValidationInfo(config=None, context=None, data={'field_a': 'x', 'field_c': 456}, field_name='field_b', model_type=<class 'tests.validators.test_model.test_validate_assignment_function.<locals>.MyModel'>)",
     ]
 
 
@@ -1183,18 +1185,30 @@ def test_frozen():
     [
         (
             core_schema.with_info_after_validator_function,
-            (({'a': 1, 'b': 2}, None, {'b'}), 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
-            (({'a': 10, 'b': 2}, None, {'a'}), 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
+            (
+                ({'a': 1, 'b': 2}, None, {'b'}),
+                'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)',
+            ),
+            (
+                ({'a': 10, 'b': 2}, None, {'a'}),
+                'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)',
+            ),
         ),
         (
             core_schema.with_info_before_validator_function,
-            ({'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
-            ({'a': 10, 'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
+            ({'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)'),
+            (
+                {'a': 10, 'b': 2},
+                'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)',
+            ),
         ),
         (
             core_schema.with_info_wrap_validator_function,
-            ({'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
-            ({'a': 10, 'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None)'),
+            ({'b': 2}, 'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)'),
+            (
+                {'a': 10, 'b': 2},
+                'ValidationInfo(config=None, context=None, data=None, field_name=None, model_type=None)',
+            ),
         ),
     ],
 )

--- a/tests/validators/test_model_root.py
+++ b/tests/validators/test_model_root.py
@@ -140,21 +140,25 @@ def test_field_function():
     v = SchemaValidator(
         core_schema.model_schema(
             RootModel,
-            core_schema.with_info_after_validator_function(f, core_schema.str_schema(), field_name='root'),
+            core_schema.with_info_after_validator_function(
+                f, core_schema.str_schema(), field_name='root', model_type=RootModel
+            ),
             root_model=True,
         )
     )
     m = v.validate_python('foobar', context='call 1')
     assert isinstance(m, RootModel)
     assert m.root == 'foobar validated'
-    assert call_infos == ["ValidationInfo(config=None, context='call 1', data=None, field_name='root')"]
+    assert call_infos == [
+        "ValidationInfo(config=None, context='call 1', data=None, field_name='root', model_type=<class 'tests.validators.test_model_root.test_field_function.<locals>.RootModel'>)"
+    ]
 
     m2 = v.validate_assignment(m, 'root', 'baz', context='assignment call')
     assert m2 is m
     assert m.root == 'baz validated'
     assert call_infos == [
-        "ValidationInfo(config=None, context='call 1', data=None, field_name='root')",
-        "ValidationInfo(config=None, context='assignment call', data=None, field_name='root')",
+        "ValidationInfo(config=None, context='call 1', data=None, field_name='root', model_type=<class 'tests.validators.test_model_root.test_field_function.<locals>.RootModel'>)",
+        "ValidationInfo(config=None, context='assignment call', data=None, field_name='root', model_type=<class 'tests.validators.test_model_root.test_field_function.<locals>.RootModel'>)",
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->
In the same way that `field_name` is provided in `ValidationInfo`, this change will expose `model_type` as well.

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
https://github.com/pydantic/pydantic/issues/11104

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
