### PR TITLE
Add none required error on optional fields

### DIFF
--- a/tests/benchmarks/test_complete_benchmark.py
+++ b/tests/benchmarks/test_complete_benchmark.py
@@ -84,7 +84,7 @@ def test_complete_invalid():
     lax_validator = SchemaValidator(lax_schema)
     with pytest.raises(ValidationError) as exc_info:
         lax_validator.validate_python(input_data_wrong())
-    assert len(exc_info.value.errors(include_url=False)) == 739
+    assert len(exc_info.value.errors(include_url=False)) == 841
 
 
 @pytest.mark.benchmark(group='complete')

--- a/tests/validators/test_definitions_recursive.py
+++ b/tests/validators/test_definitions_recursive.py
@@ -326,7 +326,13 @@ def test_recursion_branch():
             'loc': ('branch',),
             'msg': 'Recursion error - cyclic reference detected',
             'input': {'name': 'recursive', 'branch': IsPartialDict(name='recursive')},
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': ('branch',),
+            'msg': 'Input should be None',
+            'input': {'name': 'recursive', 'branch': IsPartialDict(name='recursive')},
+        },
     ]
 
 
@@ -375,7 +381,13 @@ def test_recursion_branch_from_attributes():
             'loc': ('branch',),
             'msg': 'Recursion error - cyclic reference detected',
             'input': HasAttributes(name='root', branch=AnyThing()),
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': ('branch',),
+            'msg': 'Input should be None',
+            'input': HasAttributes(name='root', branch=AnyThing()),
+        },
     ]
 
 
@@ -476,9 +488,27 @@ def test_multiple_tuple_recursion(multiple_tuple_schema: SchemaValidator):
             'input': [1, IsList(length=2)],
         },
         {
+            'type': 'none_required',
+            'loc': ('f1', 1),
+            'msg': 'Input should be None',
+            'input': [1, IsList(length=2)],
+        },
+        {
             'type': 'recursion_loop',
             'loc': ('f2', 1),
             'msg': 'Recursion error - cyclic reference detected',
+            'input': [1, IsList(length=2)],
+        },
+        {
+            'type': 'none_required',
+            'loc': ('f2', 1),
+            'msg': 'Input should be None',
+            'input': [1, IsList(length=2)],
+        },
+        {
+            'type': 'none_required',
+            'loc': ('f2',),
+            'msg': 'Input should be None',
             'input': [1, IsList(length=2)],
         },
     ]
@@ -498,9 +528,27 @@ def test_multiple_tuple_recursion_once(multiple_tuple_schema: SchemaValidator):
             'input': [1, IsList(length=2)],
         },
         {
+            'type': 'none_required',
+            'loc': ('f1', 1),
+            'msg': 'Input should be None',
+            'input': [1, IsList(length=2)],
+        },
+        {
             'type': 'recursion_loop',
             'loc': ('f2', 1),
             'msg': 'Recursion error - cyclic reference detected',
+            'input': [1, IsList(length=2)],
+        },
+        {
+            'type': 'none_required',
+            'loc': ('f2', 1),
+            'msg': 'Input should be None',
+            'input': [1, IsList(length=2)],
+        },
+        {
+            'type': 'none_required',
+            'loc': ('f2',),
+            'msg': 'Input should be None',
             'input': [1, IsList(length=2)],
         },
     ]
@@ -539,7 +587,13 @@ def test_definition_wrap():
             'loc': (1,),
             'msg': 'Recursion error - cyclic reference detected',
             'input': IsList(positions={0: 1}, length=2),
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': (1,),
+            'msg': 'Input should be None',
+            'input': IsList(positions={0: 1}, length=2),
+        },
     ]
 
 
@@ -927,7 +981,19 @@ def test_cyclic_data() -> None:
             'loc': ('b', 'a'),
             'msg': 'Recursion error - cyclic reference detected',
             'input': cyclic_data,
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': ('b', 'a'),
+            'msg': 'Input should be None',
+            'input': cyclic_data,
+        },
+        {
+            'type': 'none_required',
+            'loc': ('b',),
+            'msg': 'Input should be None',
+            'input': cyclic_data['b'],
+        },
     ]
 
 
@@ -977,7 +1043,25 @@ def test_cyclic_data_threeway() -> None:
             'loc': ('b', 'c', 'a'),
             'msg': 'Recursion error - cyclic reference detected',
             'input': cyclic_data,
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': ('b', 'c', 'a'),
+            'msg': 'Input should be None',
+            'input': cyclic_data,
+        },
+        {
+            'type': 'none_required',
+            'loc': ('b', 'c'),
+            'msg': 'Input should be None',
+            'input': cyclic_data['b']['c'],
+        },
+        {
+            'type': 'none_required',
+            'loc': ('b',),
+            'msg': 'Input should be None',
+            'input': cyclic_data['b'],
+        },
     ]
 
 
@@ -1052,6 +1136,12 @@ def test_complex_recursive_type() -> None:
             'input': datetime.date(1992, 12, 11),
         },
         {
+            'type': 'none_required',
+            'loc': ('dict[str,...]', 'a'),
+            'msg': 'Input should be None',
+            'input': datetime.date(1992, 12, 11),
+        },
+        {
             'type': 'string_type',
             'loc': ('str',),
             'msg': 'Input should be a valid string',
@@ -1073,6 +1163,12 @@ def test_complex_recursive_type() -> None:
             'type': 'bool_type',
             'loc': ('bool',),
             'msg': 'Input should be a valid boolean',
+            'input': {'a': datetime.date(1992, 12, 11)},
+        },
+        {
+            'type': 'none_required',
+            'loc': (),
+            'msg': 'Input should be None',
             'input': {'a': datetime.date(1992, 12, 11)},
         },
     ]

--- a/tests/validators/test_nullable.py
+++ b/tests/validators/test_nullable.py
@@ -21,7 +21,13 @@ def test_nullable():
             'loc': (),
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
             'input': 'hello',
-        }
+        },
+        {
+            'type': 'none_required',
+            'loc': (),
+            'msg': 'Input should be None',
+            'input': 'hello',
+        },
     ]
 
 


### PR DESCRIPTION
## Change Summary

This changes the **nullable validator**. When the inner validation fails, it now adds a `NoneRequired` error-line.

The first commit updates the nullable validator, while follow-up commits update test data. These often become more verbose especially with recursive models. This is similar to what happens with union types when the validation fails, you get lots of error-lines.

I am not sure this is the 'correct' thing to do with optional types, but it's the simplest way I found to address [pydantic#8852](https://github.com/pydantic/pydantic/issues/8852).

### Example

The goal was to have this behavior on optional fields:

```python
from typing import Optional
from pydantic import BaseModel

class User(BaseModel):
    age: Optional[int] # or an explicit union, e.g. int | None

User(age="hello")
```

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for User
age
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='hello', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing
age
  Input should be None [type=none_required, input_value='hello', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/none_required
```

With this change, the errors one gets from an _optional type_ - i.e. a type where `None` is an accepted value - look like the errors one gets when working with _union types_.

For example, if we go `int | bool` instead of `int | None`: 

```python
class User(BaseModel):
    # age: Optional[int]  # or an explicit union, e.g. int | None
    age: bool | int

User(age="hello")
```

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for User
age.bool
  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='hello', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/bool_parsing
age.int
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='hello', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing
```

## Related issue number

- [pydantic/pydantic#8852](https://github.com/pydantic/pydantic/issues/8852)

## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
