### PR TITLE
make _pydantic_core._pydantic_core pub for static linking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub fn build_info() -> String {
 }
 
 #[pymodule(gil_used = false)]
-mod _pydantic_core {
+pub mod _pydantic_core {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 


### PR DESCRIPTION
this allows linking pydantic into a pyo3 project that statically embeds cpython which is useful on target platforms without a filesystem or dynamic linking

## Change Summary

mod _pydantic_core => **pub** mod _pydantic_core

with this tiny change I can successfully build a static cpython that doesn't require dynlib to run pydantic