### PR TITLE
Revert `by_alias` default value change for `to_json()` and `to_jsonable_python()`

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -392,7 +392,10 @@ def to_json(
     indent: int | None = None,
     include: _IncEx | None = None,
     exclude: _IncEx | None = None,
-    by_alias: bool | None = None,
+    # Note: In Pydantic 2.11, the default value of `by_alias` on `SchemaSerializer` was changed from `True` to `None`,
+    # to be consistent with the Pydantic "dump" methods. However, the default of `True` was kept here for
+    # backwards compatibility. In Pydantic V3, `by_alias` is expected to default to `True` everywhere:
+    by_alias: bool = True,
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
@@ -468,7 +471,10 @@ def to_jsonable_python(
     *,
     include: _IncEx | None = None,
     exclude: _IncEx | None = None,
-    by_alias: bool | None = None,
+    # Note: In Pydantic 2.11, the default value of `by_alias` on `SchemaSerializer` was changed from `True` to `None`,
+    # to be consistent with the Pydantic "dump" methods. However, the default of `True` was kept here for
+    # backwards compatibility. In Pydantic V3, `by_alias` is expected to default to `True` everywhere:
+    by_alias: bool = True,
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -239,7 +239,7 @@ impl SchemaSerializer {
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = None,
+#[pyo3(signature = (value, *, indent = None, include = None, exclude = None, by_alias = true,
     exclude_none = false, round_trip = false, timedelta_mode = "iso8601", bytes_mode = "utf8",
     inf_nan_mode = "constants", serialize_unknown = false, fallback = None, serialize_as_any = false,
     context = None))]
@@ -249,7 +249,7 @@ pub fn to_json(
     indent: Option<usize>,
     include: Option<&Bound<'_, PyAny>>,
     exclude: Option<&Bound<'_, PyAny>>,
-    by_alias: Option<bool>,
+    by_alias: bool,
     exclude_none: bool,
     round_trip: bool,
     timedelta_mode: &str,
@@ -265,7 +265,7 @@ pub fn to_json(
     let extra = state.extra(
         py,
         &SerMode::Json,
-        by_alias,
+        Some(by_alias),
         exclude_none,
         round_trip,
         serialize_unknown,
@@ -282,7 +282,7 @@ pub fn to_json(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (value, *, include = None, exclude = None, by_alias = None, exclude_none = false, round_trip = false,
+#[pyo3(signature = (value, *, include = None, exclude = None, by_alias = true, exclude_none = false, round_trip = false,
     timedelta_mode = "iso8601", bytes_mode = "utf8", inf_nan_mode = "constants", serialize_unknown = false, fallback = None,
     serialize_as_any = false, context = None))]
 pub fn to_jsonable_python(
@@ -290,7 +290,7 @@ pub fn to_jsonable_python(
     value: &Bound<'_, PyAny>,
     include: Option<&Bound<'_, PyAny>>,
     exclude: Option<&Bound<'_, PyAny>>,
-    by_alias: Option<bool>,
+    by_alias: bool,
     exclude_none: bool,
     round_trip: bool,
     timedelta_mode: &str,
@@ -306,7 +306,7 @@ pub fn to_jsonable_python(
     let extra = state.extra(
         py,
         &SerMode::Json,
-        by_alias,
+        Some(by_alias),
         exclude_none,
         round_trip,
         serialize_unknown,


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/11577.

Regression in https://github.com/pydantic/pydantic-core/pull/1640.

`to_json()` and `to_jsonable_python()` are probably much more commonly used than the `SchemaSerializer` dump methods and as such, we should preserve existing behavior.

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
