### PR TITLE
add `CoreConfig` typed struct during schema build

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,55 @@
+use std::convert::Infallible;
+
+use pyo3::{
+    intern,
+    types::{PyAnyMethods, PyString},
+    Borrowed, Bound, FromPyObject, IntoPyObject, PyAny, PyResult, Python,
+};
+
+use crate::{
+    build_tools::{py_schema_error_type, ExtraBehavior},
+    validators::{Revalidate, TemporalUnitMode, ValBytesMode},
+};
+
+#[derive(FromPyObject, IntoPyObject, Default, Clone, Debug)]
+pub struct CoreConfig {
+    pub loc_by_alias: Option<bool>,
+    pub extra_fields_behavior: Option<ExtraBehavior>,
+    pub validate_by_alias: Option<bool>,
+    pub validate_by_name: Option<bool>,
+    pub val_json_bytes: Option<ValBytesMode>,
+    pub val_temporal_unit: Option<TemporalUnitMode>,
+    pub revalidate_instances: Option<Revalidate>,
+    pub microseconds_precision: Option<MicrosecondsPrecisionOverflowBehavior>,
+    pub strict: Option<bool>,
+    pub allow_inf_nan: Option<bool>,
+}
+
+/// Wrapper around the speedate config value to add Python conversions
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct MicrosecondsPrecisionOverflowBehavior(pub speedate::MicrosecondsPrecisionOverflowBehavior);
+
+impl FromPyObject<'_> for MicrosecondsPrecisionOverflowBehavior {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let s: &str = ob.extract()?;
+        s.parse().map(MicrosecondsPrecisionOverflowBehavior).map_err(|_| {
+            py_schema_error_type!("Invalid `microseconds_precision`, must be one of \"truncate\" or \"error\"")
+        })
+    }
+}
+
+impl<'py> IntoPyObject<'py> for MicrosecondsPrecisionOverflowBehavior {
+    type Target = PyString;
+
+    type Output = Borrowed<'py, 'py, PyString>;
+
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let s = match self.0 {
+            speedate::MicrosecondsPrecisionOverflowBehavior::Truncate => intern!(py, "truncate"),
+            speedate::MicrosecondsPrecisionOverflowBehavior::Error => intern!(py, "error"),
+        };
+        Ok(s.as_borrowed())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod py_gc;
 mod argument_markers;
 mod build_tools;
 mod common;
+mod config;
 mod definitions;
 mod errors;
 mod input;

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -15,6 +15,7 @@ use super::{
 };
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{py_schema_error_type, ExtraBehavior};
+use crate::config::CoreConfig;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::errors::PydanticSerializationUnexpectedValue;
 use crate::tools::SchemaDict;
@@ -133,7 +134,11 @@ impl BuildSerializer for ModelSerializer {
 
 fn has_extra(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<bool> {
     let py = schema.py();
-    let extra_behaviour = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
+    let typed_config: CoreConfig = match config {
+        Some(config) => config.extract()?,
+        None => CoreConfig::default(),
+    };
+    let extra_behaviour = ExtraBehavior::from_schema_or_config(py, schema, &typed_config, ExtraBehavior::Ignore)?;
     Ok(matches!(extra_behaviour, ExtraBehavior::Allow))
 }
 

--- a/src/serializers/type_serializers/typed_dict.rs
+++ b/src/serializers/type_serializers/typed_dict.rs
@@ -8,6 +8,7 @@ use ahash::AHashMap;
 
 use crate::build_tools::py_schema_err;
 use crate::build_tools::{py_schema_error_type, schema_or_config, ExtraBehavior};
+use crate::config::CoreConfig;
 use crate::definitions::DefinitionsBuilder;
 use crate::tools::SchemaDict;
 
@@ -29,7 +30,13 @@ impl BuildSerializer for TypedDictBuilder {
         let total =
             schema_or_config(schema, config, intern!(py, "total"), intern!(py, "typed_dict_total"))?.unwrap_or(true);
 
-        let fields_mode = match ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)? {
+        let typed_config: CoreConfig = match config {
+            Some(config) => config.extract()?,
+            None => CoreConfig::default(),
+        };
+
+        let fields_mode = match ExtraBehavior::from_schema_or_config(py, schema, &typed_config, ExtraBehavior::Ignore)?
+        {
             ExtraBehavior::Allow => FieldsMode::TypedDictAllow,
             _ => FieldsMode::SimpleDict,
         };

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::config::CoreConfig;
 use crate::input::Input;
 use crate::{build_tools::LazyLock, errors::ValResult};
 
@@ -21,7 +22,7 @@ impl BuildValidator for AnyValidator {
 
     fn build(
         _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         Ok(ANY_VALIDATOR.clone())

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -9,7 +9,8 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{schema_or_config_same, ExtraBehavior};
+use crate::build_tools::ExtraBehavior;
+use crate::config::CoreConfig;
 use crate::errors::{ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{Arguments, BorrowInput, Input, KeywordArgs, PositionalArgs, ValidationMatch};
 use crate::lookup_key::LookupKeyCollection;
@@ -67,7 +68,7 @@ impl BuildValidator for ArgumentsValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
@@ -166,10 +167,14 @@ impl BuildValidator for ArgumentsValidator {
             },
             var_kwargs_mode,
             var_kwargs_validator,
-            loc_by_alias: config.get_as(intern!(py, "loc_by_alias"))?.unwrap_or(true),
+            loc_by_alias: config.loc_by_alias.unwrap_or(true),
             extra: ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Forbid)?,
-            validate_by_alias: schema_or_config_same(schema, config, intern!(py, "validate_by_alias"))?,
-            validate_by_name: schema_or_config_same(schema, config, intern!(py, "validate_by_name"))?,
+            validate_by_alias: schema
+                .get_as(intern!(py, "validate_by_alias"))?
+                .or(config.validate_by_alias),
+            validate_by_name: schema
+                .get_as(intern!(py, "validate_by_name"))?
+                .or(config.validate_by_name),
         })
         .into())
     }

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -4,6 +4,7 @@ use pyo3::types::PyDict;
 use pyo3::{prelude::*, IntoPyObjectExt};
 
 use crate::build_tools::{is_strict, LazyLock};
+use crate::config::CoreConfig;
 use crate::errors::ValResult;
 use crate::input::Input;
 
@@ -25,7 +26,7 @@ impl BuildValidator for BoolValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         if is_strict(schema, config)? {

--- a/src/validators/bytes.rs
+++ b/src/validators/bytes.rs
@@ -6,6 +6,7 @@ use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::is_strict;
+use crate::config::CoreConfig;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
@@ -25,7 +26,7 @@ impl BuildValidator for BytesValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
@@ -36,7 +37,7 @@ impl BuildValidator for BytesValidator {
         } else {
             Ok(CombinedValidator::Bytes(Self {
                 strict: is_strict(schema, config)?,
-                bytes_mode: ValBytesMode::from_config(config)?,
+                bytes_mode: ValBytesMode::from_config(config),
             })
             .into())
         }
@@ -115,11 +116,11 @@ impl Validator for BytesConstrainedValidator {
 }
 
 impl BytesConstrainedValidator {
-    fn build(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Arc<CombinedValidator>> {
+    fn build(schema: &Bound<'_, PyDict>, config: &CoreConfig) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         Ok(CombinedValidator::ConstrainedBytes(Self {
             strict: is_strict(schema, config)?,
-            bytes_mode: ValBytesMode::from_config(config)?,
+            bytes_mode: ValBytesMode::from_config(config),
             min_length: schema.get_as(intern!(py, "min_length"))?,
             max_length: schema.get_as(intern!(py, "max_length"))?,
         })

--- a/src/validators/call.rs
+++ b/src/validators/call.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use pyo3::types::{PyDict, PyTuple};
 
+use crate::config::CoreConfig;
 use crate::errors::ValResult;
 use crate::input::Input;
 
@@ -27,7 +28,7 @@ impl BuildValidator for CallValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/callable.rs
+++ b/src/validators/callable.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::LazyLock;
+use crate::config::CoreConfig;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
@@ -20,7 +21,7 @@ impl BuildValidator for CallableValidator {
 
     fn build(
         _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         Ok(CALLABLE_VALIDATOR.clone())

--- a/src/validators/chain.rs
+++ b/src/validators/chain.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 use crate::build_tools::py_schema_err;
+use crate::config::CoreConfig;
 use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
@@ -23,7 +24,7 @@ impl BuildValidator for ChainValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let steps: Vec<Arc<CombinedValidator>> = schema
@@ -58,7 +59,7 @@ impl BuildValidator for ChainValidator {
 // to be flattened into `steps` above
 fn build_validator_steps(
     step: &Bound<'_, PyAny>,
-    config: Option<&Bound<'_, PyDict>>,
+    config: &CoreConfig,
     definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
 ) -> PyResult<Vec<Arc<CombinedValidator>>> {
     let validator = build_validator(step, config, definitions)?;

--- a/src/validators/complex.rs
+++ b/src/validators/complex.rs
@@ -6,6 +6,7 @@ use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyComplex, PyDict, PyString, PyType};
 
 use crate::build_tools::{is_strict, LazyLock};
+use crate::config::CoreConfig;
 use crate::errors::{ErrorTypeDefaults, ToErrorValue, ValError, ValResult};
 use crate::input::Input;
 
@@ -34,7 +35,7 @@ impl BuildValidator for ComplexValidator {
     const EXPECTED_TYPE: &'static str = "complex";
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         if is_strict(schema, config)? {

--- a/src/validators/custom_error.rs
+++ b/src/validators/custom_error.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::py_schema_err;
+use crate::config::CoreConfig;
 use crate::errors::ToErrorValue;
 use crate::errors::{ErrorType, PydanticCustomError, PydanticKnownError, ValError, ValResult};
 use crate::input::Input;
@@ -22,7 +23,7 @@ pub enum CustomError {
 impl CustomError {
     pub fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Option<Self>> {
         let py = schema.py();
@@ -71,7 +72,7 @@ impl BuildValidator for CustomErrorValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let custom_error = CustomError::build(schema, config, definitions)?.unwrap();

--- a/src/validators/date.rs
+++ b/src/validators/date.rs
@@ -8,6 +8,7 @@ use speedate::{Date, Time};
 use strum::EnumMessage;
 
 use crate::build_tools::{is_strict, py_schema_error_type};
+use crate::config::CoreConfig;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::{EitherDate, Input};
 
@@ -28,13 +29,13 @@ impl BuildValidator for DateValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         Ok(CombinedValidator::Date(Self {
             strict: is_strict(schema, config)?,
             constraints: DateConstraints::from_py(schema)?,
-            val_temporal_unit: TemporalUnitMode::from_config(config)?,
+            val_temporal_unit: TemporalUnitMode::from_config(config),
         })
         .into())
     }

--- a/src/validators/definitions.rs
+++ b/src/validators/definitions.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use pyo3::types::{PyDict, PyList};
 
+use crate::config::CoreConfig;
 use crate::definitions::DefinitionRef;
 use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
@@ -22,7 +23,7 @@ impl BuildValidator for DefinitionsValidatorBuilder {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
@@ -58,7 +59,7 @@ impl BuildValidator for DefinitionRefValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let schema_ref: Bound<'_, PyString> = schema.get_as_req(intern!(schema.py(), "schema_ref"))?;

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::build_tools::is_strict;
+use crate::config::CoreConfig;
 use crate::errors::{LocItem, ValError, ValLineError, ValResult};
 use crate::input::BorrowInput;
 use crate::input::ConsumeIterator;
@@ -32,7 +33,7 @@ impl BuildValidator for DictValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/enum_.rs
+++ b/src/validators/enum_.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
 
 use crate::build_tools::{is_strict, py_schema_err};
+use crate::config::CoreConfig;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, InputType};
 use crate::tools::{safe_repr, SchemaDict};
@@ -24,7 +25,7 @@ impl BuildValidator for BuildEnumValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let members: Bound<PyList> = schema.get_as_req(intern!(schema.py(), "members"))?;

--- a/src/validators/generator.rs
+++ b/src/validators/generator.rs
@@ -32,7 +32,7 @@ impl BuildValidator for GeneratorValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let item_validator = get_items_schema(schema, config, definitions)?;

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -47,7 +47,7 @@ impl BuildValidator for IntValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
@@ -97,7 +97,7 @@ pub struct ConstrainedIntValidator {
 }
 
 impl ConstrainedIntValidator {
-    fn build(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Arc<CombinedValidator>> {
+    fn build(schema: &Bound<'_, PyDict>, config: &CoreConfig) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         Ok(CombinedValidator::ConstrainedInt(Self {
             strict: is_strict(schema, config)?,

--- a/src/validators/is_instance.rs
+++ b/src/validators/is_instance.rs
@@ -23,7 +23,7 @@ impl BuildValidator for IsInstanceValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/is_subclass.rs
+++ b/src/validators/is_subclass.rs
@@ -22,7 +22,7 @@ impl BuildValidator for IsSubclassValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/json.rs
+++ b/src/validators/json.rs
@@ -25,7 +25,7 @@ impl BuildValidator for JsonValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let validator = match schema.get_as(intern!(schema.py(), "schema"))? {

--- a/src/validators/json_or_python.rs
+++ b/src/validators/json_or_python.rs
@@ -23,7 +23,7 @@ impl BuildValidator for JsonOrPython {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/lax_or_strict.rs
+++ b/src/validators/lax_or_strict.rs
@@ -26,7 +26,7 @@ impl BuildValidator for LaxOrStrictValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -23,7 +23,7 @@ pub struct ListValidator {
 
 pub fn get_items_schema(
     schema: &Bound<'_, PyDict>,
-    config: Option<&Bound<'_, PyDict>>,
+    config: &CoreConfig,
     definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
 ) -> PyResult<Option<Arc<CombinedValidator>>> {
     match schema.get_item(pyo3::intern!(schema.py(), "items_schema"))? {
@@ -99,7 +99,7 @@ impl BuildValidator for ListValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -255,7 +255,7 @@ impl BuildValidator for LiteralValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let expected: Bound<PyList> = schema.get_as_req(intern!(schema.py(), "expected"))?;

--- a/src/validators/missing_sentinel.rs
+++ b/src/validators/missing_sentinel.rs
@@ -22,7 +22,7 @@ impl BuildValidator for MissingSentinelValidator {
 
     fn build(
         _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         Ok(MISSING_SENTINEL_VALIDATOR.clone())

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -49,7 +49,7 @@ impl BuildValidator for ModelFieldsValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -19,7 +19,7 @@ impl BuildValidator for NoneValidator {
 
     fn build(
         _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         Ok(NONE_VALIDATOR.clone())

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -22,7 +22,7 @@ impl BuildValidator for NullableValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let schema = schema.get_as_req(intern!(schema.py(), "schema"))?;

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -24,7 +24,7 @@ macro_rules! set_build {
     () => {
         fn build(
             schema: &Bound<'_, PyDict>,
-            config: Option<&Bound<'_, PyDict>>,
+            config: &CoreConfig,
             definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
         ) -> PyResult<Arc<CombinedValidator>> {
             let py = schema.py();

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -41,7 +41,7 @@ impl BuildValidator for StrValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let con_str_validator = StrConstrainedValidator::build(schema, config)?;
@@ -178,7 +178,7 @@ impl Validator for StrConstrainedValidator {
 }
 
 impl StrConstrainedValidator {
-    fn build(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+    fn build(schema: &Bound<'_, PyDict>, config: &CoreConfig) -> PyResult<Self> {
         let py = schema.py();
 
         let pattern = schema

--- a/src/validators/time.rs
+++ b/src/validators/time.rs
@@ -28,7 +28,7 @@ impl BuildValidator for TimeValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let s = Self {

--- a/src/validators/timedelta.rs
+++ b/src/validators/timedelta.rs
@@ -45,7 +45,7 @@ impl BuildValidator for TimeDeltaValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -28,7 +28,7 @@ impl BuildValidator for TupleValidator {
     const EXPECTED_TYPE: &'static str = "tuple";
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -47,7 +47,7 @@ impl BuildValidator for TypedDictValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
+        _config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -52,7 +52,7 @@ impl BuildValidator for UnionValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
@@ -296,7 +296,7 @@ impl BuildValidator for TaggedUnionValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -97,7 +97,7 @@ static SIMPLE_URL_VALIDATOR_STRICT_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedVal
     }))
 });
 
-fn get_preserve_empty_path(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<bool> {
+fn get_preserve_empty_path(schema: &Bound<'_, PyDict>, config: &CoreConfig) -> PyResult<bool> {
     schema_or_config(
         schema,
         config,
@@ -112,7 +112,7 @@ impl BuildValidator for UrlValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let (allowed_schemes, name) = get_allowed_schemes(schema, Self::EXPECTED_TYPE)?;
@@ -357,7 +357,7 @@ impl BuildValidator for MultiHostUrlValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let (allowed_schemes, name) = get_allowed_schemes(schema, Self::EXPECTED_TYPE)?;

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -80,7 +80,7 @@ impl BuildValidator for UuidValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();

--- a/src/validators/with_default.rs
+++ b/src/validators/with_default.rs
@@ -102,7 +102,7 @@ impl BuildValidator for WithDefaultValidator {
 
     fn build(
         schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
+        config: &CoreConfig,
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();


### PR DESCRIPTION
## Change Summary

I picked this up while exploring how to resume work on #1341 

Not complete yet, pushing for another day so I don't forget it.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
