### PR TITLE
ci: avoid timeout on aarch64 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [aarch64, armv7, s390x, ppc64le]
+        target: [armv7, s390x, ppc64le]
         distro: ['ubuntu22.04']
         include:
           - target: aarch64
@@ -636,7 +636,7 @@ jobs:
             source $HOME/.local/bin/env
             uv sync --frozen --group testing --no-install-project
             uv pip install pydantic-core --no-index --no-deps --find-links dist --force-reinstall
-            uv run --no-sync pytest --ignore=tests/test_docstrings.py
+            uv run --no-sync pytest --ignore=tests/test_docstrings.py --hypothesis-profile=fast
             uv run --no-sync python -c 'import pydantic_core._pydantic_core; print(pydantic_core._pydantic_core.__version__)'
 
   test-builds-os:
@@ -646,7 +646,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu, ubuntu-24.04-arm, macos, windows, windows-11-arm]
 
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '**'
+      - "**"
   pull_request: {}
 
 env:
@@ -38,7 +38,7 @@ jobs:
           make build-dev
         env:
           RUST_BACKTRACE: 1
-          RUSTFLAGS: '-C instrument-coverage'
+          RUSTFLAGS: "-C instrument-coverage"
 
       - run: uv pip freeze
 
@@ -63,17 +63,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
-          - '3.14t'
-          - 'pypy3.10'
-          - 'pypy3.11'
-          - 'graalpy-3.11'
-          - 'graalpy-3.12'
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.10"
+          - "pypy3.11"
+          - "graalpy-3.11"
+          - "graalpy-3.12"
 
     runs-on: ubuntu-latest
 
@@ -189,8 +189,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.13'
-          - 'pypy3.10'
+          - "3.13"
+          - "pypy3.10"
 
     steps:
       - uses: actions/checkout@v5
@@ -274,7 +274,7 @@ jobs:
       # used to lint js code
       - uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: install uv
         uses: astral-sh/setup-uv@v6
@@ -306,7 +306,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - run: pip install typing_extensions
 
@@ -333,7 +333,7 @@ jobs:
           # NOTE!: as per https://github.com/pydantic/pydantic-core/pull/149 this version needs to match the version
           # in node_modules/pyodide/pyodide-lock.json, to get the version, run:
           # `cat node_modules/pyodide/pyodide-lock.json | jq .info.platform`
-          version: '3.1.58'
+          version: "3.1.58"
           actions-cache-folder: emsdk-cache
 
       - name: install uv
@@ -347,7 +347,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: "18"
 
       - run: npm install
 
@@ -365,7 +365,16 @@ jobs:
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
-    needs: [coverage, test-python, test-os, test-debug, lint, bench, build-wasm-emscripten]
+    needs:
+      [
+        coverage,
+        test-python,
+        test-os,
+        test-debug,
+        lint,
+        bench,
+        build-wasm-emscripten,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -381,7 +390,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist
@@ -480,7 +489,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: "3.13"
           architecture: ${{ matrix.python-architecture || 'x64' }}
 
       - run: pip install -U twine 'ruff==0.5.0' typing_extensions
@@ -511,7 +520,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, windows, macos]
-        interpreter: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t']
+        interpreter:
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         include:
           # standard runners with override for macos arm
           - os: linux
@@ -524,7 +534,7 @@ jobs:
         exclude:
           # macos arm only supported from 3.10 and up
           - os: macos
-            interpreter: '3.9'
+            interpreter: "3.9"
 
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -596,7 +606,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [armv7, s390x, ppc64le]
-        distro: ['ubuntu22.04']
+        distro: ["ubuntu22.04"]
         include:
           - target: aarch64
             distro: alpine_latest
@@ -636,7 +646,7 @@ jobs:
             source $HOME/.local/bin/env
             uv sync --frozen --group testing --no-install-project
             uv pip install pydantic-core --no-index --no-deps --find-links dist --force-reinstall
-            uv run --no-sync pytest --ignore=tests/test_docstrings.py --hypothesis-profile=fast
+            uv run --no-sync pytest --ignore=tests/test_docstrings.py
             uv run --no-sync python -c 'import pydantic_core._pydantic_core; print(pydantic_core._pydantic_core.__version__)'
 
   test-builds-os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,15 +650,22 @@ jobs:
             uv run --no-sync python -c 'import pydantic_core._pydantic_core; print(pydantic_core._pydantic_core.__version__)'
 
   test-builds-os:
-    name: test build on ${{ matrix.os }}
+    name: test build on ${{ matrix.platform.os }}
     needs: [build, build-pgo]
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, ubuntu-24.04-arm, macos, windows, windows-11-arm]
+        platform:
+          [
+            { os: linux, runs-on: ubuntu-latest },
+            { os: linux_aarch64, runs-on: ubuntu-24.04-arm },
+            { os: windows, runs-on: windows-latest },
+            { os: windows_aarch64, runs-on: windows-11-arm },
+            { os: macos, runs-on: macos-latest },
+          ]
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.platform.runs-on }}
     steps:
       - uses: actions/checkout@v5
 

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -150,6 +150,9 @@ _URL_PARSE_ERRORS = {'input is empty', 'relative URL without a base', 'empty hos
 
 
 @given(strategies.text())
+@pytest.mark.timeout(
+    300  # this is very slow on emulated alpine aarch64, https://github.com/pydantic/pydantic-core/pull/1821
+)
 @pytest.mark.thread_unsafe  # https://github.com/Quansight-Labs/pytest-run-parallel/issues/20
 def test_urls_text(url_validator, text):
     try:
@@ -167,6 +170,9 @@ def multi_host_url_validator():
 
 
 @given(strategies.text())
+@pytest.mark.timeout(
+    300  # this is very slow on emulated alpine aarch64, https://github.com/pydantic/pydantic-core/pull/1821
+)
 @pytest.mark.thread_unsafe  # https://github.com/Quansight-Labs/pytest-run-parallel/issues/20
 def test_multi_host_urls_text(multi_host_url_validator, text):
     try:


### PR DESCRIPTION
## Change Summary

At the moment we keep hitting timeout on aarch64 tests (on main).

This mitigates in two ways:
- move `aarch64` ubuntu tests onto the native arm runners
- set `hypothesis` profile to "fast" which should reduce the amount of test case depth being run on these emulated architectures

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
