### PR TITLE
Mark constructor parameters of exceptions as positional-only

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -714,22 +714,16 @@ class PydanticCustomError(ValueError):
                 raise PydanticCustomError('custom_value_error', 'Value must be greater than {value}', {'value': 10, 'extra_context': 'extra_data'})
             return v
         ```
+
+    Arguments:
+        error_type: The error type.
+        message_template: The message template.
+        context: The data to inject into the message template.
     """
 
     def __init__(
-        self, error_type: LiteralString, message_template: LiteralString, context: dict[str, Any] | None = None
-    ) -> None:
-        """Initializes the `PydanticCustomError`.
-
-        Arguments:
-            error_type: The error type.
-            message_template: The message template.
-            context: The data to inject into the message template.
-        """
-
-    def __new__(
-        cls, error_type: LiteralString, message_template: LiteralString, context: dict[str, Any] | None = None
-    ) -> Self: ...
+        self, error_type: LiteralString, message_template: LiteralString, context: dict[str, Any] | None = None, /
+    ) -> None: ...
     @property
     def context(self) -> dict[str, Any] | None:
         """Values which are required to render the error message, and could hence be useful in passing error data forward."""
@@ -757,20 +751,16 @@ class PydanticKnownError(ValueError):
 
         def custom_validator(v) -> None:
             if v <= 10:
-                raise PydanticKnownError(error_type='greater_than', context={'gt': 10})
+                raise PydanticKnownError('greater_than', {'gt': 10})
             return v
         ```
+
+    Arguments:
+        error_type: The error type.
+        context: The data to inject into the message template.
     """
 
-    def __init__(self, error_type: ErrorType, context: dict[str, Any] | None = None) -> None:
-        """Initializes the `PydanticKnownError`.
-
-        Arguments:
-            error_type: The error type.
-            context: The data to inject into the message template.
-        """
-
-    def __new__(cls, error_type: ErrorType, context: dict[str, Any] | None = None) -> Self: ...
+    def __init__(self, error_type: ErrorType, context: dict[str, Any] | None = None, /) -> None: ...
     @property
     def context(self) -> dict[str, Any] | None:
         """Values which are required to render the error message, and could hence be useful in passing error data forward."""
@@ -870,16 +860,12 @@ class PydanticSerializationError(ValueError):
     """An error raised when an issue occurs during serialization.
 
     In custom serializers, this error can be used to indicate that serialization has failed.
+
+    Arguments:
+        message: The message associated with the error.
     """
 
-    def __init__(self, message: str) -> None:
-        """Initializes the `PydanticSerializationError`.
-
-        Arguments:
-            message: The message associated with the error.
-        """
-
-    def __new__(cls, message: str) -> Self: ...
+    def __init__(self, message: str, /) -> None: ...
 
 @final
 class PydanticSerializationUnexpectedValue(ValueError):
@@ -918,16 +904,12 @@ class PydanticSerializationUnexpectedValue(ValueError):
 
     This is often used internally in `pydantic-core` when unexpected types are encountered during serialization,
     but it can also be used by users in custom serializers, as seen above.
+
+    Arguments:
+        message: The message associated with the unexpected value.
     """
 
-    def __init__(self, message: str) -> None:
-        """Initializes the `PydanticSerializationUnexpectedValue`.
-
-        Arguments:
-            message: The message associated with the unexpected value.
-        """
-
-    def __new__(cls, message: str | None = None) -> Self: ...
+    def __init__(self, message: str, /) -> None: ...
 
 @final
 class ArgsKwargs:

--- a/src/errors/value_exception.rs
+++ b/src/errors/value_exception.rs
@@ -65,7 +65,7 @@ pub struct PydanticCustomError {
 #[pymethods]
 impl PydanticCustomError {
     #[new]
-    #[pyo3(signature = (error_type, message_template, context = None))]
+    #[pyo3(signature = (error_type, message_template, context = None, /))]
     pub fn py_new(error_type: String, message_template: String, context: Option<Bound<'_, PyDict>>) -> Self {
         Self {
             error_type,
@@ -144,7 +144,7 @@ pub struct PydanticKnownError {
 #[pymethods]
 impl PydanticKnownError {
     #[new]
-    #[pyo3(signature = (error_type, context=None))]
+    #[pyo3(signature = (error_type, context=None, /))]
     pub fn py_new(py: Python, error_type: &str, context: Option<Bound<'_, PyDict>>) -> PyResult<Self> {
         let error_type = ErrorType::new(py, error_type, context)?;
         Ok(Self { error_type })

--- a/src/serializers/errors.rs
+++ b/src/serializers/errors.rs
@@ -81,6 +81,7 @@ impl PydanticSerializationError {
 #[pymethods]
 impl PydanticSerializationError {
     #[new]
+    #[pyo3(signature = (message, /))]
     fn py_new(message: String) -> Self {
         Self { message }
     }
@@ -139,7 +140,7 @@ impl PydanticSerializationUnexpectedValue {
 #[pymethods]
 impl PydanticSerializationUnexpectedValue {
     #[new]
-    #[pyo3(signature = (message=None, field_type=None, input_value=None))]
+    #[pyo3(signature = (message=None, field_type=None, input_value=None, /))]
     fn py_new(message: Option<String>, field_type: Option<String>, input_value: Option<PyObject>) -> Self {
         Self {
             message,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

As these exceptions also inherit from `ValueError`, providing keyword arguments fails when the `super().__new__` call is performed (`ValueError` only takes positional arguments). Generally, I also tend to enforce pos-only args for exceptions, otherwise the default repr doesn't show the argument:

```python
class MyExc(Exception):
    def __init__(self, message: str) -> None:
        self.message = message

str(MyExc('test'))
# 'test'
str(MyExc(message='test'))
# ''
```

Also clean up the stub file a bit: avoid duplicating `__new__` and `__init__` (at runtime, `__new__` is the one actually defined but it doesn't play well with mkdocstrings), unify docstrings in classes.

Fixes https://github.com/pydantic/pydantic/issues/10604.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
