### PR TITLE
Add support for validating v7 UUIDs

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1437,7 +1437,7 @@ def callable_schema(
 
 class UuidSchema(TypedDict, total=False):
     type: Required[Literal['uuid']]
-    version: Literal[1, 3, 4, 5]
+    version: Literal[1, 3, 4, 5, 7]
     strict: bool
     ref: str
     metadata: dict[str, Any]
@@ -1446,7 +1446,7 @@ class UuidSchema(TypedDict, total=False):
 
 def uuid_schema(
     *,
-    version: Literal[1, 3, 4, 5] | None = None,
+    version: Literal[1, 3, 4, 5, 7] | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: dict[str, Any] | None = None,

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -42,6 +42,7 @@ enum Version {
     UUIDv3 = 3,
     UUIDv4 = 4,
     UUIDv5 = 5,
+    UUIDv7 = 7,
 }
 
 impl From<Version> for usize {
@@ -57,6 +58,7 @@ impl From<u8> for Version {
             3 => Version::UUIDv3,
             4 => Version::UUIDv4,
             5 => Version::UUIDv5,
+            7 => Version::UUIDv7,
             _ => unreachable!(),
         }
     }

--- a/tests/validators/test_uuid.py
+++ b/tests/validators/test_uuid.py
@@ -26,6 +26,7 @@ class MyStr(str): ...
         ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')),
         ('886313e1-3b8a-5372-9b90-0c9aee199e5d', UUID('886313e1-3b8a-5372-9b90-0c9aee199e5d')),
         ('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11', UUID('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11')),
+        ('0194fdc2-5d6a-733c-97f9-2feeb9d2a609', UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609')),
         ('00000000-8000-4000-8000-000000000000', UUID('00000000-8000-4000-8000-000000000000')),
         ('00000000-0000-4000-0000-000000000000', UUID('00000000-0000-4000-0000-000000000000')),
         (MyStr('00000000-0000-4000-0000-000000000000'), UUID('00000000-0000-4000-0000-000000000000')),
@@ -124,6 +125,7 @@ def test_uuid_strict(input_value, expected):
         (UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7'), 4, UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7')),
         ('0e7ac198-9acd-4c0c-b4b4-761974bf71d7', 4, UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7')),
         (UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7'), 4, UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7')),
+        ('0194fdc2-5d6a-733c-97f9-2feeb9d2a609', 7, UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609')),
         # Cases from pydantic#7355 and pydantic#7537
         # `UUID.version` makes sense for RFC 4122 UUIDs only. For non RFC 4122 UUIDs Python uses `UUID.version=None`
         ('00000000-8000-4000-8000-000000000000', 4, UUID('00000000-8000-4000-8000-000000000000')),
@@ -137,6 +139,8 @@ def test_uuid_strict(input_value, expected):
         (UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3'), None, UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3')),
         (UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3'), 4, Err('UUID version 4 expected')),
         # Invalid UUIDs
+        ('a6cc5730-2261-11ee-9c43-2eb5a363657c', 7, Err('UUID version 7 expected')),
+        (UUID('a6cc5730-2261-11ee-9c43-2eb5a363657c'), 7, Err('UUID version 7 expected')),
         ('a6cc5730-2261-11ee-9c43-2eb5a363657c', 5, Err('UUID version 5 expected')),
         (UUID('a6cc5730-2261-11ee-9c43-2eb5a363657c'), 5, Err('UUID version 5 expected')),
         ('04e4aeb3-8f20-30d0-8852-d295e1265eed', 4, Err('UUID version 4 expected')),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Adds support for validating v7 UUIDs. UUID version 7 (along with version 6) are defined in [RFC 9562](https://datatracker.ietf.org/doc/rfc9562/) and has been seeing increased popularity. To pluck some really low-hanging fruit, implement support for it in pydantic.

## Related issue number

n/a

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
