### PR TITLE
Fix enum strict JSON validation when validators are present

### DIFF
--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -8,7 +8,7 @@ use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
 
 use crate::build_tools::{is_strict, py_schema_err};
 use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::Input;
+use crate::input::{Input, InputType};
 use crate::tools::{safe_repr, SchemaDict};
 
 use super::is_instance::class_repr;
@@ -107,7 +107,7 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
             return Ok(exact_py_input.clone().unbind());
         }
         let strict = state.strict_or(self.strict);
-        if strict && input.as_python().is_some() {
+        if strict && state.extra().input_type == InputType::Python {
             // TODO what about instances of subclasses?
             return Err(ValError::new(
                 ErrorType::IsInstanceOf {

--- a/tests/validators/test_enums.py
+++ b/tests/validators/test_enums.py
@@ -487,3 +487,20 @@ def support_custom_new_method() -> None:
     assert v.validate_python('meow') is Animal.CAT
     assert v.validate_python('dog') is Animal.DOG
     assert v.validate_python('woof') is Animal.DOG
+
+
+def test_strict_enum_wrap_json() -> None:
+    """https://github.com/pydantic/pydantic/issues/11070"""
+
+    class Animal(str, Enum):
+        CAT = 'cat'
+        DOG = 'dog'
+
+    schema = core_schema.no_info_wrap_validator_function(
+        lambda v, handler: handler(v),
+        core_schema.enum_schema(Animal, list(Animal.__members__.values()), sub_type='str', strict=True),
+    )
+    v = SchemaValidator(schema)
+
+    assert v.validate_python(Animal.CAT) == Animal.CAT
+    assert v.validate_json('"dog"') == Animal.DOG


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Same as https://github.com/pydantic/pydantic-core/pull/1080. While this addresses https://github.com/pydantic/pydantic/issues/11070, the issue happens in many places, as reported in https://github.com/pydantic/pydantic/issues/9204. The core issue is that before/wrap validators transform the input into the Python mode. This is a a though issue to address, I don't know if it's really possible to fix it properly without making breaking changes and/or tradeoffs.

<!-- Please give a short summary of the changes. -->

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/11070.

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
