### PR TITLE
inline definitions inside `SchemaValidator` construction

### DIFF
--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -45,4 +45,8 @@ impl Validator for AnyValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -55,4 +55,8 @@ impl Validator for BoolValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -60,6 +60,10 @@ impl Validator for BytesValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +115,10 @@ impl Validator for BytesConstrainedValidator {
 
     fn get_name(&self) -> &'static str {
         "constrained-bytes"
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }
 

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -48,4 +48,8 @@ impl Validator for CallableValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/complex.rs
+++ b/src/validators/complex.rs
@@ -61,6 +61,10 @@ impl Validator for ComplexValidator {
     fn get_name(&self) -> &'static str {
         "complex"
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 pub(crate) fn string_to_complex<'py>(

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -104,4 +104,20 @@ impl Validator for CustomErrorValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Exactly one child is required for a custom-error validator");
+        }
+        Ok(CombinedValidator::CustomError(Self {
+            validator: children.into_iter().next().unwrap(),
+            custom_error: self.custom_error.clone(),
+            name: self.name.clone(),
+        })
+        .into())
+    }
 }

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -107,6 +107,10 @@ impl Validator for DateValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 /// In lax mode, if the input is not a date, we try parsing the input as a datetime, then check it is an

--- a/src/validators/datetime.rs
+++ b/src/validators/datetime.rs
@@ -140,6 +140,10 @@ impl Validator for DateTimeValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 /// In lax mode, if the input is not a datetime, we try parsing the input as a date and add the "00:00:00" time.

--- a/src/validators/decimal.rs
+++ b/src/validators/decimal.rs
@@ -277,6 +277,10 @@ impl Validator for DecimalValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 pub(crate) fn create_decimal<'py>(arg: &Bound<'py, PyAny>, input: impl ToErrorValue) -> ValResult<Bound<'py, PyAny>> {

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -51,6 +51,10 @@ impl DefinitionRefValidator {
     pub fn new(definition: DefinitionRef<Arc<CombinedValidator>>) -> Self {
         Self { definition }
     }
+
+    pub fn definition(&self) -> &DefinitionRef<Arc<CombinedValidator>> {
+        &self.definition
+    }
 }
 
 impl BuildValidator for DefinitionRefValidator {
@@ -125,6 +129,12 @@ impl Validator for DefinitionRefValidator {
 
     fn get_name(&self) -> &str {
         self.definition.get_or_init_name(|v| v.get_name().into())
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        // deliberately return empty to avoid circular walk during optimization passes
+        // TODO this may not be correct
+        vec![]
     }
 }
 

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -164,6 +164,10 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -82,6 +82,10 @@ impl Validator for FloatValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -172,6 +176,10 @@ impl Validator for ConstrainedFloatValidator {
 
     fn get_name(&self) -> &'static str {
         "constrained-float"
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }
 

--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use pyo3::types::{PyDict, PyFrozenSet};
 use pyo3::{prelude::*, IntoPyObjectExt};
 
+use crate::build_tools::py_schema_err;
 use crate::errors::ValResult;
 use crate::input::{validate_iter_to_set, BorrowInput, ConsumeIterator, Input, ValidatedSet};
 use crate::tools::SchemaDict;
@@ -53,6 +54,25 @@ impl Validator for FrozenSetValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.item_validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("FrozenSetValidator expected 1 child, got {}", children.len());
+        }
+        Ok(CombinedValidator::FrozenSet(Self {
+            strict: self.strict,
+            item_validator: children.into_iter().next().unwrap(),
+            min_length: self.min_length,
+            max_length: self.max_length,
+            name: self.name.clone(),
+            fail_fast: self.fail_fast,
+        })
+        .into())
     }
 }
 

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyString};
 use pyo3::{intern, PyTraverseError, PyVisit};
 
+use crate::build_tools::py_schema_err;
 use crate::errors::{
     ErrorType, PydanticCustomError, PydanticKnownError, PydanticOmit, ToErrorValue, ValError, ValResult,
     ValidationError,
@@ -153,6 +154,25 @@ impl Validator for FunctionBeforeValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Exactly one child is required for a function-before validator");
+        }
+        Ok(CombinedValidator::FunctionBefore(Self {
+            validator: children.into_iter().next().unwrap(),
+            func: self.func.clone(),
+            config: self.config.clone(),
+            name: self.name.clone(),
+            field_name: self.field_name.clone(),
+            info_arg: self.info_arg,
+        })
+        .into())
+    }
 }
 
 #[derive(Debug)]
@@ -227,6 +247,25 @@ impl Validator for FunctionAfterValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Exactly one child is required for a function-after validator");
+        }
+        Ok(CombinedValidator::FunctionAfter(Self {
+            validator: children.into_iter().next().unwrap(),
+            func: self.func.clone(),
+            config: self.config.clone(),
+            name: self.name.clone(),
+            field_name: self.field_name.clone(),
+            info_arg: self.info_arg,
+        })
+        .into())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -288,6 +327,10 @@ impl Validator for FunctionPlainValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }
 
@@ -413,6 +456,27 @@ impl Validator for FunctionWrapValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Exactly one child is required for a function-wrap validator");
+        }
+        Ok(CombinedValidator::FunctionWrap(Self {
+            validator: children.into_iter().next().unwrap(),
+            func: self.func.clone(),
+            config: self.config.clone(),
+            name: self.name.clone(),
+            field_name: self.field_name.clone(),
+            info_arg: self.info_arg,
+            hide_input_in_errors: self.hide_input_in_errors,
+            validation_error_cause: self.validation_error_cause,
+        })
+        .into())
     }
 }
 

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use pyo3::types::{PyDict, PyString};
 use pyo3::{prelude::*, IntoPyObjectExt, PyTraverseError, PyVisit};
 
-use crate::build_tools::ExtraBehavior;
+use crate::build_tools::{py_schema_err, ExtraBehavior};
 use crate::errors::{ErrorType, LocItem, ValError, ValResult};
 use crate::input::{BorrowInput, GenericIterator, Input};
 use crate::py_gc::PyGcTraverse;
@@ -94,6 +94,35 @@ impl Validator for GeneratorValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        match &self.item_validator {
+            Some(v) => vec![v],
+            None => vec![],
+        }
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if self.item_validator.is_none() {
+            if !children.is_empty() {
+                return py_schema_err!("GeneratorValidator expected 0 children, got {}", children.len());
+            }
+            return Ok(CombinedValidator::Generator(self.clone()).into());
+        } else {
+            if children.len() != 1 {
+                return py_schema_err!("GeneratorValidator expected 1 child, got {}", children.len());
+            }
+            Ok(CombinedValidator::Generator(Self {
+                item_validator: Some(children.into_iter().next().unwrap()),
+                min_length: self.min_length,
+                max_length: self.max_length,
+                name: self.name.clone(),
+                hide_input_in_errors: self.hide_input_in_errors,
+                validation_error_cause: self.validation_error_cause,
+            })
+            .into())
+        }
     }
 }
 

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -84,6 +84,10 @@ impl Validator for IntValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -183,5 +187,9 @@ impl Validator for ConstrainedIntValidator {
 
     fn get_name(&self) -> &'static str {
         "constrained-int"
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -81,6 +81,10 @@ impl Validator for IsInstanceValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 pub fn class_repr(schema: &Bound<'_, PyDict>, class: &Bound<'_, PyAny>) -> PyResult<String> {

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -76,4 +76,8 @@ impl Validator for IsSubclassValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -4,6 +4,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::py_schema_err;
 use crate::definitions::DefinitionsBuilder;
 use crate::errors::ValResult;
 use crate::input::Input;
@@ -60,5 +61,21 @@ impl Validator for JsonOrPython {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.json, &self.python]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 2 {
+            return py_schema_err!("JsonOrPython must have exactly two children: json and python");
+        }
+        Ok(CombinedValidator::JsonOrPython(Self {
+            json: children[0].clone(),
+            python: children[1].clone(),
+            name: self.name.clone(),
+        })
+        .into())
     }
 }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -177,6 +177,28 @@ impl Validator for ListValidator {
             }
         }
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        match &self.item_validator {
+            Some(v) => vec![v],
+            None => vec![],
+        }
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() > 1 {
+            return crate::build_tools::py_schema_err!("List must have zero or one child");
+        }
+        Ok(CombinedValidator::List(Self {
+            strict: self.strict,
+            item_validator: children.into_iter().next(),
+            min_length: self.min_length,
+            max_length: self.max_length,
+            name: OnceLock::new(),
+            fail_fast: self.fail_fast,
+        })
+        .into())
+    }
 }
 
 struct ValidateToVec<'a, 's, 'py, I: Input<'py> + ?Sized> {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -302,6 +302,10 @@ impl Validator for LiteralValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 pub fn expected_repr_name(mut repr_args: Vec<String>, base_name: &'static str) -> (String, String) {

--- a/src/validators/missing_sentinel.rs
+++ b/src/validators/missing_sentinel.rs
@@ -49,4 +49,8 @@ impl Validator for MissingSentinelValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -24,7 +24,7 @@ const DUNDER_FIELDS_SET_KEY: &str = "__pydantic_fields_set__";
 const DUNDER_MODEL_EXTRA_KEY: &str = "__pydantic_extra__";
 const DUNDER_MODEL_PRIVATE_KEY: &str = "__pydantic_private__";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(super) enum Revalidate {
     Always,
     Never,
@@ -242,6 +242,29 @@ impl Validator for ModelValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Model must have exactly one child: the inner validator");
+        }
+
+        Ok(Arc::new(CombinedValidator::Model(ModelValidator {
+            revalidate: self.revalidate,
+            validator: children.into_iter().next().unwrap(),
+            class: self.class.clone(),
+            generic_origin: self.generic_origin.clone(),
+            post_init: self.post_init.clone(),
+            frozen: self.frozen,
+            custom_init: self.custom_init,
+            root_model: self.root_model,
+            undefined: self.undefined.clone(),
+            name: self.name.clone(),
+        })))
     }
 }
 

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -22,7 +22,7 @@ use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuild
 #[derive(Debug)]
 struct Field {
     name: String,
-    lookup_key_collection: LookupKeyCollection,
+    lookup_key_collection: Arc<LookupKeyCollection>,
     name_py: Py<PyString>,
     validator: Arc<CombinedValidator>,
     frozen: bool,
@@ -90,7 +90,7 @@ impl BuildValidator for ModelFieldsValidator {
             };
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, field_name)?;
+            let lookup_key_collection = Arc::new(LookupKeyCollection::new(py, validation_alias, field_name)?);
 
             fields.push(Field {
                 name: field_name.to_string(),
@@ -485,5 +485,63 @@ impl Validator for ModelFieldsValidator {
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        let mut children = Vec::with_capacity(self.fields.len() + 2);
+        for field in &self.fields {
+            children.push(&field.validator);
+        }
+        if let Some(ref v) = self.extras_validator {
+            children.push(v);
+        }
+        if let Some(ref v) = self.extras_keys_validator {
+            children.push(v);
+        }
+        children
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        let expected_len = self.fields.len()
+            + if self.extras_validator.is_some() { 1 } else { 0 }
+            + if self.extras_keys_validator.is_some() { 1 } else { 0 };
+        if children.len() != expected_len {
+            return py_schema_err!("ModelFields must have exactly {} children", expected_len);
+        }
+        let mut iter = children.into_iter();
+        let new_fields = self
+            .fields
+            .iter()
+            .map(|field| Field {
+                name: field.name.clone(),
+                lookup_key_collection: field.lookup_key_collection.clone(),
+                name_py: field.name_py.clone(),
+                validator: iter.next().unwrap(),
+                frozen: field.frozen,
+            })
+            .collect();
+        let extras_validator = if self.extras_validator.is_some() {
+            Some(iter.next().unwrap())
+        } else {
+            None
+        };
+        let extras_keys_validator = if self.extras_keys_validator.is_some() {
+            Some(iter.next().unwrap())
+        } else {
+            None
+        };
+        Ok(CombinedValidator::ModelFields(Self {
+            fields: new_fields,
+            model_name: self.model_name.clone(),
+            extra_behavior: self.extra_behavior,
+            extras_validator,
+            extras_keys_validator,
+            strict: self.strict,
+            from_attributes: self.from_attributes,
+            loc_by_alias: self.loc_by_alias,
+            validate_by_alias: self.validate_by_alias,
+            validate_by_name: self.validate_by_name,
+        })
+        .into())
     }
 }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -44,4 +44,8 @@ impl Validator for NoneValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -4,6 +4,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_tools::py_schema_err;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
@@ -49,5 +50,20 @@ impl Validator for NullableValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Nullable must have exactly one child");
+        }
+        Ok(CombinedValidator::Nullable(Self {
+            validator: children.into_iter().next().unwrap(),
+            name: self.name.clone(),
+        })
+        .into())
     }
 }

--- a/src/validators/prebuilt.rs
+++ b/src/validators/prebuilt.rs
@@ -43,4 +43,10 @@ impl Validator for PrebuiltValidator {
     fn get_name(&self) -> &str {
         self.schema_validator.get().validator.get_name()
     }
+
+    fn children(&self) -> Vec<&std::sync::Arc<CombinedValidator>> {
+        // Treat "prebuilt" as a leaf node as it may contain config boundary etc, do not want to
+        // optimize through it
+        vec![]
+    }
 }

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -86,6 +86,10 @@ impl Validator for StrValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 /// Any new properties set here must be reflected in `has_constraints_set`
@@ -174,6 +178,10 @@ impl Validator for StrConstrainedValidator {
 
     fn get_name(&self) -> &'static str {
         "constrained-str"
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }
 

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -86,6 +86,10 @@ impl Validator for TimeValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 fn convert_pytime(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyResult<Option<Time>> {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -113,6 +113,10 @@ impl Validator for TimeDeltaValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 fn pydelta_to_human_readable(py_delta: Bound<'_, PyDelta>) -> String {
     let total_seconds = py_delta.get_seconds();

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -22,7 +22,7 @@ use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuild
 #[derive(Debug)]
 struct TypedDictField {
     name: String,
-    lookup_key_collection: LookupKeyCollection,
+    lookup_key_collection: Arc<LookupKeyCollection>,
     name_py: Py<PyString>,
     required: bool,
     validator: Arc<CombinedValidator>,
@@ -121,7 +121,7 @@ impl BuildValidator for TypedDictValidator {
             }
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, field_name)?;
+            let lookup_key_collection = Arc::new(LookupKeyCollection::new(py, validation_alias, field_name)?);
 
             fields.push(TypedDictField {
                 name: field_name.to_string(),
@@ -384,5 +384,52 @@ impl Validator for TypedDictValidator {
 
     fn get_name(&self) -> &str {
         self.cls_name.as_deref().unwrap_or(Self::EXPECTED_TYPE)
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        let mut children: Vec<&Arc<CombinedValidator>> = self.fields.iter().map(|f| &f.validator).collect();
+        if let Some(extras_validator) = &self.extras_validator {
+            children.push(extras_validator);
+        }
+        children
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        let expected_len = self.fields.len() + if self.extras_validator.is_some() { 1 } else { 0 };
+        if children.len() != expected_len {
+            return py_schema_err!("Expected {} children for TypedDict validator", expected_len);
+        }
+
+        let (fields_validators, extras_validator) = if let Some(_) = &self.extras_validator {
+            let (fields, extras) = children.split_at(self.fields.len());
+            (fields.to_vec(), Some(extras[0].clone()))
+        } else {
+            (children, None)
+        };
+
+        let new_fields: Vec<TypedDictField> = self
+            .fields
+            .iter()
+            .zip(fields_validators.into_iter())
+            .map(|(field, validator)| TypedDictField {
+                name: field.name.clone(),
+                validator,
+                lookup_key_collection: field.lookup_key_collection.clone(),
+                name_py: field.name_py.clone(),
+                required: field.required,
+            })
+            .collect();
+
+        Ok(CombinedValidator::TypedDict(Self {
+            fields: new_fields,
+            extra_behavior: self.extra_behavior,
+            extras_validator,
+            strict: self.strict,
+            loc_by_alias: self.loc_by_alias,
+            validate_by_alias: self.validate_by_alias,
+            validate_by_name: self.validate_by_name,
+            cls_name: self.cls_name.clone(),
+        })
+        .into())
     }
 }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -21,7 +21,7 @@ use super::{
     build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum UnionMode {
     Smart,
     LeftToRight,
@@ -224,6 +224,31 @@ impl Validator for UnionValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        self.choices.iter().map(|(v, _)| v).collect()
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != self.choices.len() {
+            return py_schema_err!(
+                "Number of children for union must be the same as the existing number of choices ({})",
+                self.choices.len()
+            );
+        }
+        let new_choices = children
+            .into_iter()
+            .zip(self.choices.iter().map(|(_, label)| label.clone()))
+            .collect();
+
+        Ok(CombinedValidator::Union(Self {
+            mode: self.mode,
+            choices: new_choices,
+            custom_error: self.custom_error.clone(),
+            name: self.name.clone(),
+        })
+        .into())
+    }
 }
 
 struct ChoiceLineErrors<'a> {
@@ -282,7 +307,7 @@ impl<'a> MaybeErrors<'a> {
 
 #[derive(Debug)]
 pub struct TaggedUnionValidator {
-    discriminator: Discriminator,
+    discriminator: Arc<Discriminator>,
     lookup: LiteralLookup<Arc<CombinedValidator>>,
     from_attributes: bool,
     custom_error: Option<CustomError>,
@@ -300,7 +325,10 @@ impl BuildValidator for TaggedUnionValidator {
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
-        let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
+        let discriminator = Arc::new(Discriminator::new(
+            py,
+            &schema.get_as_req(intern!(py, "discriminator"))?,
+        )?);
         let discriminator_repr = discriminator.to_string_py(py)?;
 
         let choices = PyDict::new(py);
@@ -351,7 +379,7 @@ impl Validator for TaggedUnionValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        match &self.discriminator {
+        match self.discriminator.as_ref() {
             Discriminator::LookupKey(lookup_key) => {
                 let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
                 let dict = input.validate_model_fields(state.strict_or(false), from_attributes)?;
@@ -376,6 +404,33 @@ impl Validator for TaggedUnionValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        self.lookup.values.iter().collect()
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != self.lookup.values.len() {
+            return py_schema_err!(
+                "Number of children for tagged-union must be the same as the existing number of choices ({})",
+                self.lookup.values.len()
+            );
+        }
+
+        let mut new_lookup = self.lookup.clone();
+        new_lookup.values = children;
+
+        Ok(CombinedValidator::TaggedUnion(Self {
+            discriminator: self.discriminator.clone(),
+            lookup: new_lookup,
+            from_attributes: self.from_attributes,
+            custom_error: self.custom_error.clone(),
+            tags_repr: self.tags_repr.clone(),
+            discriminator_repr: self.discriminator_repr.clone(),
+            name: self.name.clone(),
+        })
+        .into())
     }
 }
 

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -105,6 +105,10 @@ impl Validator for UrlValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 impl UrlValidator {
@@ -265,6 +269,10 @@ impl Validator for MultiHostUrlValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
     }
 }
 

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -161,6 +161,10 @@ impl Validator for UuidValidator {
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![]
+    }
 }
 
 impl UuidValidator {

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -212,6 +212,26 @@ impl Validator for WithDefaultValidator {
     fn get_name(&self) -> &str {
         &self.name
     }
+
+    fn children(&self) -> Vec<&Arc<CombinedValidator>> {
+        vec![&self.validator]
+    }
+
+    fn with_new_children(&self, children: Vec<Arc<CombinedValidator>>) -> PyResult<Arc<CombinedValidator>> {
+        if children.len() != 1 {
+            return py_schema_err!("Expected 1 child, got {}", children.len());
+        }
+        Ok(CombinedValidator::WithDefault(Self {
+            default: self.default.clone(),
+            on_error: self.on_error.clone(),
+            validator: children.into_iter().next().unwrap(),
+            validate_default: self.validate_default,
+            copy_default: self.copy_default,
+            name: self.name.clone(),
+            undefined: self.undefined.clone(),
+        })
+        .into())
+    }
 }
 
 impl WithDefaultValidator {

--- a/tests/validators/test_definitions.py
+++ b/tests/validators/test_definitions.py
@@ -16,6 +16,8 @@ def test_list_with_def():
     assert v.validate_json(b'[1, 2, "3"]') == [1, 2, 3]
     r = plain_repr(v)
     assert r.startswith('SchemaValidator(title="list[int]",')
+    # definition should have been inlined, not recursive
+    assert 'DefinitionRef' not in r
 
 
 def test_ignored_def():


### PR DESCRIPTION
## Change Summary

This is an experiment to see what happens if definition inlining is implemented inside `SchemaValidator`. This should avoid the need to do it in Python (in the `clean_schema` function).

Hoping this has performance benefits.

Not fully implemented yet, there's some test diffs due to changes in the recursion defenses, I think I know how to resolve.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
