### PR TITLE
Reuse basic validators and serializers

### DIFF
--- a/src/serializers/computed_fields.rs
+++ b/src/serializers/computed_fields.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
 use pyo3::{intern, PyTraverseError, PyVisit};
@@ -21,7 +23,7 @@ impl ComputedFields {
     pub fn new(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Option<Self>> {
         let py = schema.py();
         if let Some(computed_fields) = schema.get_as::<Bound<'_, PyList>>(intern!(py, "computed_fields"))? {
@@ -182,7 +184,7 @@ struct ComputedFieldToSerialize<'a, 'py> {
 struct ComputedField {
     property_name: String,
     property_name_py: Py<PyString>,
-    serializer: CombinedSerializer,
+    serializer: Arc<CombinedSerializer>,
     alias: String,
     alias_py: Py<PyString>,
     serialize_by_alias: Option<bool>,
@@ -192,7 +194,7 @@ impl ComputedField {
     pub fn new(
         schema: &Bound<'_, PyAny>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Self> {
         let py = schema.py();
         let schema: &Bound<'_, PyDict> = schema.downcast()?;

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
@@ -39,8 +40,8 @@ pub enum WarningsArg {
 #[pyclass(module = "pydantic_core._pydantic_core", frozen)]
 #[derive(Debug)]
 pub struct SchemaSerializer {
-    serializer: CombinedSerializer,
-    definitions: Definitions<CombinedSerializer>,
+    serializer: Arc<CombinedSerializer>,
+    definitions: Definitions<Arc<CombinedSerializer>>,
     expected_json_size: AtomicUsize,
     config: SerializationConfig,
     // References to the Python schema and config objects are saved to enable

--- a/src/serializers/prebuilt.rs
+++ b/src/serializers/prebuilt.rs
@@ -18,7 +18,10 @@ impl PrebuiltSerializer {
     pub fn try_get_from_schema(type_: &str, schema: &Bound<'_, PyDict>) -> PyResult<Option<CombinedSerializer>> {
         get_prebuilt(type_, schema, "__pydantic_serializer__", |py_any| {
             let schema_serializer = py_any.extract::<Py<SchemaSerializer>>()?;
-            if matches!(schema_serializer.get().serializer, CombinedSerializer::FunctionWrap(_)) {
+            if matches!(
+                schema_serializer.get().serializer.as_ref(),
+                CombinedSerializer::FunctionWrap(_)
+            ) {
                 return Ok(None);
             }
             Ok(Some(Self { schema_serializer }.into()))

--- a/src/serializers/type_serializers/any.rs
+++ b/src/serializers/type_serializers/any.rs
@@ -30,9 +30,9 @@ impl BuildSerializer for AnySerializer {
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Ok(Self {}.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(Self::get().clone())
     }
 }
 

--- a/src/serializers/type_serializers/complex.rs
+++ b/src/serializers/type_serializers/complex.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::types::{PyComplex, PyDict};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 
 use super::{infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, SerMode, TypeSerializer};
@@ -10,14 +12,16 @@ use super::{infer_serialize, infer_to_python, BuildSerializer, CombinedSerialize
 #[derive(Debug, Clone)]
 pub struct ComplexSerializer {}
 
+static COMPLEX_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(ComplexSerializer {}.into()));
+
 impl BuildSerializer for ComplexSerializer {
     const EXPECTED_TYPE: &'static str = "complex";
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Ok(Self {}.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(COMPLEX_SERIALIZER.clone())
     }
 }
 

--- a/src/serializers/type_serializers/datetime_etc.rs
+++ b/src/serializers/type_serializers/datetime_etc.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateTime, PyDict, PyTime};
@@ -101,10 +102,10 @@ macro_rules! build_temporal_serializer {
             fn build(
                 _schema: &Bound<'_, PyDict>,
                 config: Option<&Bound<'_, PyDict>>,
-                _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-            ) -> PyResult<CombinedSerializer> {
+                _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+            ) -> PyResult<Arc<CombinedSerializer>> {
                 let temporal_mode = TemporalMode::from_config(config)?;
-                Ok(Self { temporal_mode }.into())
+                Ok(Arc::new(Self { temporal_mode }.into()))
             }
         }
 

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, infer_to_python_known};
 use crate::serializers::ob_type::{IsType, ObType};
@@ -14,15 +16,17 @@ use super::{
 #[derive(Debug)]
 pub struct DecimalSerializer {}
 
+static DECIMAL_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(DecimalSerializer {}.into()));
+
 impl BuildSerializer for DecimalSerializer {
     const EXPECTED_TYPE: &'static str = "decimal";
 
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Ok(Self {}.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(DECIMAL_SERIALIZER.clone())
     }
 }
 

--- a/src/serializers/type_serializers/float.rs
+++ b/src/serializers/type_serializers/float.rs
@@ -2,9 +2,11 @@ use pyo3::types::PyDict;
 use pyo3::{intern, prelude::*, IntoPyObjectExt};
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use serde::Serializer;
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::config::InfNanMode;
 use crate::tools::SchemaDict;
@@ -21,13 +23,36 @@ pub struct FloatSerializer {
     inf_nan_mode: InfNanMode,
 }
 
+static FLOAT_SERIALIZER_NULL: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| {
+    Arc::new(CombinedSerializer::Float(FloatSerializer {
+        inf_nan_mode: InfNanMode::Null,
+    }))
+});
+
+static FLOAT_SERIALIZER_CONSTANTS: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| {
+    Arc::new(CombinedSerializer::Float(FloatSerializer {
+        inf_nan_mode: InfNanMode::Constants,
+    }))
+});
+
+static FLOAT_SERIALIZER_STRINGS: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| {
+    Arc::new(CombinedSerializer::Float(FloatSerializer {
+        inf_nan_mode: InfNanMode::Strings,
+    }))
+});
+
 impl FloatSerializer {
-    pub fn new(py: Python, config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+    pub fn get(py: Python, config: Option<&Bound<'_, PyDict>>) -> PyResult<&'static Arc<CombinedSerializer>> {
         let inf_nan_mode = config
             .and_then(|c| c.get_as(intern!(py, "ser_json_inf_nan")).transpose())
             .transpose()?
             .unwrap_or_default();
-        Ok(Self { inf_nan_mode })
+
+        match inf_nan_mode {
+            InfNanMode::Null => Ok(&FLOAT_SERIALIZER_NULL),
+            InfNanMode::Constants => Ok(&FLOAT_SERIALIZER_CONSTANTS),
+            InfNanMode::Strings => Ok(&FLOAT_SERIALIZER_STRINGS),
+        }
     }
 }
 
@@ -55,9 +80,9 @@ impl BuildSerializer for FloatSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Self::new(schema.py(), config).map(Into::into)
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Self::get(schema.py(), config).cloned()
     }
 }
 

--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -31,17 +31,17 @@ impl BuildSerializer for GeneratorSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
         let item_serializer = match schema.get_as(intern!(py, "items_schema"))? {
             Some(items_schema) => CombinedSerializer::build(&items_schema, config, definitions)?,
             None => AnySerializer::build(schema, config, definitions)?,
         };
-        Ok(Self {
-            item_serializer: Arc::new(item_serializer),
+        Ok(CombinedSerializer::Generator(Self {
+            item_serializer,
             filter: SchemaFilter::from_schema(schema)?,
-        }
+        })
         .into())
     }
 }

--- a/src/serializers/type_serializers/json_or_python.rs
+++ b/src/serializers/type_serializers/json_or_python.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -10,8 +11,8 @@ use crate::tools::SchemaDict;
 
 #[derive(Debug)]
 pub struct JsonOrPythonSerializer {
-    json: Box<CombinedSerializer>,
-    python: Box<CombinedSerializer>,
+    json: Arc<CombinedSerializer>,
+    python: Arc<CombinedSerializer>,
     name: String,
 }
 
@@ -21,8 +22,8 @@ impl BuildSerializer for JsonOrPythonSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
         let json_schema = schema.get_as_req(intern!(py, "json_schema"))?;
         let python_schema = schema.get_as_req(intern!(py, "python_schema"))?;
@@ -36,12 +37,7 @@ impl BuildSerializer for JsonOrPythonSerializer {
             json.get_name(),
             python.get_name(),
         );
-        Ok(Self {
-            json: Box::new(json),
-            python: Box::new(python),
-            name,
-        }
-        .into())
+        Ok(Arc::new(Self { json, python, name }.into()))
     }
 }
 

--- a/src/serializers/type_serializers/list.rs
+++ b/src/serializers/type_serializers/list.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -18,7 +19,7 @@ use super::{
 
 #[derive(Debug)]
 pub struct ListSerializer {
-    item_serializer: Box<CombinedSerializer>,
+    item_serializer: Arc<CombinedSerializer>,
     filter: SchemaFilter<usize>,
     name: String,
 }
@@ -29,20 +30,22 @@ impl BuildSerializer for ListSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
         let item_serializer = match schema.get_as(intern!(py, "items_schema"))? {
             Some(items_schema) => CombinedSerializer::build(&items_schema, config, definitions)?,
             None => AnySerializer::build(schema, config, definitions)?,
         };
         let name = format!("{}[{}]", Self::EXPECTED_TYPE, item_serializer.get_name());
-        Ok(Self {
-            item_serializer: Box::new(item_serializer),
-            filter: SchemaFilter::from_schema(schema)?,
-            name,
-        }
-        .into())
+        Ok(Arc::new(
+            Self {
+                item_serializer,
+                filter: SchemaFilter::from_schema(schema)?,
+                name,
+            }
+            .into(),
+        ))
     }
 }
 

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -31,8 +32,8 @@ impl BuildSerializer for LiteralSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let expected: Bound<'_, PyList> = schema.get_as_req(intern!(schema.py(), "expected"))?;
 
         if expected.is_empty() {
@@ -56,16 +57,18 @@ impl BuildSerializer for LiteralSerializer {
             }
         }
 
-        Ok(Self {
-            expected_int,
-            expected_str,
-            expected_py: match expected_py.is_empty() {
-                true => None,
-                false => Some(expected_py.into()),
-            },
-            name: format!("{}[{}]", Self::EXPECTED_TYPE, repr_args.join(",")),
-        }
-        .into())
+        Ok(Arc::new(
+            Self {
+                expected_int,
+                expected_str,
+                expected_py: match expected_py.is_empty() {
+                    true => None,
+                    false => Some(expected_py.into()),
+                },
+                name: format!("{}[{}]", Self::EXPECTED_TYPE, repr_args.join(",")),
+            }
+            .into(),
+        ))
     }
 }
 

--- a/src/serializers/type_serializers/nullable.rs
+++ b/src/serializers/type_serializers/nullable.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -11,7 +12,7 @@ use super::{infer_json_key_known, BuildSerializer, CombinedSerializer, Extra, Is
 
 #[derive(Debug)]
 pub struct NullableSerializer {
-    serializer: Box<CombinedSerializer>,
+    serializer: Arc<CombinedSerializer>,
 }
 
 impl BuildSerializer for NullableSerializer {
@@ -20,12 +21,12 @@ impl BuildSerializer for NullableSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let sub_schema = schema.get_as_req(intern!(schema.py(), "schema"))?;
-        Ok(Self {
-            serializer: Box::new(CombinedSerializer::build(&sub_schema, config, definitions)?),
-        }
+        Ok(CombinedSerializer::Nullable(Self {
+            serializer: CombinedSerializer::build(&sub_schema, config, definitions)?,
+        })
         .into())
     }
 }

--- a/src/serializers/type_serializers/other.rs
+++ b/src/serializers/type_serializers/other.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -17,8 +19,8 @@ impl BuildSerializer for ChainBuilder {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let last_schema = schema
             .get_as_req::<Bound<'_, PyList>>(intern!(schema.py(), "steps"))?
             .iter()
@@ -37,8 +39,8 @@ impl BuildSerializer for CustomErrorBuilder {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let sub_schema = schema.get_as_req(intern!(schema.py(), "schema"))?;
         CombinedSerializer::build(&sub_schema, config, definitions)
     }
@@ -52,8 +54,8 @@ impl BuildSerializer for CallBuilder {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let return_schema = schema.get_as(intern!(schema.py(), "return_schema"))?;
         match return_schema {
             Some(return_schema) => CombinedSerializer::build(&return_schema, config, definitions),
@@ -70,8 +72,8 @@ impl BuildSerializer for LaxOrStrictBuilder {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let strict_schema = schema.get_as_req(intern!(schema.py(), "strict_schema"))?;
         CombinedSerializer::build(&strict_schema, config, definitions)
     }
@@ -85,8 +87,8 @@ impl BuildSerializer for ArgumentsBuilder {
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         py_schema_err!("`arguments` validators require a custom serializer")
     }
 }
@@ -101,8 +103,8 @@ macro_rules! any_build_serializer {
             fn build(
                 schema: &Bound<'_, PyDict>,
                 config: Option<&Bound<'_, PyDict>>,
-                definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-            ) -> PyResult<CombinedSerializer> {
+                definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+            ) -> PyResult<Arc<CombinedSerializer>> {
                 AnySerializer::build(schema, config, definitions)
             }
         }

--- a/src/serializers/type_serializers/string.rs
+++ b/src/serializers/type_serializers/string.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::types::{PyDict, PyString};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 
 use super::{
@@ -13,9 +15,11 @@ use super::{
 #[derive(Debug)]
 pub struct StrSerializer;
 
+static STR_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(StrSerializer.into()));
+
 impl StrSerializer {
-    pub fn new() -> Self {
-        Self {}
+    pub fn get() -> &'static Arc<CombinedSerializer> {
+        &STR_SERIALIZER
     }
 }
 
@@ -25,9 +29,9 @@ impl BuildSerializer for StrSerializer {
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Ok(Self::new().into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(Self::get().clone())
     }
 }
 

--- a/src/serializers/type_serializers/timedelta.rs
+++ b/src/serializers/type_serializers/timedelta.rs
@@ -2,6 +2,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use crate::definitions::DefinitionsBuilder;
 use crate::input::EitherTimedelta;
@@ -23,8 +24,8 @@ impl BuildSerializer for TimeDeltaSerializer {
     fn build(
         _schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let temporal_set = config
             .and_then(|cfg| cfg.contains(intern!(cfg.py(), "ser_json_temporal")).ok())
             .unwrap_or(false);
@@ -35,7 +36,7 @@ impl BuildSerializer for TimeDeltaSerializer {
             td_mode.into()
         };
 
-        Ok(Self { temporal_mode }.into())
+        Ok(Arc::new(Self { temporal_mode }.into()))
     }
 }
 

--- a/src/serializers/type_serializers/tuple.rs
+++ b/src/serializers/type_serializers/tuple.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 use std::borrow::Cow;
 use std::iter;
+use std::sync::Arc;
 
 use serde::ser::SerializeSeq;
 
@@ -19,7 +20,7 @@ use super::{
 
 #[derive(Debug)]
 pub struct TupleSerializer {
-    serializers: Vec<CombinedSerializer>,
+    serializers: Vec<Arc<CombinedSerializer>>,
     variadic_item_index: Option<usize>,
     filter: SchemaFilter<usize>,
     name: String,
@@ -31,28 +32,28 @@ impl BuildSerializer for TupleSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
         let items: Bound<'_, PyList> = schema.get_as_req(intern!(py, "items_schema"))?;
-        let serializers: Vec<CombinedSerializer> = items
+        let serializers: Vec<Arc<CombinedSerializer>> = items
             .iter()
             .map(|item| CombinedSerializer::build(item.downcast()?, config, definitions))
             .collect::<PyResult<_>>()?;
 
-        let mut serializer_names = serializers.iter().map(TypeSerializer::get_name).collect::<Vec<_>>();
+        let mut serializer_names = serializers.iter().map(|v| v.get_name()).collect::<Vec<_>>();
         let variadic_item_index: Option<usize> = schema.get_as(intern!(py, "variadic_item_index"))?;
         if let Some(variadic_item_index) = variadic_item_index {
             serializer_names.insert(variadic_item_index + 1, "...");
         }
         let name = format!("tuple[{}]", serializer_names.join(", "));
 
-        Ok(Self {
+        Ok(CombinedSerializer::Tuple(Self {
             serializers,
             variadic_item_index,
             filter: SchemaFilter::from_schema(schema)?,
             name,
-        }
+        })
         .into())
     }
 }

--- a/src/serializers/type_serializers/typed_dict.rs
+++ b/src/serializers/type_serializers/typed_dict.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
@@ -20,8 +22,8 @@ impl BuildSerializer for TypedDictBuilder {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
 
         let total =
@@ -82,6 +84,8 @@ impl BuildSerializer for TypedDictBuilder {
 
         let computed_fields = ComputedFields::new(schema, config, definitions)?;
 
-        Ok(GeneralFieldsSerializer::new(fields, fields_mode, extra_serializer, computed_fields).into())
+        Ok(Arc::new(
+            GeneralFieldsSerializer::new(fields, fields_mode, extra_serializer, computed_fields).into(),
+        ))
     }
 }

--- a/src/serializers/type_serializers/url.rs
+++ b/src/serializers/type_serializers/url.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
-
 use crate::url::{PyMultiHostUrl, PyUrl};
 
 use super::{
@@ -24,9 +25,11 @@ macro_rules! build_serializer {
             fn build(
                 _schema: &Bound<'_, PyDict>,
                 _config: Option<&Bound<'_, PyDict>>,
-                _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-            ) -> PyResult<CombinedSerializer> {
-                Ok(Self {}.into())
+                _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+            ) -> PyResult<Arc<CombinedSerializer>> {
+                static SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
+                    LazyLock::new(|| Arc::new(CombinedSerializer::from($struct_name {})));
+                Ok(SERIALIZER.clone())
             }
         }
 

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -1,9 +1,11 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::types::PyDict;
 use pyo3::{intern, prelude::*, IntoPyObjectExt};
 use uuid::Uuid;
 
+use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 
 use super::{
@@ -21,6 +23,9 @@ pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
 #[derive(Debug)]
 pub struct UuidSerializer;
 
+static UUID_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
+    LazyLock::new(|| Arc::new(CombinedSerializer::from(UuidSerializer {})));
+
 impl_py_gc_traverse!(UuidSerializer {});
 
 impl BuildSerializer for UuidSerializer {
@@ -29,9 +34,9 @@ impl BuildSerializer for UuidSerializer {
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
-        Ok(Self {}.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(UUID_SERIALIZER.clone())
     }
 }
 

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -13,7 +14,7 @@ use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
 #[derive(Debug)]
 pub struct WithDefaultSerializer {
     default: DefaultType,
-    serializer: Box<CombinedSerializer>,
+    serializer: Arc<CombinedSerializer>,
 }
 
 impl BuildSerializer for WithDefaultSerializer {
@@ -22,15 +23,15 @@ impl BuildSerializer for WithDefaultSerializer {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedSerializer>,
-    ) -> PyResult<CombinedSerializer> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
         let default = DefaultType::new(schema)?;
 
         let sub_schema = schema.get_as_req(intern!(py, "schema"))?;
-        let serializer = Box::new(CombinedSerializer::build(&sub_schema, config, definitions)?);
+        let serializer = CombinedSerializer::build(&sub_schema, config, definitions)?;
 
-        Ok(Self { default, serializer }.into())
+        Ok(Arc::new(Self { default, serializer }.into()))
     }
 }
 

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::errors::ValResult;
 use crate::input::Input;
+use crate::{build_tools::LazyLock, errors::ValResult};
 
 use super::{
     validation_state::Exactness, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator,
@@ -12,15 +14,17 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct AnyValidator;
 
+static ANY_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(AnyValidator.into()));
+
 impl BuildValidator for AnyValidator {
     const EXPECTED_TYPE: &'static str = "any";
 
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(ANY_VALIDATOR.clone())
     }
 }
 

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use pyo3::types::PyDict;
 use pyo3::{prelude::*, IntoPyObjectExt};
 
-use crate::build_tools::is_strict;
+use crate::build_tools::{is_strict, LazyLock};
 use crate::errors::ValResult;
 use crate::input::Input;
 
@@ -12,18 +14,25 @@ pub struct BoolValidator {
     strict: bool,
 }
 
+static STRICT_BOOL_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
+    LazyLock::new(|| Arc::new(BoolValidator { strict: true }.into()));
+
+static LAX_BOOL_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
+    LazyLock::new(|| Arc::new(BoolValidator { strict: false }.into()));
+
 impl BuildValidator for BoolValidator {
     const EXPECTED_TYPE: &'static str = "bool";
 
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self {
-            strict: is_strict(schema, config)?,
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        if is_strict(schema, config)? {
+            Ok(STRICT_BOOL_VALIDATOR.clone())
+        } else {
+            Ok(LAX_BOOL_VALIDATOR.clone())
         }
-        .into())
     }
 }
 

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -15,8 +17,8 @@ use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuild
 #[derive(Debug)]
 pub struct CallValidator {
     function: Py<PyAny>,
-    arguments_validator: Box<CombinedValidator>,
-    return_validator: Option<Box<CombinedValidator>>,
+    arguments_validator: Arc<CombinedValidator>,
+    return_validator: Option<Arc<CombinedValidator>>,
     name: String,
 }
 
@@ -26,16 +28,16 @@ impl BuildValidator for CallValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
 
         let arguments_schema = schema.get_as_req(intern!(py, "arguments_schema"))?;
-        let arguments_validator = Box::new(build_validator(&arguments_schema, config, definitions)?);
+        let arguments_validator = build_validator(&arguments_schema, config, definitions)?;
 
         let return_schema = schema.get_item(intern!(py, "return_schema"))?;
         let return_validator = match return_schema {
-            Some(return_schema) => Some(Box::new(build_validator(&return_schema, config, definitions)?)),
+            Some(return_schema) => Some(build_validator(&return_schema, config, definitions)?),
             None => None,
         };
         let function: Bound<'_, PyAny> = schema.get_as_req(intern!(py, "function"))?;
@@ -58,12 +60,12 @@ impl BuildValidator for CallValidator {
         let function_name = function_name.bind(py);
         let name = format!("{}[{function_name}]", Self::EXPECTED_TYPE);
 
-        Ok(Self {
+        Ok(CombinedValidator::FunctionCall(Self {
             function: function.unbind(),
             arguments_validator,
             return_validator,
             name,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::LazyLock;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
@@ -10,15 +13,17 @@ use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationSta
 #[derive(Debug, Clone)]
 pub struct CallableValidator;
 
+static CALLABLE_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(CallableValidator.into()));
+
 impl BuildValidator for CallableValidator {
     const EXPECTED_TYPE: &'static str = "callable";
 
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(CALLABLE_VALIDATOR.clone())
     }
 }
 

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::PyKeyError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -28,7 +30,7 @@ struct Field {
     init: bool,
     init_only: bool,
     lookup_key_collection: LookupKeyCollection,
-    validator: CombinedValidator,
+    validator: Arc<CombinedValidator>,
     frozen: bool,
 }
 
@@ -40,7 +42,7 @@ pub struct DataclassArgsValidator {
     dataclass_name: String,
     validator_name: String,
     extra_behavior: ExtraBehavior,
-    extras_validator: Option<Box<CombinedValidator>>,
+    extras_validator: Option<Arc<CombinedValidator>>,
     loc_by_alias: bool,
     validate_by_alias: Option<bool>,
     validate_by_name: Option<bool>,
@@ -52,14 +54,14 @@ impl BuildValidator for DataclassArgsValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
 
         let extra_behavior = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
 
         let extras_validator = match (schema.get_item(intern!(py, "extras_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(Box::new(build_validator(&v, config, definitions)?)),
+            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
             (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
             (_, _) => None,
         };
@@ -82,7 +84,7 @@ impl BuildValidator for DataclassArgsValidator {
                 Err(err) => return py_schema_err!("Field '{}':\n  {}", name, err),
             };
 
-            if let CombinedValidator::WithDefault(ref v) = validator {
+            if let CombinedValidator::WithDefault(v) = validator.as_ref() {
                 if v.omit_on_error() {
                     return py_schema_err!("Field `{}`: omit_on_error cannot be used with arguments", name);
                 }
@@ -116,7 +118,7 @@ impl BuildValidator for DataclassArgsValidator {
         let dataclass_name: String = schema.get_as_req(intern!(py, "dataclass_name"))?;
         let validator_name = format!("dataclass-args[{dataclass_name}]");
 
-        Ok(Self {
+        Ok(CombinedValidator::DataclassArgs(Self {
             fields,
             positional_count,
             init_only_count,
@@ -127,7 +129,7 @@ impl BuildValidator for DataclassArgsValidator {
             loc_by_alias: config.get_as(intern!(py, "loc_by_alias"))?.unwrap_or(true),
             validate_by_alias: config.get_as(intern!(py, "validate_by_alias"))?,
             validate_by_name: config.get_as(intern!(py, "validate_by_name"))?,
-        }
+        })
         .into())
     }
 }
@@ -452,7 +454,7 @@ impl Validator for DataclassArgsValidator {
 #[derive(Debug)]
 pub struct DataclassValidator {
     strict: bool,
-    validator: Box<CombinedValidator>,
+    validator: Arc<CombinedValidator>,
     class: Py<PyType>,
     generic_origin: Option<Py<PyType>>,
     fields: Vec<Py<PyString>>,
@@ -469,8 +471,8 @@ impl BuildValidator for DataclassValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
 
         // dataclasses ignore the parent config and always use the config from this dataclasses
@@ -494,9 +496,9 @@ impl BuildValidator for DataclassValidator {
 
         let fields = schema.get_as_req(intern!(py, "fields"))?;
 
-        Ok(Self {
+        Ok(CombinedValidator::Dataclass(Self {
             strict: is_strict(schema, config)?,
-            validator: Box::new(validator),
+            validator,
             class: class.into(),
             generic_origin: generic_origin.map(std::convert::Into::into),
             fields,
@@ -510,7 +512,7 @@ impl BuildValidator for DataclassValidator {
             name,
             frozen: schema.get_as(intern!(py, "frozen"))?.unwrap_or(false),
             slots: schema.get_as(intern!(py, "slots"))?.unwrap_or(false),
-        }
+        })
         .into())
     }
 }

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -27,13 +29,13 @@ impl BuildValidator for DateValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(CombinedValidator::Date(Self {
             strict: is_strict(schema, config)?,
             constraints: DateConstraints::from_py(schema)?,
             val_temporal_unit: TemporalUnitMode::from_config(config)?,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -5,6 +5,7 @@ use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyDict, PyString};
 use speedate::{DateTime, MicrosecondsPrecisionOverflowBehavior, Time};
 use std::cmp::Ordering;
+use std::sync::Arc;
 use strum::EnumMessage;
 
 use crate::build_tools::{is_strict, py_schema_error_type};
@@ -46,14 +47,14 @@ impl BuildValidator for DateTimeValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(CombinedValidator::Datetime(Self {
             strict: is_strict(schema, config)?,
             constraints: DateTimeConstraints::from_py(schema)?,
             microseconds_precision: extract_microseconds_precision(schema, config)?,
             val_temporal_unit: TemporalUnitMode::from_config(config)?,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::sync::PyOnceLock;
@@ -63,8 +65,8 @@ impl BuildValidator for DecimalValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
 
         let allow_inf_nan = schema_or_config_same(schema, config, intern!(py, "allow_inf_nan"))?.unwrap_or(false);
@@ -76,7 +78,7 @@ impl BuildValidator for DecimalValidator {
             ));
         }
 
-        Ok(Self {
+        Ok(CombinedValidator::Decimal(Self {
             strict: is_strict(schema, config)?,
             allow_inf_nan,
             check_digits: decimal_places.is_some() || max_digits.is_some(),
@@ -87,7 +89,7 @@ impl BuildValidator for DecimalValidator {
             ge: validate_as_decimal(py, schema, intern!(py, "ge"))?,
             gt: validate_as_decimal(py, schema, intern!(py, "gt"))?,
             max_digits,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -1,5 +1,6 @@
 // Validator for Enums, so named because "enum" is a reserved keyword in Rust.
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
@@ -24,8 +25,8 @@ impl BuildValidator for BuildEnumValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let members: Bound<PyList> = schema.get_as_req(intern!(schema.py(), "members"))?;
         if members.is_empty() {
             return py_schema_err!("`members` should have length > 0");
@@ -65,11 +66,11 @@ impl BuildValidator for BuildEnumValidator {
 
         let sub_type: Option<String> = schema.get_as(intern!(py, "sub_type"))?;
         match sub_type.as_deref() {
-            Some("int") => Ok(CombinedValidator::IntEnum(build!(IntEnumValidator, "int-enum"))),
-            Some("str") => Ok(CombinedValidator::StrEnum(build!(StrEnumValidator, "str-enum"))),
-            Some("float") => Ok(CombinedValidator::FloatEnum(build!(FloatEnumValidator, "float-enum"))),
+            Some("int") => Ok(CombinedValidator::IntEnum(build!(IntEnumValidator, "int-enum")).into()),
+            Some("str") => Ok(CombinedValidator::StrEnum(build!(StrEnumValidator, "str-enum")).into()),
+            Some("float") => Ok(CombinedValidator::FloatEnum(build!(FloatEnumValidator, "float-enum")).into()),
             Some(_) => py_schema_err!("`sub_type` must be one of: 'int', 'str', 'float' or None"),
-            None => Ok(CombinedValidator::PlainEnum(build!(PlainEnumValidator, "enum"))),
+            None => Ok(CombinedValidator::PlainEnum(build!(PlainEnumValidator, "enum")).into()),
         }
     }
 }

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::types::{PyDict, PyFrozenSet};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
@@ -13,7 +15,7 @@ use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
 #[derive(Debug)]
 pub struct FrozenSetValidator {
     strict: bool,
-    item_validator: Box<CombinedValidator>,
+    item_validator: Arc<CombinedValidator>,
     min_length: Option<usize>,
     max_length: Option<usize>,
     name: String,

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -33,9 +33,9 @@ impl BuildValidator for GeneratorValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        let item_validator = get_items_schema(schema, config, definitions)?.map(Arc::new);
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        let item_validator = get_items_schema(schema, config, definitions)?;
         let name = match item_validator {
             Some(ref v) => format!("{}[{}]", Self::EXPECTED_TYPE, v.get_name()),
             None => format!("{}[any]", Self::EXPECTED_TYPE),
@@ -46,14 +46,14 @@ impl BuildValidator for GeneratorValidator {
         let validation_error_cause: bool = config
             .get_as(pyo3::intern!(schema.py(), "validation_error_cause"))?
             .unwrap_or(false);
-        Ok(Self {
+        Ok(CombinedValidator::Generator(Self {
             item_validator,
             name,
             min_length: schema.get_as(pyo3::intern!(schema.py(), "min_length"))?,
             max_length: schema.get_as(pyo3::intern!(schema.py(), "max_length"))?,
             hide_input_in_errors,
             validation_error_cause,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
@@ -22,8 +24,8 @@ impl BuildValidator for IsInstanceValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         let cls_key = intern!(py, "cls");
         let class = schema.get_as_req(cls_key)?;
@@ -36,11 +38,11 @@ impl BuildValidator for IsInstanceValidator {
 
         let class_repr = class_repr(schema, &class)?;
         let name = format!("{}[{class_repr}]", Self::EXPECTED_TYPE);
-        Ok(Self {
+        Ok(CombinedValidator::IsInstance(Self {
             class: class.into(),
             class_repr,
             name,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
@@ -21,8 +23,8 @@ impl BuildValidator for IsSubclassValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         let class = schema.get_as_req::<Bound<'_, PyType>>(intern!(py, "cls"))?;
 
@@ -31,11 +33,11 @@ impl BuildValidator for IsSubclassValidator {
             None => class.qualname()?.to_string(),
         };
         let name = format!("{}[{class_repr}]", Self::EXPECTED_TYPE);
-        Ok(Self {
+        Ok(CombinedValidator::IsSubclass(Self {
             class: class.into(),
             class_repr,
             name,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -11,8 +13,8 @@ use super::{build_validator, BuildValidator, CombinedValidator, InputType, Valid
 
 #[derive(Debug)]
 pub struct JsonOrPython {
-    json: Box<CombinedValidator>,
-    python: Box<CombinedValidator>,
+    json: Arc<CombinedValidator>,
+    python: Arc<CombinedValidator>,
     name: String,
 }
 
@@ -22,8 +24,8 @@ impl BuildValidator for JsonOrPython {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         let json_schema = schema.get_as_req(intern!(py, "json_schema"))?;
         let python_schema = schema.get_as_req(intern!(py, "python_schema"))?;
@@ -37,12 +39,7 @@ impl BuildValidator for JsonOrPython {
             json.get_name(),
             python.get_name(),
         );
-        Ok(Self {
-            json: Box::new(json),
-            python: Box::new(python),
-            name,
-        }
-        .into())
+        Ok(CombinedValidator::JsonOrPython(Self { json, python, name }).into())
     }
 }
 

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -2,6 +2,7 @@
 // which can be an int, a string, bytes or an Enum value (including `class Foo(str, Enum)` type enums)
 use core::fmt::Debug;
 use std::cell::OnceCell;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyInt, PyList};
@@ -255,8 +256,8 @@ impl BuildValidator for LiteralValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let expected: Bound<PyList> = schema.get_as_req(intern!(schema.py(), "expected"))?;
         if expected.is_empty() {
             return py_schema_err!("`expected` should have length > 0");
@@ -272,7 +273,8 @@ impl BuildValidator for LiteralValidator {
             lookup,
             expected_repr,
             name,
-        }))
+        })
+        .into())
     }
 }
 

--- a/src/validators/missing_sentinel.rs
+++ b/src/validators/missing_sentinel.rs
@@ -1,8 +1,10 @@
 use core::fmt::Debug;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::LazyLock;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
@@ -12,15 +14,18 @@ use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationSta
 #[derive(Debug, Clone)]
 pub struct MissingSentinelValidator {}
 
+static MISSING_SENTINEL_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
+    LazyLock::new(|| CombinedValidator::MissingSentinel(MissingSentinelValidator {}).into());
+
 impl BuildValidator for MissingSentinelValidator {
     const EXPECTED_TYPE: &'static str = "missing-sentinel";
 
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(CombinedValidator::MissingSentinel(Self {}))
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(MISSING_SENTINEL_VALIDATOR.clone())
     }
 }
 

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::LazyLock;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
@@ -9,15 +12,17 @@ use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationSta
 #[derive(Debug, Clone)]
 pub struct NoneValidator;
 
+static NONE_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(NoneValidator.into()));
+
 impl BuildValidator for NoneValidator {
     const EXPECTED_TYPE: &'static str = "none";
 
     fn build(
         _schema: &Bound<'_, PyDict>,
         _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
-        Ok(Self.into())
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        Ok(NONE_VALIDATOR.clone())
     }
 }
 

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -11,7 +13,7 @@ use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuild
 
 #[derive(Debug)]
 pub struct NullableValidator {
-    validator: Box<CombinedValidator>,
+    validator: Arc<CombinedValidator>,
     name: String,
 }
 
@@ -21,12 +23,12 @@ impl BuildValidator for NullableValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let schema = schema.get_as_req(intern!(schema.py(), "schema"))?;
-        let validator = Box::new(build_validator(&schema, config, definitions)?);
+        let validator = build_validator(&schema, config, definitions)?;
         let name = format!("{}[{}]", Self::EXPECTED_TYPE, validator.get_name());
-        Ok(Self { validator, name }.into())
+        Ok(CombinedValidator::Nullable(Self { validator, name }).into())
     }
 }
 

--- a/src/validators/prebuilt.rs
+++ b/src/validators/prebuilt.rs
@@ -18,7 +18,7 @@ impl PrebuiltValidator {
         get_prebuilt(type_, schema, "__pydantic_validator__", |py_any| {
             let schema_validator = py_any.extract::<Py<SchemaValidator>>()?;
             if matches!(
-                schema_validator.get().validator,
+                schema_validator.get().validator.as_ref(),
                 CombinedValidator::FunctionWrap(_) | CombinedValidator::FunctionAfter(_)
             ) {
                 return Ok(None);

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -27,14 +29,14 @@ impl BuildValidator for TimeValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let s = Self {
             strict: is_strict(schema, config)?,
             constraints: TimeConstraints::from_py(schema)?,
             microseconds_precision: extract_microseconds_precision(schema, config)?,
         };
-        Ok(s.into())
+        Ok(Arc::new(s.into()))
     }
 }
 

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -44,8 +46,8 @@ impl BuildValidator for TimeDeltaValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         let constraints = TimedeltaConstraints {
             le: get_constraint(schema, intern!(py, "le"))?,
@@ -54,7 +56,7 @@ impl BuildValidator for TimeDeltaValidator {
             gt: get_constraint(schema, intern!(py, "gt"))?,
         };
 
-        Ok(Self {
+        Ok(CombinedValidator::Timedelta(Self {
             strict: is_strict(schema, config)?,
             constraints: (constraints.le.is_some()
                 || constraints.lt.is_some()
@@ -62,7 +64,7 @@ impl BuildValidator for TimeDeltaValidator {
                 || constraints.gt.is_some())
             .then_some(constraints),
             microseconds_precision: extract_microseconds_precision(schema, config)?,
-        }
+        })
         .into())
     }
 }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::py_gc::PyGcTraverse;
 use pyo3::prelude::*;
@@ -41,7 +42,7 @@ impl FromStr for UnionMode {
 #[derive(Debug)]
 pub struct UnionValidator {
     mode: UnionMode,
-    choices: Vec<(CombinedValidator, Option<String>)>,
+    choices: Vec<(Arc<CombinedValidator>, Option<String>)>,
     custom_error: Option<CustomError>,
     name: String,
 }
@@ -52,10 +53,10 @@ impl BuildValidator for UnionValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
-        let choices: Vec<(CombinedValidator, Option<String>)> = schema
+        let choices: Vec<(Arc<CombinedValidator>, Option<String>)> = schema
             .get_as_req::<Bound<'_, PyList>>(intern!(py, "choices"))?
             .iter()
             .map(|choice| {
@@ -70,7 +71,7 @@ impl BuildValidator for UnionValidator {
                 };
                 Ok((build_validator(&choice, config, definitions)?, label))
             })
-            .collect::<PyResult<Vec<(CombinedValidator, Option<String>)>>>()?;
+            .collect::<PyResult<_>>()?;
 
         let auto_collapse = || schema.get_as_req(intern!(py, "auto_collapse")).unwrap_or(true);
         let mode = schema
@@ -86,12 +87,12 @@ impl BuildValidator for UnionValidator {
                     .collect::<Vec<_>>()
                     .join(",");
 
-                Ok(Self {
+                Ok(CombinedValidator::Union(Self {
                     mode,
                     choices,
                     custom_error: CustomError::build(schema, config, definitions)?,
                     name: format!("{}[{descr}]", Self::EXPECTED_TYPE),
-                }
+                })
                 .into())
             }
         }
@@ -282,7 +283,7 @@ impl<'a> MaybeErrors<'a> {
 #[derive(Debug)]
 pub struct TaggedUnionValidator {
     discriminator: Discriminator,
-    lookup: LiteralLookup<CombinedValidator>,
+    lookup: LiteralLookup<Arc<CombinedValidator>>,
     from_attributes: bool,
     custom_error: Option<CustomError>,
     tags_repr: String,
@@ -296,8 +297,8 @@ impl BuildValidator for TaggedUnionValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
         let discriminator_repr = discriminator.to_string_py(py)?;
@@ -328,7 +329,7 @@ impl BuildValidator for TaggedUnionValidator {
         let key = intern!(py, "from_attributes");
         let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(true);
 
-        Ok(Self {
+        Ok(CombinedValidator::TaggedUnion(Self {
             discriminator,
             lookup,
             from_attributes,
@@ -336,7 +337,7 @@ impl BuildValidator for TaggedUnionValidator {
             tags_repr,
             discriminator_repr,
             name: format!("{}[{descr}]", Self::EXPECTED_TYPE),
-        }
+        })
         .into())
     }
 }

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -1,4 +1,5 @@
 use std::str::from_utf8;
+use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -80,15 +81,15 @@ impl BuildValidator for UuidValidator {
     fn build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<CombinedValidator>,
-    ) -> PyResult<CombinedValidator> {
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         // Note(lig): let's keep this conversion through the Version enum just for the sake of validation
         let version = schema.get_as::<u8>(intern!(py, "version"))?.map(Version::from);
-        Ok(Self {
+        Ok(CombinedValidator::Uuid(Self {
             strict: is_strict(schema, config)?,
             version: version.map(usize::from),
-        }
+        })
         .into())
     }
 }


### PR DESCRIPTION
## Change Summary

This diff wraps all validators and serializers across the codebase in `Arc`, for two reasons:
- This makes it possible to re-use simple validators, making progress to reduce memory usage observed in https://github.com/pydantic/pydantic/issues/12272
- It makes it possible to do further optimizations:
  - Re-use of portions of serializer / validator trees (left for future follow up, figuring out where to deduplicate is hard)
  - Tree traversal algorithms which rewrite portions of trees (this would allow schema cleaning to move into Rust)

In this PR, the memory usage from the repro in #12272 falls from about 600KB per model to 500 KB. We should be able to do more to improve this based on the follow ups.

<img width="1843" height="999" alt="image" src="https://github.com/user-attachments/assets/06c6de74-7a52-4b9b-b1ce-a61cc874955b" />

## Related issue number

Partial improvement for https://github.com/pydantic/pydantic/issues/12272

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
