### PR TITLE
Draft: Remove `validate_core_schema`

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -8,7 +8,7 @@ use test::{black_box, Bencher};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
-use _pydantic_core::{validate_core_schema, SchemaValidator};
+use _pydantic_core::SchemaValidator;
 
 fn build_schema_validator_with_globals(
     py: Python,
@@ -16,7 +16,6 @@ fn build_schema_validator_with_globals(
     globals: Option<&Bound<'_, PyDict>>,
 ) -> SchemaValidator {
     let mut schema = py.eval(code, globals, None).unwrap().extract().unwrap();
-    schema = validate_core_schema(&schema, None).unwrap().extract().unwrap();
     SchemaValidator::py_new(py, &schema, None).unwrap()
 }
 

--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -25,7 +25,6 @@ from ._pydantic_core import (
     from_json,
     to_json,
     to_jsonable_python,
-    validate_core_schema,
 )
 from .core_schema import CoreConfig, CoreSchema, CoreSchemaType, ErrorType
 
@@ -66,7 +65,6 @@ __all__ = [
     'to_json',
     'from_json',
     'to_jsonable_python',
-    'validate_core_schema',
 ]
 
 

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -34,7 +34,6 @@ __all__ = [
     'to_jsonable_python',
     'list_all_errors',
     'TzInfo',
-    'validate_core_schema',
 ]
 __version__: str
 build_profile: str
@@ -1003,11 +1002,3 @@ class TzInfo(datetime.tzinfo):
 
     def __deepcopy__(self, _memo: dict[Any, Any]) -> TzInfo: ...
 
-def validate_core_schema(schema: CoreSchema, *, strict: bool | None = None) -> CoreSchema:
-    """Validate a core schema.
-
-    This currently uses lax mode for validation (i.e. will coerce strings to dates and such)
-    but may use strict mode in the future.
-    We may also remove this function altogether, do not rely on it being present if you are
-    using pydantic-core directly.
-    """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use serializers::{
     to_json, to_jsonable_python, PydanticSerializationError, PydanticSerializationUnexpectedValue, SchemaSerializer,
     WarningsArg,
 };
-pub use validators::{validate_core_schema, PySome, SchemaValidator};
+pub use validators::{PySome, SchemaValidator};
 
 use crate::input::Input;
 
@@ -134,6 +134,5 @@ fn _pydantic_core(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(from_json, m)?)?;
     m.add_function(wrap_pyfunction!(to_jsonable_python, m)?)?;
     m.add_function(wrap_pyfunction!(list_all_errors, m)?)?;
-    m.add_function(wrap_pyfunction!(validate_core_schema, m)?)?;
     Ok(())
 }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -470,12 +470,6 @@ impl<'py> SelfValidator<'py> {
     }
 }
 
-#[pyfunction(signature = (schema, *, strict = None))]
-pub fn validate_core_schema<'py>(schema: &Bound<'py, PyAny>, strict: Option<bool>) -> PyResult<Bound<'py, PyAny>> {
-    let self_validator = SelfValidator::new(schema.py())?;
-    self_validator.validate_schema(schema, strict)
-}
-
 pub trait BuildValidator: Sized {
     const EXPECTED_TYPE: &'static str;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import hypothesis
 import pytest
 from typing_extensions import Literal
 
-from pydantic_core import ArgsKwargs, SchemaValidator, ValidationError, validate_core_schema
+from pydantic_core import ArgsKwargs, SchemaValidator, ValidationError
 from pydantic_core.core_schema import CoreConfig
 
 __all__ = 'Err', 'PyAndJson', 'plain_repr', 'infinite_generator'
@@ -53,7 +53,7 @@ class PyAndJsonValidator:
     def __init__(
         self, schema, config: CoreConfig | None = None, *, validator_type: Literal['json', 'python'] | None = None
     ):
-        self.validator = SchemaValidator(validate_core_schema(schema), config)
+        self.validator = SchemaValidator(schema, config)
         self.validator_type = validator_type
 
     def validate_python(self, py_input, strict: bool | None = None, context: Any = None):


### PR DESCRIPTION
This improves perf significantly in `pydantic`, so we no longer have a use for this in `pydantic-core`.

cc @davidhewitt, before I continue:
* Can we remove the self schema gen
* Can I comb through tests using this function and either remove them or modify the schema errors?