### PR TITLE
Only create class instance after validation in `ModelValidator.validate_construct()`

### DIFF
--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -300,11 +300,12 @@ impl ModelValidator {
             }
         }
 
-        let instance = create_class(self.class.bind(py))?;
+        let instance;
 
         if self.root_model {
             let state = &mut state.rebind_extra(|extra| extra.field_name = Some(PyString::new(py, ROOT_FIELD)));
             let output = self.validator.validate(py, input, state)?;
+            instance = create_class(self.class.bind(py))?;
 
             let fields_set = if input.as_python().is_some_and(|py_input| py_input.is(&self.undefined)) {
                 PySet::empty(py)?
@@ -315,6 +316,7 @@ impl ModelValidator {
             force_setattr(py, &instance, intern!(py, ROOT_FIELD), output)?;
         } else {
             let output = self.validator.validate(py, input, state)?;
+            instance = create_class(self.class.bind(py))?;
 
             let (model_dict, model_extra, val_fields_set): (Bound<PyAny>, Bound<PyAny>, Bound<PyAny>) =
                 output.extract(py)?;


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/12230.

Subtle regression in https://github.com/pydantic/pydantic-core/pull/1692.

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
