### PR TITLE
disable `inline-snapshot` on 3.13t test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,8 @@ jobs:
       - run: uv run pytest
         env:
           HYPOTHESIS_PROFILE: slow
-          # TODO: remove -x when test suite is more stable; we use it so that first error (hopefully) gets
-          # reported without the interpreter crashing
-          PYTEST_ADDOPTS: ${{ endsWith(matrix.python-version, 't') && '--parallel-threads=2 -x' || '' }}
+          # TODO: remove --inline-snapshot=disable after https://github.com/15r10nk/inline-snapshot/issues/192
+          PYTEST_ADDOPTS: ${{ endsWith(matrix.python-version, 't') && '--parallel-threads=2 --inline-snapshot=disable' || '' }}
           # TODO: add `gil_used = false` to the PyO3 `#[pymodule]` when test suite is ok
           PYTHON_GIL: ${{ endsWith(matrix.python-version, 't') && '0' || '1' }}
 


### PR DESCRIPTION
## Change Summary

For #1555 

## Related issue number

https://github.com/15r10nk/inline-snapshot/issues/192

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
