### PR TITLE
fix `EitherString::as_cow` implementation

### DIFF
--- a/src/input/input_abstract.rs
+++ b/src/input/input_abstract.rs
@@ -85,7 +85,7 @@ pub trait Input<'py>: fmt::Debug {
 
     fn validate_dataclass_args<'a>(&'a self, dataclass_name: &str) -> ValResult<Self::Arguments<'a>>;
 
-    fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValMatch<EitherString<'_>>;
+    fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValMatch<EitherString<'_, 'py>>;
 
     fn validate_bytes<'a>(&'a self, strict: bool, mode: ValBytesMode) -> ValMatch<EitherBytes<'a, 'py>>;
 
@@ -103,7 +103,7 @@ pub trait Input<'py>: fmt::Debug {
 
     /// Extract a String from the input, only allowing exact
     /// matches for a String (no subclasses)
-    fn exact_str(&self) -> ValResult<EitherString<'_>> {
+    fn exact_str(&self) -> ValResult<EitherString<'_, 'py>> {
         self.validate_str(true, false).and_then(|val_match| {
             val_match
                 .require_exact()

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -107,7 +107,11 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValResult<ValidationMatch<EitherString<'_>>> {
+    fn validate_str(
+        &self,
+        strict: bool,
+        coerce_numbers_to_str: bool,
+    ) -> ValResult<ValidationMatch<EitherString<'_, 'py>>> {
         // Justification for `strict` instead of `exact` is that in JSON strings can also
         // represent other datatypes such as UUID and date more exactly, so string is a
         // converting input
@@ -163,7 +167,7 @@ impl<'py, 'data> Input<'py> for JsonValue<'data> {
         }
     }
 
-    fn exact_str(&self) -> ValResult<EitherString<'_>> {
+    fn exact_str(&self) -> ValResult<EitherString<'_, 'py>> {
         match self {
             JsonValue::Str(s) => Ok(s.as_ref().into()),
             _ => Err(ValError::new(ErrorTypeDefaults::StringType, self)),
@@ -414,7 +418,7 @@ impl<'py> Input<'py> for str {
         &self,
         _strict: bool,
         _coerce_numbers_to_str: bool,
-    ) -> ValResult<ValidationMatch<EitherString<'_>>> {
+    ) -> ValResult<ValidationMatch<EitherString<'_, 'py>>> {
         // Justification for `strict` instead of `exact` is that in JSON strings can also
         // represent other datatypes such as UUID and date more exactly, so string is a
         // converting input

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -163,7 +163,11 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
     }
 
-    fn validate_str(&self, strict: bool, coerce_numbers_to_str: bool) -> ValResult<ValidationMatch<EitherString<'_>>> {
+    fn validate_str(
+        &self,
+        strict: bool,
+        coerce_numbers_to_str: bool,
+    ) -> ValResult<ValidationMatch<EitherString<'_, 'py>>> {
         if let Ok(py_str) = self.downcast_exact::<PyString>() {
             return Ok(ValidationMatch::exact(py_str.clone().into()));
         } else if let Ok(py_str) = self.downcast::<PyString>() {
@@ -310,7 +314,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
     }
 
-    fn exact_str(&self) -> ValResult<EitherString<'_>> {
+    fn exact_str(&self) -> ValResult<EitherString<'_, 'py>> {
         if let Ok(py_str) = self.downcast_exact() {
             Ok(EitherString::Py(py_str.clone()))
         } else {

--- a/src/input/input_string.rs
+++ b/src/input/input_string.rs
@@ -105,7 +105,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
         &self,
         _strict: bool,
         _coerce_numbers_to_str: bool,
-    ) -> ValResult<ValidationMatch<EitherString<'_>>> {
+    ) -> ValResult<ValidationMatch<EitherString<'_, 'py>>> {
         match self {
             Self::String(s) => Ok(ValidationMatch::strict(s.clone().into())),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::StringType, self)),


### PR DESCRIPTION
## Change Summary

- Unnecessary `.clone()` in `EitherString::as_cow` could clone strings needlessly
- Split the lifetimes in `EitherString`, already done in `EitherBytes` and describes the possible data flow better

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
