### PR TITLE
ci: fix pydantic integration test to actually use local core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
 
       # Run pytest with lax xfail because we often add tests to pydantic
       # which xfail on a pending release of pydantic-core
-      - run: uv run pytest --override-ini=xfail_strict=False
+      - run: uv run --no-sync pytest --override-ini=xfail_strict=False
         working-directory: pydantic
         env:
           PYDANTIC_PRIVATE_ALLOW_UNHANDLED_SCHEMA_TYPES: 1


### PR DESCRIPTION
## Change Summary

I think that `uv` is currently reinstalling the released pydantic-core 😬 

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
