### PR TITLE
drop serde-json `preserve_order` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,12 +84,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,12 +108,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -270,16 +258,6 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -604,7 +582,6 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,15 @@ rust-version = "1.75"
 [dependencies]
 # TODO it would be very nice to remove the "py-clone" feature as it can panic,
 # but needs a bit of work to make sure it's not used in the codebase
-pyo3 = { version = "0.24", features = ["generate-import-lib", "num-bigint", "py-clone"] }
+pyo3 = { version = "0.24", features = [
+    "generate-import-lib",
+    "num-bigint",
+    "py-clone",
+] }
 regex = "1.11.1"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
-serde_json = {version = "1.0.140", features = ["arbitrary_precision", "preserve_order"]}
+serde_json = { version = "1.0.140", features = ["arbitrary_precision"] }
 enum_dispatch = "0.3.13"
 serde = { version = "1.0.219", features = ["derive"] }
 speedate = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,7 @@ rust-version = "1.75"
 [dependencies]
 # TODO it would be very nice to remove the "py-clone" feature as it can panic,
 # but needs a bit of work to make sure it's not used in the codebase
-pyo3 = { version = "0.24", features = [
-    "generate-import-lib",
-    "num-bigint",
-    "py-clone",
-] }
+pyo3 = { version = "0.24", features = ["generate-import-lib", "num-bigint", "py-clone"] }
 regex = "1.11.1"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"


### PR DESCRIPTION
## Change Summary

Observed in https://github.com/pydantic/pydantic/issues/7424#issuecomment-2480525714, we currently use `preserve_order` feature of `serde-json`. This preserves ordering of values during parse.

This should not be needed since we moved to `jiter` for parsing.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
