### PR TITLE
Coerce `'timedelta'` schema constraints

### DIFF
--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -9,7 +9,6 @@ use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::{EitherDate, Input};
 
-use crate::tools::SchemaDict;
 use crate::validators::datetime::{NowConstraint, NowOp};
 
 use super::Exactness;
@@ -177,7 +176,7 @@ impl DateConstraints {
 }
 
 fn convert_pydate(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyResult<Option<Date>> {
-    match schema.get_as::<Bound<'_, PyAny>>(key)? {
+    match schema.get_item(key)? {
         Some(value) => match value.validate_date(false) {
             Ok(v) => Ok(Some(v.into_inner().as_raw()?)),
             Err(_) => Err(PyValueError::new_err(format!(

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -210,7 +210,7 @@ impl DateTimeConstraints {
 }
 
 fn py_datetime_as_datetime(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyResult<Option<DateTime>> {
-    match schema.get_as::<Bound<'_, PyAny>>(key)? {
+    match schema.get_item(key)? {
         Some(value) => match value.validate_datetime(false, MicrosecondsPrecisionOverflowBehavior::Truncate) {
             Ok(v) => Ok(Some(v.into_inner().as_raw()?)),
             Err(_) => Err(PyValueError::new_err(format!(

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -1,7 +1,7 @@
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::sync::GILOnceCell;
-use pyo3::types::{IntoPyDict, PyDict, PyString, PyTuple, PyType};
+use pyo3::types::{IntoPyDict, PyDict, PyTuple, PyType};
 use pyo3::{prelude::*, PyTypeInfo};
 
 use crate::build_tools::{is_strict, schema_or_config_same};
@@ -29,7 +29,7 @@ pub fn get_decimal_type(py: Python) -> &Bound<'_, PyType> {
 }
 
 fn validate_as_decimal(py: Python, schema: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<Py<PyAny>>> {
-    match schema.get_as::<Bound<'_, PyAny>>(&PyString::new(py, key))? {
+    match schema.get_item(key)? {
         Some(value) => match value.validate_decimal(false, py) {
             Ok(v) => Ok(Some(v.into_inner().unbind())),
             Err(_) => Err(PyValueError::new_err(format!(

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -2,18 +2,17 @@ use num_bigint::BigInt;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, Int};
-use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-fn validate_as_int(py: Python, schema: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<Int>> {
-    match schema.get_as::<Bound<'_, PyAny>>(&PyString::new(py, key))? {
+fn validate_as_int(schema: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<Int>> {
+    match schema.get_item(key)? {
         Some(value) => match value.validate_int(false) {
             Ok(v) => match v.into_inner().as_int() {
                 Ok(v) => Ok(Some(v)),
@@ -90,14 +89,13 @@ pub struct ConstrainedIntValidator {
 
 impl ConstrainedIntValidator {
     fn build(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<CombinedValidator> {
-        let py = schema.py();
         Ok(Self {
             strict: is_strict(schema, config)?,
-            multiple_of: validate_as_int(py, schema, "multiple_of")?,
-            le: validate_as_int(py, schema, "le")?,
-            lt: validate_as_int(py, schema, "lt")?,
-            ge: validate_as_int(py, schema, "ge")?,
-            gt: validate_as_int(py, schema, "gt")?,
+            multiple_of: validate_as_int(schema, "multiple_of")?,
+            le: validate_as_int(schema, "le")?,
+            lt: validate_as_int(schema, "lt")?,
+            ge: validate_as_int(schema, "ge")?,
+            gt: validate_as_int(schema, "gt")?,
         }
         .into())
     }

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -17,9 +17,15 @@ from ..conftest import Err, PyAndJson
     'constraint',
     ['le', 'lt', 'ge', 'gt'],
 )
-def test_constraints_schema_validation(constraint: str) -> None:
+def test_constraints_schema_validation_error(constraint: str) -> None:
     with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a date instance"):
         SchemaValidator(cs.date_schema(**{constraint: 'bad_value'}))
+
+
+def test_constraints_schema_validation() -> None:
+    val = SchemaValidator(cs.date_schema(gt='2020-01-01'))
+    with pytest.raises(ValidationError):
+        val.validate_python('2019-01-01')
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -18,9 +18,15 @@ from ..conftest import Err, PyAndJson
     'constraint',
     ['le', 'lt', 'ge', 'gt'],
 )
-def test_constraints_schema_validation(constraint: str) -> None:
+def test_constraints_schema_validation_error(constraint: str) -> None:
     with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a datetime instance"):
         SchemaValidator(cs.datetime_schema(**{constraint: 'bad_value'}))
+
+
+def test_constraints_schema_validation() -> None:
+    val = SchemaValidator(cs.datetime_schema(gt='2020-01-01T00:00:00'))
+    with pytest.raises(ValidationError):
+        val.validate_python('2019-01-01T00:00:00')
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_decimal.py
+++ b/tests/validators/test_decimal.py
@@ -25,9 +25,15 @@ class DecimalSubclass(Decimal):
     'constraint',
     ['multiple_of', 'le', 'lt', 'ge', 'gt'],
 )
-def test_constraints_schema_validation(constraint: str) -> None:
+def test_constraints_schema_validation_error(constraint: str) -> None:
     with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a Decimal instance"):
         SchemaValidator(cs.decimal_schema(**{constraint: 'bad_value'}))
+
+
+def test_constraints_schema_validation() -> None:
+    val = SchemaValidator(cs.decimal_schema(gt='1'))
+    with pytest.raises(ValidationError):
+        val.validate_python('0')
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -18,9 +18,15 @@ i64_max = 9_223_372_036_854_775_807
     'constraint',
     ['multiple_of', 'le', 'lt', 'ge', 'gt'],
 )
-def test_constraints_schema_validation(constraint: str) -> None:
+def test_constraints_schema_validation_error(constraint: str) -> None:
     with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to an integer"):
         SchemaValidator(cs.int_schema(**{constraint: 'bad_value'}))
+
+
+def test_constraints_schema_validation() -> None:
+    val = SchemaValidator(cs.int_schema(gt='1'))
+    with pytest.raises(ValidationError):
+        val.validate_python('0')
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_timedelta.py
+++ b/tests/validators/test_timedelta.py
@@ -16,6 +16,21 @@ except ImportError:
 
 
 @pytest.mark.parametrize(
+    'constraint',
+    ['le', 'lt', 'ge', 'gt'],
+)
+def test_constraints_schema_validation_error(constraint: str) -> None:
+    with pytest.raises(SchemaError, match=f"'{constraint}' must be coercible to a timedelta instance"):
+        SchemaValidator(core_schema.timedelta_schema(**{constraint: 'bad_value'}))
+
+
+def test_constraints_schema_validation() -> None:
+    val = SchemaValidator(core_schema.timedelta_schema(gt=3))
+    with pytest.raises(ValidationError):
+        val.validate_python(1)
+
+
+@pytest.mark.parametrize(
     'input_value,expected',
     [
         (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Follow up on https://github.com/pydantic/pydantic-core/pull/1661.

Fixes https://github.com/pydantic/pydantic/issues/11655.

(Also simplifies existing functions using `get_item()` and add more tests).

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
