### PR TITLE
ci: fix coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - run: |
           source <(cargo llvm-cov show-env --export-prefix)
-          cargo llvm --codecov --output-path=codecov.json
+          cargo llvm-cov --codecov --output-path=codecov.json
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,22 +14,15 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: install rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-
-      - id: cache-rust
-        name: cache rust
-        uses: Swatinem/rust-cache@v2
-
-      - run: cargo install rustfilt coverage-prepare
-        if: steps.cache-rust.outputs.cache-hit != 'true'
-
-      - run: rustup component add llvm-tools-preview
+      # rust-nightly used for `#[coverage(off)]`
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: install uv
         uses: astral-sh/setup-uv@v6
@@ -39,7 +32,10 @@ jobs:
 
       - run: rustc --version --verbose
 
-      - run: make build-dev
+      - run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov clean --workspace --profraw-only
+          make build-dev
         env:
           RUST_BACKTRACE: 1
           RUSTFLAGS: '-C instrument-coverage'
@@ -51,9 +47,13 @@ jobs:
       - run: ls -lha
       - run: uv run coverage xml
 
-      - run: coverage-prepare lcov python/pydantic_core/*.so
+      - run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm --codecov --output-path=codecov.json
 
       - uses: codecov/codecov-action@v5
+        with:
+          files: codecov.json
 
   # See https://github.com/PyO3/pyo3/discussions/2781
   # tests intermittently segfault with pypy and cpython 3.7 when using `coverage run ...`, hence separate job


### PR DESCRIPTION
## Change Summary

Fixes the coverage job in CI, currently failing because it attempts to run on the now-deprecated ubuntu-20.04.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
