### PR TITLE
refactor `LookupKey` logic to reduce redundancy

### DIFF
--- a/src/common/union.rs
+++ b/src/common/union.rs
@@ -4,7 +4,7 @@ use pyo3::{PyTraverseError, PyVisit};
 use crate::lookup_key::LookupKey;
 use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Discriminator {
     /// use `LookupKey` to find the tag, same as we do to find values in typed_dict aliases
     LookupKey(LookupKey),

--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -8,8 +8,6 @@ use pyo3::types::{PyList, PyTuple};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
-use crate::lookup_key::{LookupPath, PathItem};
-
 /// Used to store individual items of the error location, e.g. a string for key/field names
 /// or a number for array indices.
 #[derive(Clone, Eq, PartialEq, IntoPyObjectRef)]
@@ -71,20 +69,6 @@ impl From<usize> for LocItem {
     }
 }
 
-/// eventually it might be good to combine PathItem and LocItem
-impl From<PathItem> for LocItem {
-    fn from(path_item: PathItem) -> Self {
-        match path_item {
-            PathItem::S(s, _) => s.into(),
-            PathItem::Pos(val) => val.into(),
-            PathItem::Neg(val) => {
-                let neg_value = -(val as i64);
-                neg_value.into()
-            }
-        }
-    }
-}
-
 impl Serialize for LocItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -134,17 +118,6 @@ impl<'py> IntoPyObject<'py> for &'_ Location {
                 .bind(py)
                 .clone()),
         }
-    }
-}
-
-impl From<&LookupPath> for Location {
-    fn from(lookup_path: &LookupPath) -> Self {
-        let v = lookup_path
-            .iter()
-            .rev()
-            .map(|path_item| path_item.clone().into())
-            .collect();
-        Self::List(v)
     }
 }
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -7,7 +7,7 @@ mod validation_exception;
 mod value_exception;
 
 pub use self::line_error::{InputValue, ToErrorValue, ValError, ValLineError, ValResult};
-pub use self::location::LocItem;
+pub use self::location::{LocItem, Location};
 pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
 pub use self::validation_exception::{PyLineError, ValidationError};
 pub use self::value_exception::{PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault};


### PR DESCRIPTION
## Change Summary

Precursor to #1620, which is itself a precursor to moving forward with https://github.com/pydantic/jiter/pull/184

The idea here is that the `LookupPath` stuff contains a bunch of redundant `String` and `Py<PyString>` values. I work these away.

I also removed `Clone` implementation at the same time, which gets us closer to removing PyO3's `py-clone` feature.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
