### PR TITLE
update to `speedate` 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,10 +608,11 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "speedate"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5e7adf4e07e7de39a64d77962ca14a09165e592d42d0c9f9acadb679f4f937"
+checksum = "bc823f2eb39713ef0d286058af264ce0d8ddcf62b8a78a0aec02cd0105576d87"
 dependencies = [
+ "lexical-parse-float",
  "strum",
  "strum_macros",
 ]
@@ -630,18 +631,18 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ rust-version = "1.75"
 # but needs a bit of work to make sure it's not used in the codebase
 pyo3 = { version = "0.25", features = ["generate-import-lib", "num-bigint", "py-clone"] }
 regex = "1.11.1"
-strum = { version = "0.26.3", features = ["derive"] }
-strum_macros = "0.26.4"
+strum = { version = "0.27", features = ["derive"] }
+strum_macros = "0.27"
 serde_json = { version = "1.0.140", features = ["arbitrary_precision"] }
 enum_dispatch = "0.3.13"
 serde = { version = "1.0.219", features = ["derive"] }
-speedate = "0.15.0"
+speedate = "0.16.0"
 smallvec = "1.15.0"
 ahash = "0.8.12"
 url = "2.5.4"

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -6,8 +6,9 @@ use pyo3::pyclass::CompareOp;
 use pyo3::types::PyTuple;
 use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
 use pyo3::IntoPyObjectExt;
-use speedate::MicrosecondsPrecisionOverflowBehavior;
-use speedate::{Date, DateTime, Duration, ParseError, Time, TimeConfig};
+use speedate::{
+    Date, DateTime, DateTimeConfig, Duration, MicrosecondsPrecisionOverflowBehavior, ParseError, Time, TimeConfig,
+};
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::Write;
@@ -366,9 +367,12 @@ pub fn bytes_as_datetime<'py>(
 ) -> ValResult<EitherDateTime<'py>> {
     match DateTime::parse_bytes_with_config(
         bytes,
-        &TimeConfig {
-            microseconds_precision_overflow_behavior: microseconds_overflow_behavior,
-            unix_timestamp_offset: Some(0),
+        &DateTimeConfig {
+            time_config: TimeConfig {
+                microseconds_precision_overflow_behavior: microseconds_overflow_behavior,
+                unix_timestamp_offset: Some(0),
+            },
+            ..Default::default()
         },
     ) {
         Ok(dt) => Ok(dt.into()),
@@ -390,8 +394,11 @@ pub fn int_as_datetime<'py>(
     match DateTime::from_timestamp_with_config(
         timestamp,
         timestamp_microseconds,
-        &TimeConfig {
-            unix_timestamp_offset: Some(0),
+        &DateTimeConfig {
+            time_config: TimeConfig {
+                unix_timestamp_offset: Some(0),
+                ..Default::default()
+            },
             ..Default::default()
         },
     ) {

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -32,7 +32,7 @@ pub(crate) fn extract_microseconds_precision(
     schema_or_config_same(schema, config, intern!(schema.py(), "microseconds_precision"))?
         .map_or(
             Ok(speedate::MicrosecondsPrecisionOverflowBehavior::Truncate),
-            |v: Bound<'_, PyString>| speedate::MicrosecondsPrecisionOverflowBehavior::try_from(v.to_str().unwrap()),
+            |v: Bound<'_, PyString>| v.to_str().unwrap().parse(),
         )
         .map_err(|_| {
             py_schema_error_type!("Invalid `microseconds_precision`, must be one of \"truncate\" or \"error\"")


### PR DESCRIPTION
## Change Summary

Updates to speedate 0.16.

Does not add support for the new timestamp unit setting (cc @ollz272, I understood you have a branch for that).

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
