### PR TITLE
Match return type of SerializationInfo.mode() to mode of model_dump()

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -145,7 +145,7 @@ class SerializationInfo(Protocol[ContextT]):
         ...
 
     @property
-    def mode(self) -> Literal['python', 'json']:
+    def mode(self) -> Literal['python', 'json'] | str:
         """The serialization mode set during serialization."""
         ...
 


### PR DESCRIPTION
## Change Summary

Pydantic in some place use `Literal['python', 'json'] | str`  for the serialization mode, using a more restrictive type can break stuff (e.g. typing validation). So this commit adapt the return type to make it matches with other pydantic valid serialization mode.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
