### PR TITLE
always use maturin for the uv commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,56 +40,32 @@ install-rust-coverage:
 .PHONY: build-dev
 build-dev:
 	@rm -f python/pydantic_core/*.so
-ifneq ($(USE_MATURIN),)
 	uv run maturin develop --uv
-else
-	uv pip install --force-reinstall -v -e . --config-settings=build-args='--profile dev'
-endif
 
 .PHONY: build-prod
 build-prod:
 	@rm -f python/pydantic_core/*.so
-ifneq ($(USE_MATURIN),)
 	uv run maturin develop --uv --release
-else
-	uv pip install -v -e .
-endif
 
 .PHONY: build-profiling
 build-profiling:
 	@rm -f python/pydantic_core/*.so
-ifneq ($(USE_MATURIN),)
 	uv run maturin develop --uv --profile profiling
-else
-	uv pip install --force-reinstall -v -e . --config-settings=build-args='--profile profiling'
-endif
 
 .PHONY: build-coverage
 build-coverage:
 	@rm -f python/pydantic_core/*.so
-ifneq ($(USE_MATURIN),)
 	RUSTFLAGS='-C instrument-coverage' uv run maturin develop --uv --release
-else
-	RUSTFLAGS='-C instrument-coverage' uv pip install -v -e .
-endif
 
 .PHONY: build-pgo
 build-pgo:
 	@rm -f python/pydantic_core/*.so
 	$(eval PROFDATA := $(shell mktemp -d))
-ifneq ($(USE_MATURIN),)
 	RUSTFLAGS='-Cprofile-generate=$(PROFDATA)' uv run maturin develop --uv --release
-else
-	RUSTFLAGS='-Cprofile-generate=$(PROFDATA)' uv pip install --force-reinstall -v -e .
-endif
 	pytest tests/benchmarks
 	$(eval LLVM_PROFDATA := $(shell rustup run stable bash -c 'echo $$RUSTUP_HOME/toolchains/$$RUSTUP_TOOLCHAIN/lib/rustlib/$$(rustc -Vv | grep host | cut -d " " -f 2)/bin/llvm-profdata'))
 	$(LLVM_PROFDATA) merge -o $(PROFDATA)/merged.profdata $(PROFDATA)
-ifneq ($(USE_MATURIN),)
 	RUSTFLAGS='-Cprofile-use=$(PROFDATA)/merged.profdata' uv run maturin develop --uv --release
-else
-	RUSTFLAGS='-Cprofile-use=$(PROFDATA)/merged.profdata' uv pip install --force-reinstall -v -e .
-endif
 	@rm -rf $(PROFDATA)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,12 @@
 [build-system]
-requires = [
-    'maturin>=1,<2',
-    'typing-extensions >=4.6.0,!=4.7.0'
-]
+requires = ['maturin>=1,<2', 'typing-extensions >=4.6.0,!=4.7.0']
 build-backend = 'maturin'
 
 [project]
 name = 'pydantic_core'
 description = "Core functionality for Pydantic validation and serialization"
 requires-python = '>=3.9'
-authors = [
-    {name = 'Samuel Colvin', email = 's@muelcolvin.com'}
-]
+authors = [{ name = 'Samuel Colvin', email = 's@muelcolvin.com' }]
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python',
@@ -32,15 +27,8 @@ classifiers = [
     'Operating System :: MacOS',
     'Typing :: Typed',
 ]
-dependencies = [
-    'typing-extensions >=4.6.0,!=4.7.0'
-]
-dynamic = [
-    'description',
-    'license',
-    'readme',
-    'version'
-]
+dependencies = ['typing-extensions >=4.6.0,!=4.7.0']
+dynamic = ['description', 'license', 'readme', 'version']
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-core'
@@ -48,7 +36,9 @@ Funding = 'https://github.com/sponsors/samuelcolvin'
 Source = 'https://github.com/pydantic/pydantic-core'
 
 [dependency-groups]
+dev = ["maturin"]
 testing = [
+    { include-group = "dev" },
     'backports.zoneinfo; python_version < "3.9"',
     'coverage',
     'dirty-equals',
@@ -70,26 +60,18 @@ testing = [
     'tzdata',
     'typing_extensions',
 ]
-linting = [
-    'griffe',
-    'pyright',
-    'ruff',
-    'mypy',
-]
-wasm = [
-    'typing_extensions',
-    'maturin>=1,<2',
-    'ruff',
-]
+linting = [{ include-group = "dev" }, 'griffe', 'pyright', 'ruff', 'mypy']
+wasm = [{ include-group = "dev" }, 'typing_extensions', 'ruff']
 codspeed = [
     # codspeed is only run on CI, with latest version of CPython
     'pytest-codspeed; python_version == "3.13" and implementation_name == "cpython"',
 ]
 
 all = [
-  { include-group = 'testing' },
-  { include-group = 'linting' },
-  { include-group = 'wasm' },
+    { include-group = "dev" },
+    { include-group = 'testing' },
+    { include-group = 'linting' },
+    { include-group = 'wasm' },
 ]
 
 [tool.maturin]
@@ -105,9 +87,9 @@ target-version = 'py39'
 [tool.ruff.lint]
 extend-select = ['Q', 'RUF100', 'C90', 'I', 'UP']
 extend-ignore = [
-    'E721',  # using type() instead of isinstance() - we use this in tests
+    'E721', # using type() instead of isinstance() - we use this in tests
 ]
-flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
+flake8-quotes = { inline-quotes = 'single', multiline-quotes = 'double' }
 mccabe = { max-complexity = 13 }
 isort = { known-first-party = ['pydantic_core', 'tests'] }
 
@@ -130,10 +112,13 @@ timeout = 30
 xfail_strict = true
 # min, max, mean, stddev, median, iqr, outliers, ops, rounds, iterations
 addopts = [
-    '--benchmark-columns', 'min,mean,stddev,outliers,rounds,iterations',
-    '--benchmark-group-by', 'group',
-    '--benchmark-warmup', 'on',
-    '--benchmark-disable',  # this is enable by `make benchmark` when you actually want to run benchmarks
+    '--benchmark-columns',
+    'min,mean,stddev,outliers,rounds,iterations',
+    '--benchmark-group-by',
+    'group',
+    '--benchmark-warmup',
+    'on',
+    '--benchmark-disable',                        # this is enable by `make benchmark` when you actually want to run benchmarks
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -596,6 +596,9 @@ all = [
 codspeed = [
     { name = "pytest-codspeed", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" },
 ]
+dev = [
+    { name = "maturin" },
+]
 linting = [
     { name = "griffe" },
     { name = "mypy" },
@@ -608,6 +611,7 @@ testing = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "hypothesis" },
     { name = "inline-snapshot" },
+    { name = "maturin" },
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
     { name = "numpy", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
     { name = "pandas", marker = "python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
@@ -639,7 +643,7 @@ all = [
     { name = "griffe" },
     { name = "hypothesis" },
     { name = "inline-snapshot" },
-    { name = "maturin", specifier = ">=1,<2" },
+    { name = "maturin" },
     { name = "mypy" },
     { name = "numpy", marker = "python_full_version >= '3.9' and python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
     { name = "pandas", marker = "python_full_version >= '3.9' and python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
@@ -656,6 +660,7 @@ all = [
     { name = "tzdata" },
 ]
 codspeed = [{ name = "pytest-codspeed", marker = "python_full_version == '3.13.*' and implementation_name == 'cpython'" }]
+dev = [{ name = "maturin" }]
 linting = [
     { name = "griffe" },
     { name = "mypy" },
@@ -669,6 +674,7 @@ testing = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "hypothesis" },
     { name = "inline-snapshot" },
+    { name = "maturin" },
     { name = "numpy", marker = "python_full_version >= '3.9' and python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
     { name = "pandas", marker = "python_full_version >= '3.9' and python_full_version < '3.13' and implementation_name == 'cpython' and platform_machine == 'x86_64'" },
     { name = "pytest" },
@@ -682,7 +688,7 @@ testing = [
     { name = "tzdata" },
 ]
 wasm = [
-    { name = "maturin", specifier = ">=1,<2" },
+    { name = "maturin" },
     { name = "ruff" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
## Change Summary

Since we moved to `uv` we can guarantee that `maturin` should be properly installed in the venv, so this should be fine to run like this.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
