### PR TITLE
Skip reusing wrap validators / serializers for prebuilt variants

### DIFF
--- a/src/common/prebuilt.rs
+++ b/src/common/prebuilt.rs
@@ -8,7 +8,7 @@ pub fn get_prebuilt<T>(
     type_: &str,
     schema: &Bound<'_, PyDict>,
     prebuilt_attr_name: &str,
-    extractor: impl FnOnce(Bound<'_, PyAny>) -> PyResult<T>,
+    extractor: impl FnOnce(Bound<'_, PyAny>) -> PyResult<Option<T>>,
 ) -> PyResult<Option<T>> {
     let py = schema.py();
 
@@ -40,5 +40,5 @@ pub fn get_prebuilt<T>(
 
     // Retrieve the prebuilt validator / serializer if available
     let prebuilt: Bound<'_, PyAny> = class_dict.get_item(prebuilt_attr_name)?;
-    extractor(prebuilt).map(Some)
+    extractor(prebuilt)
 }

--- a/src/serializers/prebuilt.rs
+++ b/src/serializers/prebuilt.rs
@@ -17,9 +17,11 @@ pub struct PrebuiltSerializer {
 impl PrebuiltSerializer {
     pub fn try_get_from_schema(type_: &str, schema: &Bound<'_, PyDict>) -> PyResult<Option<CombinedSerializer>> {
         get_prebuilt(type_, schema, "__pydantic_serializer__", |py_any| {
-            py_any
-                .extract::<Py<SchemaSerializer>>()
-                .map(|schema_serializer| Self { schema_serializer }.into())
+            let schema_serializer = py_any.extract::<Py<SchemaSerializer>>()?;
+            if matches!(schema_serializer.get().serializer, CombinedSerializer::FunctionWrap(_)) {
+                return Ok(None);
+            }
+            Ok(Some(Self { schema_serializer }.into()))
         })
     }
 }

--- a/src/validators/prebuilt.rs
+++ b/src/validators/prebuilt.rs
@@ -16,9 +16,11 @@ pub struct PrebuiltValidator {
 impl PrebuiltValidator {
     pub fn try_get_from_schema(type_: &str, schema: &Bound<'_, PyDict>) -> PyResult<Option<CombinedValidator>> {
         get_prebuilt(type_, schema, "__pydantic_validator__", |py_any| {
-            py_any
-                .extract::<Py<SchemaValidator>>()
-                .map(|schema_validator| Self { schema_validator }.into())
+            let schema_validator = py_any.extract::<Py<SchemaValidator>>()?;
+            if matches!(schema_validator.get().validator, CombinedValidator::FunctionWrap(_)) {
+                return Ok(None);
+            }
+            Ok(Some(Self { schema_validator }.into()))
         })
     }
 }

--- a/tests/test_prebuilt.py
+++ b/tests/test_prebuilt.py
@@ -46,3 +46,123 @@ def test_prebuilt_val_and_ser_used() -> None:
     result = outer_validator.validate_python({'inner': {'x': 1}})
     assert result.inner.x == 1
     assert outer_serializer.to_python(result) == {'inner': {'x': 1}}
+
+
+def test_prebuilt_not_used_for_wrap_serializer_functions() -> None:
+    class InnerModel:
+        x: str
+
+        def __init__(self, x: str) -> None:
+            self.x = x
+
+    def serialize_inner(v: InnerModel, serializer) -> str:
+        v.x = v.x + ' modified'
+        return serializer(v)
+
+    inner_schema = core_schema.model_schema(
+        InnerModel,
+        schema=core_schema.model_fields_schema(
+            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+        ),
+        serialization=core_schema.wrap_serializer_function_ser_schema(serialize_inner),
+    )
+
+    inner_schema_serializer = SchemaSerializer(inner_schema)
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_serializer__ = inner_schema_serializer  # pyright: ignore[reportAttributeAccessIssue]
+
+    class OuterModel:
+        inner: InnerModel
+
+        def __init__(self, inner: InnerModel) -> None:
+            self.inner = inner
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            # note, we use a simple str schema (with no custom serialization)
+                            # in order to verify that the prebuilt serializer from InnerModel is not used
+                            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    inner_serializer = SchemaSerializer(inner_schema)
+    outer_serializer = SchemaSerializer(outer_schema)
+
+    # the custom serialization function does apply for the inner model
+    inner_instance = InnerModel(x='hello')
+    assert inner_serializer.to_python(inner_instance) == {'x': 'hello modified'}
+
+    # but the outer model doesn't reuse the custom wrap serializer function, so we see simple str ser
+    outer_instance = OuterModel(inner=InnerModel(x='hello'))
+    assert outer_serializer.to_python(outer_instance) == {'inner': {'x': 'hello'}}
+
+
+def test_prebuilt_not_used_for_wrap_validator_functions() -> None:
+    class InnerModel:
+        x: str
+
+        def __init__(self, x: str) -> None:
+            self.x = x
+
+    def validate_inner(data, validator) -> str:
+        data['x'] = data['x'] + ' modified'
+        return validator(data)
+
+    inner_schema = core_schema.no_info_wrap_validator_function(
+        validate_inner,
+        core_schema.model_schema(
+            InnerModel,
+            schema=core_schema.model_fields_schema(
+                {'x': core_schema.model_field(schema=core_schema.str_schema())},
+            ),
+        ),
+    )
+
+    inner_schema_validator = SchemaValidator(inner_schema)
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_validator__ = inner_schema_validator  # pyright: ignore[reportAttributeAccessIssue]
+
+    class OuterModel:
+        inner: InnerModel
+
+        def __init__(self, inner: InnerModel) -> None:
+            self.inner = inner
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            # note, we use a simple str schema (with no custom validation)
+                            # in order to verify that the prebuilt validator from InnerModel is not used
+                            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    inner_validator = SchemaValidator(inner_schema)
+    outer_validator = SchemaValidator(outer_schema)
+
+    # the custom validation function does apply for the inner model
+    result_inner = inner_validator.validate_python({'x': 'hello'})
+    assert result_inner.x == 'hello modified'
+
+    # but the outer model doesn't reuse the custom wrap validator function, so we see simple str val
+    result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
+    assert result_outer.inner.x == 'hello'

--- a/tests/test_prebuilt.py
+++ b/tests/test_prebuilt.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from pydantic_core import SchemaSerializer, SchemaValidator, core_schema
 
 
@@ -55,7 +57,7 @@ def test_prebuilt_not_used_for_wrap_serializer_functions() -> None:
         def __init__(self, x: str) -> None:
             self.x = x
 
-    def serialize_inner(v: InnerModel, serializer) -> dict[str, str] | str:
+    def serialize_inner(v: InnerModel, serializer) -> Union[dict[str, str], str]:
         v.x = v.x + ' modified'
         return serializer(v)
 

--- a/tests/test_prebuilt.py
+++ b/tests/test_prebuilt.py
@@ -55,7 +55,7 @@ def test_prebuilt_not_used_for_wrap_serializer_functions() -> None:
         def __init__(self, x: str) -> None:
             self.x = x
 
-    def serialize_inner(v: InnerModel, serializer) -> str:
+    def serialize_inner(v: InnerModel, serializer) -> dict[str, str] | str:
         v.x = v.x + ' modified'
         return serializer(v)
 
@@ -114,7 +114,7 @@ def test_prebuilt_not_used_for_wrap_validator_functions() -> None:
         def __init__(self, x: str) -> None:
             self.x = x
 
-    def validate_inner(data, validator) -> str:
+    def validate_inner(data, validator) -> InnerModel:
         data['x'] = data['x'] + ' modified'
         return validator(data)
 
@@ -166,3 +166,118 @@ def test_prebuilt_not_used_for_wrap_validator_functions() -> None:
     # but the outer model doesn't reuse the custom wrap validator function, so we see simple str val
     result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
     assert result_outer.inner.x == 'hello'
+
+
+def test_reuse_plain_serializer_ok() -> None:
+    class InnerModel:
+        x: str
+
+        def __init__(self, x: str) -> None:
+            self.x = x
+
+    def serialize_inner(v: InnerModel) -> str:
+        return v.x + ' modified'
+
+    inner_schema = core_schema.model_schema(
+        InnerModel,
+        schema=core_schema.model_fields_schema(
+            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+        ),
+        serialization=core_schema.plain_serializer_function_ser_schema(serialize_inner),
+    )
+
+    inner_schema_serializer = SchemaSerializer(inner_schema)
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_serializer__ = inner_schema_serializer  # pyright: ignore[reportAttributeAccessIssue]
+
+    class OuterModel:
+        inner: InnerModel
+
+        def __init__(self, inner: InnerModel) -> None:
+            self.inner = inner
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            # note, we use a simple str schema (with no custom serialization)
+                            # in order to verify that the prebuilt serializer from InnerModel is used instead
+                            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    inner_serializer = SchemaSerializer(inner_schema)
+    outer_serializer = SchemaSerializer(outer_schema)
+
+    # the custom serialization function does apply for the inner model
+    inner_instance = InnerModel(x='hello')
+    assert inner_serializer.to_python(inner_instance) == 'hello modified'
+    assert 'FunctionPlainSerializer' in repr(inner_serializer)
+
+    # the custom ser function applies for the outer model as well, a plain serializer is permitted as a prebuilt candidate
+    outer_instance = OuterModel(inner=InnerModel(x='hello'))
+    assert outer_serializer.to_python(outer_instance) == {'inner': 'hello modified'}
+    assert 'PrebuiltSerializer' in repr(outer_serializer)
+
+
+def test_reuse_plain_validator_ok() -> None:
+    class InnerModel:
+        x: str
+
+        def __init__(self, x: str) -> None:
+            self.x = x
+
+    def validate_inner(data) -> InnerModel:
+        data['x'] = data['x'] + ' modified'
+        return InnerModel(**data)
+
+    inner_schema = core_schema.no_info_plain_validator_function(validate_inner)
+
+    inner_schema_validator = SchemaValidator(inner_schema)
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_validator__ = inner_schema_validator  # pyright: ignore[reportAttributeAccessIssue]
+
+    class OuterModel:
+        inner: InnerModel
+
+        def __init__(self, inner: InnerModel) -> None:
+            self.inner = inner
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            # note, we use a simple str schema (with no custom validation)
+                            # in order to verify that the prebuilt validator from InnerModel is used instead
+                            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    inner_validator = SchemaValidator(inner_schema)
+    outer_validator = SchemaValidator(outer_schema)
+
+    # the custom validation function does apply for the inner model
+    result_inner = inner_validator.validate_python({'x': 'hello'})
+    assert result_inner.x == 'hello modified'
+    assert 'FunctionPlainValidator' in repr(inner_validator)
+
+    # the custom validation function does apply for the outer model as well, a plain validator is permitted as a prebuilt candidate
+    result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
+    assert result_outer.inner.x == 'hello modified'
+    assert 'PrebuiltValidator' in repr(outer_validator)


### PR DESCRIPTION
Reuse of wrap validators / serializers leads to some really odd behavior (double calls).

This PR fixes https://github.com/pydantic/pydantic/issues/11505, where you can find some reproducible examples.

This bug was originally introduced by me in https://github.com/pydantic/pydantic-core/pull/1616 where we added reuse of schema validators and serializers to optimize memory in the case of reused models.

As discussed with DH, perhaps a cleaner approach going forward would be to use a new type of core schema to control reuse of schema validators and serializers. Though this avoids introducing edge case checks like this one in `pydantic-core`, it just pushes the burden up to `pydantic`, where things actually may be more complicated (ex - with schema cleaning + discriminator application or parametrized generics).

Note: the failing integration tests are not related to this PR. I think it makes sense to add corresponding tests to `pydantic` for the realistic use case here - I'll do that when we bump the version after a `pydantic-core` release.