### PR TITLE
Allow JSON `BigInt` to validate against `float` schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "idna",
  "jiter",
  "num-bigint",
+ "num-traits",
  "pyo3",
  "pyo3-build-config",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ url = "2.5.4"
 idna = "1.0.3"
 base64 = "0.22.1"
 num-bigint = "0.4.6"
+num-traits = "0.2.19"
 uuid = "1.16.0"
 jiter = { version = "0.9.0", features = ["python"] }
 hex = "0.4.3"

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use jiter::{JsonArray, JsonObject, JsonValue};
+use num_traits::cast::ToPrimitive;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
 use speedate::MicrosecondsPrecisionOverflowBehavior;
@@ -173,6 +174,9 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         match self {
             JsonValue::Float(f) => Ok(ValidationMatch::exact(EitherFloat::F64(*f))),
             JsonValue::Int(i) => Ok(ValidationMatch::strict(EitherFloat::F64(*i as f64))),
+            JsonValue::BigInt(b) => Ok(ValidationMatch::strict(EitherFloat::F64(
+                b.to_f64().expect("BigInt should always return some value"),
+            ))),
             JsonValue::Bool(b) if !strict => Ok(ValidationMatch::lax(EitherFloat::F64(if *b { 1.0 } else { 0.0 }))),
             JsonValue::Str(str) if !strict => str_as_float(self, str).map(ValidationMatch::lax),
             _ => Err(ValError::new(ErrorTypeDefaults::FloatType, self)),

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -11,6 +11,7 @@ from pydantic_core import core_schema as cs
 
 from ..conftest import Err, PyAndJson, plain_repr
 
+i64_max = 9_223_372_036_854_775_807
 f64_max = 1.7976931348623157e308
 
 
@@ -20,6 +21,7 @@ f64_max = 1.7976931348623157e308
         (0, 0),
         (1, 1),
         (42, 42),
+        (i64_max + 1, i64_max + 1),
         ('42', 42),
         ('  42.1  ', 42.1),
         ('42.123', 42.123),

--- a/tests/validators/test_float.py
+++ b/tests/validators/test_float.py
@@ -1,5 +1,6 @@
 import math
 import re
+import sys
 from decimal import Decimal
 from typing import Any
 
@@ -11,8 +12,8 @@ from pydantic_core import core_schema as cs
 
 from ..conftest import Err, PyAndJson, plain_repr
 
-i64_max = 9_223_372_036_854_775_807
-f64_max = 1.7976931348623157e308
+i64_max = (2**63) - 1
+f64_max = sys.float_info.max
 
 
 @pytest.mark.parametrize(
@@ -22,6 +23,7 @@ f64_max = 1.7976931348623157e308
         (1, 1),
         (42, 42),
         (i64_max + 1, i64_max + 1),
+        (f64_max, f64_max),
         ('42', 42),
         ('  42.1  ', 42.1),
         ('42.123', 42.123),

--- a/tests/validators/test_int.py
+++ b/tests/validators/test_int.py
@@ -11,7 +11,7 @@ from pydantic_core import core_schema as cs
 
 from ..conftest import Err, PyAndJson, plain_repr
 
-i64_max = 9_223_372_036_854_775_807
+i64_max = (2**63) - 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/10944.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
