### PR TITLE
Add support for UUIDv6 and UUIDv8 validation

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -1446,7 +1446,7 @@ class UuidSchema(TypedDict, total=False):
 
 def uuid_schema(
     *,
-    version: Literal[1, 3, 4, 5, 7] | None = None,
+    version: Literal[1, 3, 4, 5, 6, 7, 8] | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: dict[str, Any] | None = None,

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -42,7 +42,9 @@ enum Version {
     UUIDv3 = 3,
     UUIDv4 = 4,
     UUIDv5 = 5,
+    UUIDv6 = 6,
     UUIDv7 = 7,
+    UUIDv8 = 8,
 }
 
 impl From<Version> for usize {
@@ -58,7 +60,9 @@ impl From<u8> for Version {
             3 => Version::UUIDv3,
             4 => Version::UUIDv4,
             5 => Version::UUIDv5,
+            6 => Version::UUIDv6,
             7 => Version::UUIDv7,
+            8 => Version::UUIDv8,
             _ => unreachable!(),
         }
     }

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -140,8 +140,8 @@ impl Validator for UuidValidator {
             }
             let uuid = self.get_uuid(input)?;
             // This block checks if the UUID version matches the expected version and
-            // if the UUID variant conforms to RFC 4122. When dealing with Python inputs,
-            // UUIDs must adhere to RFC 4122 standards.
+            // if the UUID variant conforms to RFC 9562 (superseding RFC 4122).
+            // When dealing with Python inputs, UUIDs must adhere to RFC 9562 standards.
             if let Some(expected_version) = self.version {
                 if uuid.get_version_num() != expected_version || uuid.get_variant() != Variant::RFC4122 {
                     return Err(ValError::new(

--- a/tests/validators/test_uuid.py
+++ b/tests/validators/test_uuid.py
@@ -26,7 +26,9 @@ class MyStr(str): ...
         ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')),
         ('886313e1-3b8a-5372-9b90-0c9aee199e5d', UUID('886313e1-3b8a-5372-9b90-0c9aee199e5d')),
         ('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11', UUID('c0a8f9a8-aa5e-482b-a067-9cb3a51f5c11')),
+        ('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05', UUID('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05')),
         ('0194fdc2-5d6a-733c-97f9-2feeb9d2a609', UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609')),
+        ('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11', UUID('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11')),
         ('00000000-8000-4000-8000-000000000000', UUID('00000000-8000-4000-8000-000000000000')),
         ('00000000-0000-4000-0000-000000000000', UUID('00000000-0000-4000-0000-000000000000')),
         (MyStr('00000000-0000-4000-0000-000000000000'), UUID('00000000-0000-4000-0000-000000000000')),
@@ -126,6 +128,11 @@ def test_uuid_strict(input_value, expected):
         ('0e7ac198-9acd-4c0c-b4b4-761974bf71d7', 4, UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7')),
         (UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7'), 4, UUID('0e7ac198-9acd-4c0c-b4b4-761974bf71d7')),
         ('0194fdc2-5d6a-733c-97f9-2feeb9d2a609', 7, UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609')),
+        (UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609'), 7, UUID('0194fdc2-5d6a-733c-97f9-2feeb9d2a609')),
+        ('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05', 6, UUID('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05')),
+        (UUID('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05'), 6, UUID('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05')),
+        ('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11', 8, UUID('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11')),
+        (UUID('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11'), 8, UUID('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11')),
         # Cases from pydantic#7355 and pydantic#7537
         # `UUID.version` makes sense for RFC 4122 UUIDs only. For non RFC 4122 UUIDs Python uses `UUID.version=None`
         ('00000000-8000-4000-8000-000000000000', 4, UUID('00000000-8000-4000-8000-000000000000')),
@@ -139,6 +146,10 @@ def test_uuid_strict(input_value, expected):
         (UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3'), None, UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3')),
         (UUID('b34b6755-f49c-3bd2-6f06-131a708c2bf3'), 4, Err('UUID version 4 expected')),
         # Invalid UUIDs
+        ('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05', 8, Err('UUID version 8 expected')),
+        (UUID('1efea93d-7bb8-6ea0-afdc-e76cbc0c8e05'), 8, Err('UUID version 8 expected')),
+        ('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11', 6, Err('UUID version 6 expected')),
+        (UUID('c0a8f9a8-aa5e-882b-a067-9cb3a51f5c11'), 6, Err('UUID version 6 expected')),
         ('a6cc5730-2261-11ee-9c43-2eb5a363657c', 7, Err('UUID version 7 expected')),
         (UUID('a6cc5730-2261-11ee-9c43-2eb5a363657c'), 7, Err('UUID version 7 expected')),
         ('a6cc5730-2261-11ee-9c43-2eb5a363657c', 5, Err('UUID version 5 expected')),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Adds support for validating v6 and v8 UUIDs. UUID version 6 and 8 defined in [RFC 9562](https://datatracker.ietf.org/doc/rfc9562/).

Upon request from from @Viicos on pydantic/pydantic#11436, creating this PR to wire up UUID v6 and v8 validation support.

## Related issue number

n/a

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle