### PR TITLE
Remove unneeded `Option` map in `PyMultiHostUrl.build`

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -400,7 +400,7 @@ impl PyMultiHostUrl {
                     username: username.map(Into::into),
                     password: password.map(Into::into),
                     host: host.map(Into::into),
-                    port: port.map(Into::into),
+                    port,
                 };
                 format!("{scheme}://{url_host}")
             } else {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
