### PR TITLE
[wip] sort keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,18 @@ rust-version = "1.75"
 [dependencies]
 # TODO it would be very nice to remove the "py-clone" feature as it can panic,
 # but needs a bit of work to make sure it's not used in the codebase
-pyo3 = { version = "0.23.5", features = ["generate-import-lib", "num-bigint", "py-clone"] }
+pyo3 = { version = "0.23.5", features = [
+    "generate-import-lib",
+    "num-bigint",
+    "py-clone",
+] }
 regex = "1.11.1"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
-serde_json = {version = "1.0.138", features = ["arbitrary_precision", "preserve_order"]}
+serde_json = { version = "1.0.138", features = [
+    "arbitrary_precision",
+    "preserve_order",
+] }
 enum_dispatch = "0.3.13"
 serde = { version = "1.0.218", features = ["derive"] }
 speedate = "0.15.0"

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -427,6 +427,7 @@ def to_json(
         serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
         context: The context to use for serialization, this is passed to functional serializers as
             [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
+        sort_keys: Whether to sort the keys of the serialized object.
 
     Raises:
         PydanticSerializationError: If serialization fails and no `fallback` function is provided.
@@ -479,6 +480,7 @@ def to_jsonable_python(
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
     context: Any | None = None,
+    sort_keys: bool = False,
 ) -> Any:
     """
     Serialize/marshal a Python object to a JSON-serializable Python object including transforming and filtering data.
@@ -503,7 +505,7 @@ def to_jsonable_python(
         serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
         context: The context to use for serialization, this is passed to functional serializers as
             [`info.context`][pydantic_core.core_schema.SerializationInfo.context].
-
+        sort_keys: Whether to sort the keys of the serialized object.
     Raises:
         PydanticSerializationError: If serialization fails and no `fallback` function is provided.
 

--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -402,6 +402,7 @@ def to_json(
     fallback: Callable[[Any], Any] | None = None,
     serialize_as_any: bool = False,
     context: Any | None = None,
+    sort_keys: bool = False,
 ) -> bytes:
     """
     Serialize a Python object to JSON including transforming and filtering data.

--- a/src/errors/validation_exception.rs
+++ b/src/errors/validation_exception.rs
@@ -351,6 +351,7 @@ impl ValidationError {
             None,
             DuckTypingSerMode::SchemaBased,
             None,
+            false,
         );
         let serializer = ValidationErrorSerializer {
             py,

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -87,9 +87,10 @@ impl SerializationState {
         exclude_none: bool,
         round_trip: bool,
         serialize_unknown: bool,
-        fallback: Option<&'py Bound<'_, PyAny>>,
+        fallback: Option<&'py Bound<'py, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
-        context: Option<&'py Bound<'_, PyAny>>,
+        context: Option<&'py Bound<'py, PyAny>>,
+        sort_keys: bool,
     ) -> Extra<'py> {
         Extra::new(
             py,
@@ -106,6 +107,7 @@ impl SerializationState {
             fallback,
             duck_typing_ser_mode,
             context,
+            sort_keys,
         )
     }
 
@@ -139,6 +141,7 @@ pub(crate) struct Extra<'a> {
     pub fallback: Option<&'a Bound<'a, PyAny>>,
     pub duck_typing_ser_mode: DuckTypingSerMode,
     pub context: Option<&'a Bound<'a, PyAny>>,
+    pub sort_keys: bool,
 }
 
 impl<'a> Extra<'a> {
@@ -158,6 +161,7 @@ impl<'a> Extra<'a> {
         fallback: Option<&'a Bound<'a, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
         context: Option<&'a Bound<'a, PyAny>>,
+        sort_keys: bool,
     ) -> Self {
         Self {
             mode,
@@ -177,6 +181,7 @@ impl<'a> Extra<'a> {
             fallback,
             duck_typing_ser_mode,
             context,
+            sort_keys,
         }
     }
 
@@ -288,11 +293,12 @@ impl ExtraOwned {
             fallback: self.fallback.as_ref().map(|m| m.bind(py)),
             duck_typing_ser_mode: self.duck_typing_ser_mode,
             context: self.context.as_ref().map(|m| m.bind(py)),
+            sort_keys: false,
         }
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) enum SerMode {
     Python,

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -65,6 +65,7 @@ impl SchemaSerializer {
         fallback: Option<&'a Bound<'a, PyAny>>,
         duck_typing_ser_mode: DuckTypingSerMode,
         context: Option<&'a Bound<'a, PyAny>>,
+        sort_keys: bool,
     ) -> Extra<'b> {
         Extra::new(
             py,
@@ -81,6 +82,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            sort_keys,
         )
     }
 }
@@ -148,6 +150,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            false,
         );
         let v = self.serializer.to_python(value, include, exclude, &extra)?;
         warnings.final_check(py)?;
@@ -157,7 +160,7 @@ impl SchemaSerializer {
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = None,
         exclude_unset = false, exclude_defaults = false, exclude_none = false, round_trip = false, warnings = WarningsArg::Bool(true),
-        fallback = None, serialize_as_any = false, context = None))]
+        fallback = None, serialize_as_any = false, context = None, sort_keys = false))]
     pub fn to_json(
         &self,
         py: Python,
@@ -174,6 +177,7 @@ impl SchemaSerializer {
         fallback: Option<&Bound<'_, PyAny>>,
         serialize_as_any: bool,
         context: Option<&Bound<'_, PyAny>>,
+        sort_keys: bool,
     ) -> PyResult<PyObject> {
         let warnings_mode = match warnings {
             WarningsArg::Bool(b) => b.into(),
@@ -196,6 +200,7 @@ impl SchemaSerializer {
             fallback,
             duck_typing_ser_mode,
             context,
+            sort_keys,
         );
         let bytes = to_json_bytes(
             value,
@@ -242,7 +247,7 @@ impl SchemaSerializer {
 #[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = None,
     exclude_none = false, round_trip = false, timedelta_mode = "iso8601", bytes_mode = "utf8",
     inf_nan_mode = "constants", serialize_unknown = false, fallback = None, serialize_as_any = false,
-    context = None))]
+    context = None, sort_keys = false))]
 pub fn to_json(
     py: Python,
     value: &Bound<'_, PyAny>,
@@ -259,6 +264,7 @@ pub fn to_json(
     fallback: Option<&Bound<'_, PyAny>>,
     serialize_as_any: bool,
     context: Option<&Bound<'_, PyAny>>,
+    sort_keys: bool,
 ) -> PyResult<PyObject> {
     let state = SerializationState::new(timedelta_mode, bytes_mode, inf_nan_mode)?;
     let duck_typing_ser_mode = DuckTypingSerMode::from_bool(serialize_as_any);
@@ -272,6 +278,7 @@ pub fn to_json(
         fallback,
         duck_typing_ser_mode,
         context,
+        sort_keys,
     );
     let serializer = type_serializers::any::AnySerializer.into();
     let bytes = to_json_bytes(value, &serializer, include, exclude, &extra, indent, 1024)?;
@@ -284,7 +291,7 @@ pub fn to_json(
 #[pyfunction]
 #[pyo3(signature = (value, *, include = None, exclude = None, by_alias = None, exclude_none = false, round_trip = false,
     timedelta_mode = "iso8601", bytes_mode = "utf8", inf_nan_mode = "constants", serialize_unknown = false, fallback = None,
-    serialize_as_any = false, context = None))]
+    serialize_as_any = false, context = None, sort_keys = false))]
 pub fn to_jsonable_python(
     py: Python,
     value: &Bound<'_, PyAny>,
@@ -300,6 +307,7 @@ pub fn to_jsonable_python(
     fallback: Option<&Bound<'_, PyAny>>,
     serialize_as_any: bool,
     context: Option<&Bound<'_, PyAny>>,
+    sort_keys: bool,
 ) -> PyResult<PyObject> {
     let state = SerializationState::new(timedelta_mode, bytes_mode, inf_nan_mode)?;
     let duck_typing_ser_mode = DuckTypingSerMode::from_bool(serialize_as_any);
@@ -313,6 +321,7 @@ pub fn to_jsonable_python(
         fallback,
         duck_typing_ser_mode,
         context,
+        sort_keys,
     );
     let v = infer::infer_to_python(value, include, exclude, &extra)?;
     state.final_check(py)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -104,6 +104,7 @@ a = A()
                     None,
                     false,
                     None,
+                    false,
                 )
                 .unwrap();
             let serialized: &[u8] = serialized.extract(py).unwrap();
@@ -212,6 +213,7 @@ dump_json_input_2 = {'a': 'something'}
                     None,
                     false,
                     None,
+                    false,
                 )
                 .unwrap();
             let repr = format!("{}", serialization_result.bind(py).repr().unwrap());
@@ -233,6 +235,7 @@ dump_json_input_2 = {'a': 'something'}
                     None,
                     false,
                     None,
+                    false,
                 )
                 .unwrap();
             let repr = format!("{}", serialization_result.bind(py).repr().unwrap());

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,6 +1,7 @@
 import json
 import platform
 import re
+from typing import Any
 
 import pytest
 from dirty_equals import IsFloatNan, IsList
@@ -253,7 +254,7 @@ def test_to_json_fallback():
         ),
     ],
 )
-def test_to_json_sort_keys(input_value, unsorted_output_value, sorted_output_value):
+def test_to_json_sort_keys(input_value: dict[str, Any], unsorted_output_value: bytes, sorted_output_value: bytes):
     assert to_json(input_value) == unsorted_output_value
     assert to_json(input_value, sort_keys=True) == sorted_output_value
 
@@ -272,6 +273,21 @@ def test_to_jsonable_python_fallback():
     assert to_jsonable_python(Foobar(), serialize_unknown=True) == 'Foobar.__str__'
     assert to_jsonable_python(Foobar(), serialize_unknown=True, fallback=fallback_func) == 'fallback:Foobar'
     assert to_jsonable_python(Foobar(), fallback=fallback_func) == 'fallback:Foobar'
+
+
+@pytest.mark.parametrize(
+    'input_value,unsorted_output_value,sorted_output_value',
+    [
+        ({'b': 2, 'a': 1}, {'b': 2, 'a': 1}, {'a': 1, 'b': 2}),
+        ({'b': {'d': 4, 'c': 3}}, {'b': {'d': 4, 'c': 3}}, {'b': {'c': 3, 'd': 4}}),
+        ({'b': {'d': 4, 'c': 3}, 'a': 1}, {'b': {'d': 4, 'c': 3}, 'a': 1}, {'a': 1, 'b': {'c': 3, 'd': 4}}),
+    ],
+)
+def test_to_jsonable_python_sort_keys(
+    input_value: dict[str, Any], unsorted_output_value: dict[str, Any], sorted_output_value: dict[str, Any]
+):
+    assert to_jsonable_python(input_value) == unsorted_output_value
+    assert to_jsonable_python(input_value, sort_keys=True) == sorted_output_value
 
 
 def test_to_jsonable_python_schema_serializer():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -233,6 +233,31 @@ def test_to_json_fallback():
     assert to_json(Foobar(), fallback=fallback_func) == b'"fallback:Foobar"'
 
 
+@pytest.mark.parametrize(
+    'input_value,unsorted_output_value,sorted_output_value',
+    [
+        (
+            {'b': 2, 'a': 1},
+            b'{"b":2,"a":1}',
+            b'{"a":1,"b":2}',
+        ),
+        (
+            {'b': {'d': 4, 'c': 3}},
+            b'{"b":{"d":4,"c":3}}',
+            b'{"b":{"c":3,"d":4}}',
+        ),
+        (
+            {'b': {'d': 4, 'c': 3}, 'a': 1},
+            b'{"b":{"d":4,"c":3},"a":1}',
+            b'{"a":1,"b":{"c":3,"d":4}}',
+        ),
+    ],
+)
+def test_to_json_sort_keys(input_value, unsorted_output_value, sorted_output_value):
+    assert to_json(input_value) == unsorted_output_value
+    assert to_json(input_value, sort_keys=True) == sorted_output_value
+
+
 def test_to_jsonable_python():
     assert to_jsonable_python([1, 2]) == [1, 2]
     assert to_jsonable_python({1, 2}) == IsList(1, 2, check_order=False)


### PR DESCRIPTION
adds `sort_keys` a la `json.dumps` to `to_json`/`to_python_jsonable`

not sure if this is the best place to do this, opening for criticism / feedback - happy to work through clean up if im on the right track

seems like i'd need to add a little coverage for rust if this is not otherwise fundamentally flawed

related to https://github.com/pydantic/pydantic/issues/7424

---

ope I totally missed https://github.com/pydantic/pydantic-core/pull/1637 lol, happy to close and consolidate there if desirable