### PR TITLE
feat: make TzInfo instantiable without any arguments

### DIFF
--- a/python/pydantic_core/_pydantic_core.pyi
+++ b/python/pydantic_core/_pydantic_core.pyi
@@ -993,7 +993,14 @@ def list_all_errors() -> list[ErrorTypeInfo]:
 class TzInfo(datetime.tzinfo):
     """An `pydantic-core` implementation of the abstract [`datetime.tzinfo`][] class."""
 
-    # def __new__(cls, seconds: float) -> Self: ...
+    def __init__(self, seconds: float = 0.0) -> None:
+        """Initializes the `TzInfo`.
+
+        Arguments:
+            seconds: The offset from UTC in seconds. Defaults to 0.0 (UTC).
+        """
+
+    def __new__(cls, seconds: float = 0.0) -> Self: ...
 
     # Docstrings for attributes sourced from the abstract base class, [`datetime.tzinfo`](https://docs.python.org/3/library/datetime.html#datetime.tzinfo).
 

--- a/src/input/datetime.rs
+++ b/src/input/datetime.rs
@@ -643,6 +643,7 @@ pub struct TzInfo {
 #[pymethods]
 impl TzInfo {
     #[new]
+    #[pyo3(signature = (seconds = 0.0))]
     fn py_new(seconds: f32) -> PyResult<Self> {
         Self::try_from(seconds.trunc() as i32)
     }

--- a/tests/test_tzinfo.py
+++ b/tests/test_tzinfo.py
@@ -213,6 +213,22 @@ class TestTzInfo(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     TzInfo(delta.total_seconds())
 
+    def test_no_args_constructor(self):
+        # Test that TzInfo can be constructed without arguments
+        tz = TzInfo()
+        self.assertEqual(tz.utcoffset(None), timedelta(0))
+        self.assertEqual(str(tz), 'UTC')
+
+    def test_pickle(self):
+        # Test that TzInfo can be pickled and unpickled
+        for tz in self.ACDT, self.EST, self.UTC:
+            for pickler, unpickler, proto in pickle_choices:
+                with self.subTest(tz=tz, proto=proto):
+                    pickled = pickler.dumps(tz, proto)
+                    unpickled = unpickler.loads(pickled)
+                    self.assertEqual(tz, unpickled)
+                    self.assertEqual(tz.utcoffset(None), unpickled.utcoffset(None))
+
 
 def test_tzinfo_could_be_reused():
     class Model:


### PR DESCRIPTION
## Change Summary
Allow TzInfo() to be instantiated without arguments, defaulting to UTC (0 seconds offset). This provides convenience for creating UTC timezones and satisfies the Python datetime documentation requirement for tzinfo subclasses to support no-argument construction.

ℹ pickle already worked via pyo3 automatic `__reduce__()` implementation, but this improves API usability and ensures full compliance with datetime.tzinfo requirements.

## Related issue number
fix #1745

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt