### PR TITLE
Coerce validator constraints to their valid type

### DIFF
--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -14,6 +14,15 @@ from ..conftest import Err, PyAndJson
 
 
 @pytest.mark.parametrize(
+    'constraint',
+    ['le', 'lt', 'ge', 'gt'],
+)
+def test_constraints_schema_validation(constraint: str) -> None:
+    with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a date instance"):
+        SchemaValidator(cs.date_schema(**{constraint: 'bad_value'}))
+
+
+@pytest.mark.parametrize(
     'input_value,expected',
     [
         pytest.param(date(2022, 6, 8), date(2022, 6, 8), id='date'),

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -15,6 +15,15 @@ from ..conftest import Err, PyAndJson
 
 
 @pytest.mark.parametrize(
+    'constraint',
+    ['le', 'lt', 'ge', 'gt'],
+)
+def test_constraints_schema_validation(constraint: str) -> None:
+    with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a datetime instance"):
+        SchemaValidator(cs.datetime_schema(**{constraint: 'bad_value'}))
+
+
+@pytest.mark.parametrize(
     'input_value,expected',
     [
         (datetime(2022, 6, 8, 12, 13, 14), datetime(2022, 6, 8, 12, 13, 14)),

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -6,12 +6,21 @@ from typing import Any
 import pytest
 from dirty_equals import IsStr
 
-from pydantic_core import SchemaValidator, ValidationError, core_schema
+from pydantic_core import SchemaError, SchemaValidator, ValidationError
 from pydantic_core import core_schema as cs
 
 from ..conftest import Err, PyAndJson, plain_repr
 
 i64_max = 9_223_372_036_854_775_807
+
+
+@pytest.mark.parametrize(
+    'constraint',
+    ['multiple_of', 'le', 'lt', 'ge', 'gt'],
+)
+def test_constraints_schema_validation(constraint: str) -> None:
+    with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to an integer"):
+        SchemaValidator(cs.int_schema(**{constraint: 'bad_value'}))
 
 
 @pytest.mark.parametrize(
@@ -532,7 +541,7 @@ def test_int_subclass_plain_enum() -> None:
 
 
 def test_allow_inf_nan_true_json() -> None:
-    v = SchemaValidator(core_schema.int_schema(), config=core_schema.CoreConfig(allow_inf_nan=True))
+    v = SchemaValidator(cs.int_schema(), config=cs.CoreConfig(allow_inf_nan=True))
 
     assert v.validate_json('123') == 123
     with pytest.raises(ValidationError, match=r'Input should be a finite number \[type=finite_number'):
@@ -544,7 +553,7 @@ def test_allow_inf_nan_true_json() -> None:
 
 
 def test_allow_inf_nan_false_json() -> None:
-    v = SchemaValidator(core_schema.int_schema(), config=core_schema.CoreConfig(allow_inf_nan=False))
+    v = SchemaValidator(cs.int_schema(), config=cs.CoreConfig(allow_inf_nan=False))
 
     assert v.validate_json('123') == 123
     with pytest.raises(ValidationError, match=r'Input should be a finite number \[type=finite_number'):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11341, fixes https://github.com/pydantic/pydantic-core/issues/1608.

I've applied the coercion for decimals and ints as per https://github.com/pydantic/pydantic/issues/11341#issuecomment-2615492914, should we extend to others? I'm thinking datetime types as well?

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
