### PR TITLE
use `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,6 +661,10 @@ jobs:
     needs: [test-builds-arch, test-builds-os, build-sdist, check]
     if: success() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -684,11 +688,10 @@ jobs:
 
       - run: twine check --strict dist/*
 
-      - name: upload to pypi
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          skip-existing: true
 
       - name: get wasm dist artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
I'd like to use this flow for all important projects, and delete the PyPI token.

@davidhewitt I think there was some discussion of whether this would work for rust packages, please confirm?