### PR TITLE
support free-threaded Python 3.13t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, windows, macos]
-        interpreter: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        interpreter: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         include:
           # standard runners with override for macos arm
           - os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
           HYPOTHESIS_PROFILE: slow
           # TODO: remove --inline-snapshot=disable after https://github.com/15r10nk/inline-snapshot/issues/192
           PYTEST_ADDOPTS: ${{ endsWith(matrix.python-version, 't') && '--parallel-threads=2 --inline-snapshot=disable' || '' }}
-          # TODO: add `gil_used = false` to the PyO3 `#[pymodule]` when test suite is ok
-          PYTHON_GIL: ${{ endsWith(matrix.python-version, 't') && '0' || '1' }}
 
   test-os:
     name: test on ${{ matrix.os }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,33 +106,26 @@ pub fn build_info() -> String {
     )
 }
 
-#[pymodule]
-fn _pydantic_core(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("__version__", get_pydantic_core_version())?;
-    m.add("build_profile", env!("PROFILE"))?;
-    m.add("build_info", build_info())?;
-    m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;
-    m.add("PydanticUndefined", PydanticUndefinedType::new(py))?;
-    m.add_class::<PydanticUndefinedType>()?;
-    m.add_class::<PySome>()?;
-    m.add_class::<SchemaValidator>()?;
-    m.add_class::<ValidationError>()?;
-    m.add_class::<SchemaError>()?;
-    m.add_class::<PydanticCustomError>()?;
-    m.add_class::<PydanticKnownError>()?;
-    m.add_class::<PydanticOmit>()?;
-    m.add_class::<PydanticUseDefault>()?;
-    m.add_class::<PydanticSerializationError>()?;
-    m.add_class::<PydanticSerializationUnexpectedValue>()?;
-    m.add_class::<PyUrl>()?;
-    m.add_class::<PyMultiHostUrl>()?;
-    m.add_class::<ArgsKwargs>()?;
-    m.add_class::<SchemaSerializer>()?;
-    m.add_class::<TzInfo>()?;
-    m.add_function(wrap_pyfunction!(to_json, m)?)?;
-    m.add_function(wrap_pyfunction!(from_json, m)?)?;
-    m.add_function(wrap_pyfunction!(to_jsonable_python, m)?)?;
-    m.add_function(wrap_pyfunction!(list_all_errors, m)?)?;
-    m.add_function(wrap_pyfunction!(validate_core_schema, m)?)?;
-    Ok(())
+#[pymodule(gil_used = false)]
+mod _pydantic_core {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    #[pymodule_export]
+    use crate::{
+        from_json, list_all_errors, to_json, to_jsonable_python, validate_core_schema, ArgsKwargs, PyMultiHostUrl,
+        PySome, PyUrl, PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticSerializationError,
+        PydanticSerializationUnexpectedValue, PydanticUndefinedType, PydanticUseDefault, SchemaError, SchemaSerializer,
+        SchemaValidator, TzInfo, ValidationError,
+    };
+
+    #[pymodule_init]
+    fn module_init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add("__version__", get_pydantic_core_version())?;
+        m.add("build_profile", env!("PROFILE"))?;
+        m.add("build_info", build_info())?;
+        m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;
+        m.add("PydanticUndefined", PydanticUndefinedType::new(m.py()))?;
+        Ok(())
+    }
 }

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -182,11 +182,7 @@ impl Validator for DecimalValidator {
 
         if let Some(multiple_of) = &self.multiple_of {
             // fraction = (decimal / multiple_of) % 1
-            let fraction = unsafe {
-                let division = decimal.div(multiple_of)?;
-                let one = 1u8.into_pyobject(py)?;
-                Bound::from_owned_ptr_or_err(py, pyo3::ffi::PyNumber_Remainder(division.as_ptr(), one.as_ptr()))?
-            };
+            let fraction = (decimal.div(multiple_of)?).rem(1)?;
             let zero = 0u8.into_pyobject(py)?;
             if !fraction.eq(&zero)? {
                 return Err(ValError::new(


### PR DESCRIPTION
## Change Summary

Adds the PyO3 flag `#[pymodule(gil_used = false)]` to declare full support for free-threading.

Also adds wheel builds for 3.13t.

(I couldn't help myself doing a drive-by cleanup to the `#[pymodule]` to use more modern PyO3 syntax at the same time.)

cc @ngoldbaum

## Related issue number

Closes #1555 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
