### PR TITLE
Reapply "Match return type of SerializationInfo.mode() to mode of model_dump() (#1770)" (#1797)

### DIFF
--- a/python/pydantic_core/core_schema.py
+++ b/python/pydantic_core/core_schema.py
@@ -145,7 +145,7 @@ class SerializationInfo(Protocol[ContextT]):
         ...
 
     @property
-    def mode(self) -> Literal['python', 'json']:
+    def mode(self) -> Literal['python', 'json'] | str:
         """The serialization mode set during serialization."""
         ...
 


### PR DESCRIPTION


This reverts commit 25b06492631f289e2689200779088a15e7f0667b.

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
