### PR TITLE
Remove unecessary required fields count when `exclude_none` is set

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -162,11 +162,6 @@ impl GeneralFieldsSerializer {
             let key_str = key_str(&key)?;
             let op_field = self.fields.get(key_str);
             if extra.exclude_none && value.is_none() {
-                if let Some(field) = op_field {
-                    if field.required {
-                        used_req_fields += 1;
-                    }
-                }
                 continue;
             }
             let field_extra = Extra {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

If you look some lines below, the `used_req_fields` is only used to error if `exclude_none` (or some other settings) is _not_ set, which makes this unnecessary.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
