### PR TITLE
Add support for extra keys validation for model fields

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -3013,6 +3013,7 @@ class ModelFieldsSchema(TypedDict, total=False):
     computed_fields: list[ComputedField]
     strict: bool
     extras_schema: CoreSchema
+    extras_keys_schema: CoreSchema
     extra_behavior: ExtraBehavior
     from_attributes: bool
     ref: str
@@ -3027,6 +3028,7 @@ def model_fields_schema(
     computed_fields: list[ComputedField] | None = None,
     strict: bool | None = None,
     extras_schema: CoreSchema | None = None,
+    extras_keys_schema: CoreSchema | None = None,
     extra_behavior: ExtraBehavior | None = None,
     from_attributes: bool | None = None,
     ref: str | None = None,
@@ -3034,7 +3036,7 @@ def model_fields_schema(
     serialization: SerSchema | None = None,
 ) -> ModelFieldsSchema:
     """
-    Returns a schema that matches a typed dict, e.g.:
+    Returns a schema that matches the fields of a Pydantic model, e.g.:
 
     ```py
     from pydantic_core import SchemaValidator, core_schema
@@ -3048,15 +3050,16 @@ def model_fields_schema(
     ```
 
     Args:
-        fields: The fields to use for the typed dict
+        fields: The fields of the model
         model_name: The name of the model, used for error messages, defaults to "Model"
         computed_fields: Computed fields to use when serializing the model, only applies when directly inside a model
-        strict: Whether the typed dict is strict
-        extras_schema: The extra validator to use for the typed dict
+        strict: Whether the model is strict
+        extras_schema: The schema to use when validating extra input data
+        extras_keys_schema: The schema to use when validating the keys of extra input data
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
-        extra_behavior: The extra behavior to use for the typed dict
-        from_attributes: Whether the typed dict should be populated from attributes
+        extra_behavior: The extra behavior to use for the model fields
+        from_attributes: Whether the model fields should be populated from attributes
         serialization: Custom serialization schema
     """
     return _dict_not_none(
@@ -3066,6 +3069,7 @@ def model_fields_schema(
         computed_fields=computed_fields,
         strict=strict,
         extras_schema=extras_schema,
+        extras_keys_schema=extras_keys_schema,
         extra_behavior=extra_behavior,
         from_attributes=from_attributes,
         ref=ref,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Part of https://github.com/pydantic/pydantic/issues/9400.

This is only implemented for model fields but this could be done for dataclass/typed dict as well. I only went with models for now as it is the only data type where extra validation can be customized through `__pydantic_extra__`.

This also only implements validation support. Extra values can have serialization customized but I don't think we should also allow serialization customization for extra keys as we don't have such a concept for "normal" field names.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
