### PR TITLE
fix clippy lints for Rust 1.86

### DIFF
--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -147,7 +147,7 @@ impl Location {
             Self::Empty => {
                 *self = Self::new_some(loc_item);
             }
-        };
+        }
     }
 }
 

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -10,6 +10,7 @@ use speedate::MicrosecondsPrecisionOverflowBehavior;
 use speedate::{Date, DateTime, Duration, ParseError, Time, TimeConfig};
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
+use std::fmt::Write;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -59,7 +60,7 @@ impl<'py> EitherDate<'py> {
                         },
                         input,
                     ));
-                };
+                }
                 let py_date = PyDate::new(py, date.year.into(), date.month, date.day)?;
                 Ok(py_date.into())
             }
@@ -296,7 +297,7 @@ impl<'py> EitherDateTime<'py> {
                         },
                         input,
                     ));
-                };
+                }
                 let py_dt = PyDateTime::new(
                     py,
                     dt.date.year.into(),
@@ -590,7 +591,7 @@ impl TzInfo {
         );
 
         if seconds != 0 {
-            result.push_str(&format!(":{:02}", seconds.abs()));
+            write!(result, ":{:02}", seconds.abs()).expect("writing to string should never fail");
         }
 
         result

--- a/src/input/shared.rs
+++ b/src/input/shared.rs
@@ -181,7 +181,7 @@ fn strip_leading_zeros(s: &str) -> Option<&str> {
         Some((_, c)) if ('1'..='9').contains(&c) || c == '-' => return Some(s),
         // anything else is invalid, we return None
         _ => return None,
-    };
+    }
     for (i, c) in char_iter {
         match c {
             // continue on more leading zeros or if we get an underscore we continue - we're "within the number"

--- a/src/serializers/errors.rs
+++ b/src/serializers/errors.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::Write;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -154,7 +155,7 @@ impl PydanticSerializationUnexpectedValue {
             if !message.is_empty() {
                 message.push_str(": ");
             }
-            message.push_str(&format!("Expected `{field_type}`"));
+            write!(message, "Expected `{field_type}`").expect("writing to string should never fail");
             if self.input_value.is_some() {
                 message.push_str(" - serialized value may not be as expected");
             }
@@ -170,7 +171,8 @@ impl PydanticSerializationUnexpectedValue {
 
             let value_str = truncate_safe_repr(bound_input, None);
 
-            message.push_str(&format!(" [input_value={value_str}, input_type={input_type}]"));
+            write!(message, " [input_value={value_str}, input_type={input_type}]")
+                .expect("writing to string should never fail");
         }
 
         if message.is_empty() {

--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -115,10 +115,7 @@ impl TypeSerializer for GeneratorSerializer {
     ) -> Result<S::Ok, S::Error> {
         match value.downcast::<PyIterator>() {
             Ok(py_iter) => {
-                let len = match value.len() {
-                    Ok(len) => Some(len),
-                    Err(_) => None,
-                };
+                let len = value.len().ok();
                 let mut seq = serializer.serialize_seq(len)?;
                 let item_serializer = self.item_serializer.as_ref();
 

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -243,10 +243,10 @@ impl TupleSerializer {
                         serializer: &CombinedSerializer::Any(AnySerializer),
                     }) {
                         return Ok(Err(e));
-                    };
+                    }
                 }
             }
-        };
+        }
         Ok(Ok(()))
     }
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -392,7 +392,7 @@ impl PyMultiHostUrl {
                     multi_url.push_str(&single_host.to_string());
                     if index != hosts.len() - 1 {
                         multi_url.push(',');
-                    };
+                    }
                 }
                 multi_url
             } else if host.is_some() {
@@ -456,7 +456,7 @@ impl fmt::Display for UrlHostParts {
             (None, Some(password)) => write!(f, ":{password}@")?,
             (Some(username), Some(password)) => write!(f, "{username}:{password}@")?,
             (None, None) => {}
-        };
+        }
         if let Some(host) = &self.host {
             write!(f, "{host}")?;
         }

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -280,7 +280,7 @@ impl Validator for ArgumentsValidator {
                             input,
                             index,
                         ));
-                    };
+                    }
                 }
             }
         }

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -190,9 +190,9 @@ impl Validator for DataclassArgsValidator {
                     // We could try to "fix" this in the future if desired.
                     Err(ValError::LineErrors(line_errors)) => errors.extend(line_errors),
                     Err(err) => return Err(err),
-                };
+                }
                 continue;
-            };
+            }
 
             let mut pos_value = None;
             if let Some(args) = args.args() {
@@ -265,7 +265,7 @@ impl Validator for DataclassArgsValidator {
                                 &field.name,
                             ));
                         }
-                        Err(ValError::Omit) => continue,
+                        Err(ValError::Omit) => {}
                         Err(ValError::LineErrors(line_errors)) => {
                             for err in line_errors {
                                 // Note: this will always use the field name even if there is an alias

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -194,7 +194,7 @@ impl Validator for DecimalValidator {
                             }
                         }
                     }
-                };
+                }
             }
         }
 

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -158,7 +158,7 @@ impl<T: Debug> LiteralLookup<T> {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));
             }
-        };
+        }
         if let Some(expected_py_values) = &self.expected_py_values {
             let py_input = get_py_input()?;
             for (k, id) in expected_py_values {
@@ -166,7 +166,7 @@ impl<T: Debug> LiteralLookup<T> {
                     return Ok(Some((input, &self.values[*id])));
                 }
             }
-        };
+        }
 
         // this one must be last to avoid conflicts with the other lookups, think of this
         // almost as a lax fallback
@@ -179,7 +179,7 @@ impl<T: Debug> LiteralLookup<T> {
                 let id: usize = v.extract().unwrap();
                 return Ok(Some((input, &self.values[id])));
             }
-        };
+        }
         Ok(None)
     }
 

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -228,7 +228,7 @@ impl Validator for ModelFieldsValidator {
                             &field.name,
                         ));
                     }
-                    Err(ValError::Omit) => continue,
+                    Err(ValError::Omit) => {}
                     Err(ValError::LineErrors(line_errors)) => {
                         for err in line_errors {
                             // Note: this will always use the field name even if there is an alias
@@ -334,7 +334,7 @@ impl Validator for ModelFieldsValidator {
                                 } else {
                                     model_extra_dict.set_item(&py_key, value.to_object(self.py)?)?;
                                     self.fields_set_vec.push(py_key.into());
-                                };
+                                }
                             }
                         }
                     }
@@ -368,7 +368,7 @@ impl Validator for ModelFieldsValidator {
             // from attributes, set it now so __pydantic_extra__ is always a dict if extra=allow
             if matches!(self.extra_behavior, ExtraBehavior::Allow) && model_extra_dict_op.is_none() {
                 model_extra_dict_op = Some(PyDict::new(py));
-            };
+            }
 
             Ok((model_dict, model_extra_dict_op, fields_set).into_py_any(py)?)
         }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -252,7 +252,7 @@ impl Validator for TypedDictValidator {
                             ));
                         }
                     }
-                    Err(ValError::Omit) => continue,
+                    Err(ValError::Omit) => {}
                     Err(ValError::LineErrors(line_errors)) => {
                         for err in line_errors {
                             // Note: this will always use the field name even if there is an alias
@@ -347,7 +347,7 @@ impl Validator for TypedDictValidator {
                                     }
                                 } else {
                                     self.output_dict.set_item(py_key, value.to_object(self.py)?)?;
-                                };
+                                }
                             }
                         }
                     }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -193,7 +193,7 @@ impl UnionValidator {
             match validator.validate(py, input, state) {
                 Err(ValError::LineErrors(lines)) => errors.push(validator, label.as_deref(), lines),
                 otherwise => return otherwise,
-            };
+            }
         }
 
         Err(errors.into_val_error(input))

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -392,7 +392,7 @@ fn parse_multihost_url<'py>(
                 '\t' | '\n' | '\r' => (),
                 c if c <= &' ' => (),
                 _ => break,
-            };
+            }
             chars.next();
         } else {
             break;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -215,7 +215,7 @@ impl UuidValidator {
                     input,
                 ));
             }
-        };
+        }
         Ok(uuid)
     }
 


### PR DESCRIPTION
## Change Summary

Fix lints for Rust 1.86

NB use of the `write!(string, ...)` macro instead of `string.push_str(&format!(...))` is recommended by clippy because it's more efficient (avoids an intermediate allocation in the `format!()` call), and should be infallible just like `push_str` but we have to handle the results because other possible targets for `write!()` (like IO streams) might fail.

Because it should never fail, I chose to just `.expect()` these.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
