### PR TITLE
Make `ValidationInfo` generic for `context`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ classifiers = [
     'Operating System :: MacOS',
     'Typing :: Typed',
 ]
-dependencies = ['typing-extensions>=4.6.0,!=4.7.0']
+dependencies = [
+    'typing-extensions>=4.12.0',
+]
 dynamic = ['description', 'license', 'readme', 'version']
 
 [project.urls]

--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Callable, Literal, Union
 
-from typing_extensions import deprecated
+from typing_extensions import TypeVar, deprecated
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
@@ -163,13 +163,16 @@ class FieldSerializationInfo(SerializationInfo, Protocol):
     def field_name(self) -> str: ...
 
 
-class ValidationInfo(Protocol):
+ContextT = TypeVar('ContextT', covariant=True, default='Any | None')
+
+
+class ValidationInfo(Protocol[ContextT]):
     """
     Argument passed to validation functions.
     """
 
     @property
-    def context(self) -> Any | None:
+    def context(self) -> ContextT:
         """Current validation context."""
         ...
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version == '3.13.*' and implementation_name == 'cpython'",
@@ -635,7 +636,7 @@ wasm = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions", specifier = ">=4.6.0,!=4.7.0" }]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.12.0" }]
 
 [package.metadata.requires-dev]
 all = [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11485.

Example usage:

```python
@dataclass
class MyContext:
    some_value: int

def validator(value: int, info: ValidationInfo[MyContext]):
    ...
```

One one hand, it isn't strictly correct to give the validator implementation a way to "enforce" (at least from a static type checking perspective) a context type, as ultimately this can be unsafe if provide a different context value in the validate functions. On the other hand, it is convenient if you are guaranteed that the correct context will be used during validation.

If users don't control how validation is performed, they can still leave `ValidationInfo` unparameterized (and have the context type fallback to `Any | None`) and have safety guards on the `info.context` value.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
