### PR TITLE
fix: submodel fields with wrap validator affect smart union selection

### DIFF
--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -380,7 +380,9 @@ impl Validator for FunctionWrapValidator {
         let handler = Bound::new(py, handler)?;
         #[allow(clippy::used_underscore_items)]
         let result = self._validate(handler.as_any(), py, input, state);
-        state.exactness = handler.borrow_mut().validator.exactness;
+        let handler = handler.borrow();
+        state.exactness = handler.validator.exactness;
+        state.fields_set_count = handler.validator.fields_set_count;
         result
     }
 

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -225,6 +225,7 @@ pub struct InternalValidator {
     self_instance: Option<PyObject>,
     recursion_guard: RecursionState,
     pub(crate) exactness: Option<Exactness>,
+    pub(crate) fields_set_count: Option<usize>,
     validation_mode: InputType,
     hide_input_in_errors: bool,
     validation_error_cause: bool,
@@ -256,6 +257,7 @@ impl InternalValidator {
             self_instance: extra.self_instance.map(|d| d.clone().unbind()),
             recursion_guard: state.recursion_guard.clone(),
             exactness: state.exactness,
+            fields_set_count: state.fields_set_count,
             validation_mode: extra.input_type,
             hide_input_in_errors,
             validation_error_cause,
@@ -284,7 +286,8 @@ impl InternalValidator {
             by_name: None,
         };
         let mut state = ValidationState::new(extra, &mut self.recursion_guard, false.into());
-        state.exactness = self.exactness;
+        // state.exactness = self.exactness;
+        // state.fields_set_count = self.fields_set_count;
         let result = self
             .validator
             .validate_assignment(py, model, field_name, field_value, &mut state)
@@ -299,7 +302,8 @@ impl InternalValidator {
                     self.validation_error_cause,
                 )
             });
-        self.exactness = state.exactness;
+        // self.exactness = state.exactness;
+        // self.fields_set_count = state.fields_set_count;
         result
     }
 
@@ -323,6 +327,7 @@ impl InternalValidator {
         };
         let mut state = ValidationState::new(extra, &mut self.recursion_guard, false.into());
         state.exactness = self.exactness;
+        state.fields_set_count = self.fields_set_count;
         let result = self.validator.validate(py, input, &mut state).map_err(|e| {
             ValidationError::from_val_error(
                 py,
@@ -335,6 +340,7 @@ impl InternalValidator {
             )
         });
         self.exactness = state.exactness;
+        self.fields_set_count = state.fields_set_count;
         result
     }
 }

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -286,8 +286,7 @@ impl InternalValidator {
             by_name: None,
         };
         let mut state = ValidationState::new(extra, &mut self.recursion_guard, false.into());
-        // state.exactness = self.exactness;
-        // state.fields_set_count = self.fields_set_count;
+        state.exactness = self.exactness;
         let result = self
             .validator
             .validate_assignment(py, model, field_name, field_value, &mut state)
@@ -302,8 +301,7 @@ impl InternalValidator {
                     self.validation_error_cause,
                 )
             });
-        // self.exactness = state.exactness;
-        // self.fields_set_count = state.fields_set_count;
+        self.exactness = state.exactness;
         result
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

- Keep `fields_set_count` state when validating submodels

<!-- Please give a short summary of the changes. -->

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/11752

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt