### PR TITLE
update python3-dll-a for PyPy 3.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "python3-dll-a"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b66f9171950e674e64bad3456e11bb3cca108e5c34844383cfe277f45c8a7a8"
+checksum = "49fe4227a288cf9493942ad0220ea3f185f4d1f2a14f197f7344d6d02f4ed4ed"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Contains https://github.com/PyO3/python3-dll-a/pull/87. Should fix the new windows build failure on main.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
