### PR TITLE
Add GraalPy 3.12 to CI, build GraalPy wheels for more platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,7 @@ jobs:
           - os: linux
             manylinux: auto
             target: aarch64
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11
           - os: linux
             manylinux: auto
             target: armv7
@@ -446,9 +447,10 @@ jobs:
           # arm pypy and older pythons which can't be run on the arm hardware for PGO
           - os: macos
             target: x86_64
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11
           - os: macos
             target: aarch64
-            interpreter: 3.9 pypy3.10 pypy3.11
+            interpreter: 3.9 pypy3.10 pypy3.11 graalpy3.11
 
           # windows;
           # x86_64 pypy builds are not PGO optimized
@@ -490,7 +492,6 @@ jobs:
           args: --release --out dist --interpreter ${{ matrix.interpreter || '3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11' }}
           rust-toolchain: stable
           docker-options: -e CI
-          before-script-linux: ${{ contains(matrix.interpreter, 'graalpy') && 'manylinux-interpreters ensure-all' || '' }}
 
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - 'pypy3.10'
           - 'pypy3.11'
           - 'graalpy-3.11'
+          - 'graalpy-3.12'
 
     runs-on: ubuntu-latest
 
@@ -409,7 +410,7 @@ jobs:
           - os: linux
             manylinux: auto
             target: aarch64
-            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11 graalpy3.12
           - os: linux
             manylinux: auto
             target: armv7
@@ -429,7 +430,7 @@ jobs:
           - os: linux
             manylinux: auto
             target: x86_64
-            interpreter: graalpy3.11
+            interpreter: graalpy3.11 graalpy3.12
 
           # musllinux
           - os: linux
@@ -447,10 +448,10 @@ jobs:
           # arm pypy and older pythons which can't be run on the arm hardware for PGO
           - os: macos
             target: x86_64
-            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.10 pypy3.11 graalpy3.11 graalpy3.12
           - os: macos
             target: aarch64
-            interpreter: 3.9 pypy3.10 pypy3.11 graalpy3.11
+            interpreter: 3.9 pypy3.10 pypy3.11 graalpy3.11 graalpy3.12
 
           # windows;
           # x86_64 pypy builds are not PGO optimized

--- a/uv.lock
+++ b/uv.lock
@@ -288,16 +288,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.124.2"
+version = "6.139.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/3b/3a7cf8973b0424c6af0b2b5fe30f89ab738616bad2a16aafcc49ff069ed4/hypothesis-6.124.2.tar.gz", hash = "sha256:c98823fc1323f23399e5f2251982fd1f38259f84cf627aaaea1b3f0a0d4d2b03", size = 419462, upload-time = "2025-01-21T18:45:00.461Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/8e/f408b1a6d9745bf02c3d56e0788c930add554eee6b88a39bba141e897ac4/hypothesis-6.139.2.tar.gz", hash = "sha256:2dc2ff36ea977a9cb7fb68f24a5dbf5d673b88a2e502212676eafe09b699f511", size = 466099, upload-time = "2025-09-18T03:29:15.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e1/80f1819e65a9a0b1b744b453cd26803764fc192cff8eaea202e76f6f5a65/hypothesis-6.124.2-py3-none-any.whl", hash = "sha256:fef7709a404929a9cd3e785f60a6e026089aab986e288b1fdced13091574d474", size = 482180, upload-time = "2025-01-21T18:44:55.288Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/81/4a85771072ae39064f114f23716e312771a42bfe3a089cba3da6697dd231/hypothesis-6.139.2-py3-none-any.whl", hash = "sha256:6f466780b7d1db074fb473af14e3111a5dd4fe36c47fcd776cd7c480ae0a02f2", size = 533752, upload-time = "2025-09-18T03:29:12.088Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add GraalPy 3.12 (GraalPy version 25.0) to CI test and wheel builds
- Build GraalPy wheels also for Linux aarch64 and Mac x86_64+aarch64
- Update hypothesis (needed for supporting GraalPy 3.12)

@davidhewitt, could you please review?