### PR TITLE
chore: Correct grammar in docstring

### DIFF
--- a/python/pydantic_core/__init__.py
+++ b/python/pydantic_core/__init__.py
@@ -117,7 +117,7 @@ class ErrorTypeInfo(_TypedDict):
     """
 
     type: ErrorType
-    """The type of error that occurred, this should a "slug" identifier that changes rarely or never."""
+    """The type of error that occurred, this should be a "slug" identifier that changes rarely or never."""
     message_template_python: str
     """String template to render a human readable error message from using context, when the input is Python."""
     example_message_python: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Correct grammar in docstring for `ErrorTypeInfo.type` by changing 'this should a "slug"' to 'this should *be* a "slug"', as is the case in the docstring for `InitErrorDetails.type`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] ~Unit tests for the changes exist~ N/A
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
