### PR TITLE
build PGO wheels on `macos-latest` runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,7 +506,7 @@ jobs:
             ls: dir
             runs-on: windows-latest
           - os: macos
-            runs-on: macos-latest-xlarge
+            runs-on: macos-latest
         exclude:
           # macos arm only supported from 3.10 and up
           - os: macos


### PR DESCRIPTION
## Change Summary

Latest build on main failed to start for the `xlarge` runners, and I don't think we need them.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
