### PR TITLE
fix `default_factory` which takes data on more types

### DIFF
--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -157,6 +157,8 @@ impl Validator for DataclassArgsValidator {
         let mut used_keys: AHashSet<&str> = AHashSet::with_capacity(self.fields.len());
 
         let state = &mut state.rebind_extra(|extra| extra.data = Some(output_dict.clone()));
+        let state = &mut state.scoped_set(|state| &mut state.has_field_error, false);
+
         let extra_behavior = state.extra_behavior_or(self.extra_behavior);
 
         let validate_by_alias = state.validate_by_alias_or(self.validate_by_alias);
@@ -235,6 +237,7 @@ impl Validator for DataclassArgsValidator {
                         fields_set_count += 1;
                     }
                     Err(ValError::LineErrors(line_errors)) => {
+                        state.has_field_error = true;
                         errors.extend(line_errors.into_iter().map(|err| err.with_outer_location(index)));
                     }
                     Err(err) => return Err(err),
@@ -246,6 +249,7 @@ impl Validator for DataclassArgsValidator {
                         fields_set_count += 1;
                     }
                     Err(ValError::LineErrors(line_errors)) => {
+                        state.has_field_error = true;
                         errors.extend(
                             line_errors
                                 .into_iter()
@@ -272,6 +276,7 @@ impl Validator for DataclassArgsValidator {
                         }
                         Err(ValError::Omit) => {}
                         Err(ValError::LineErrors(line_errors)) => {
+                            state.has_field_error = true;
                             for err in line_errors {
                                 // Note: this will always use the field name even if there is an alias
                                 // However, we don't mind so much because this error can only happen if the

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -179,6 +179,7 @@ impl Validator for ModelFieldsValidator {
 
         {
             let state = &mut state.rebind_extra(|extra| extra.data = Some(model_dict.clone()));
+            let state = &mut state.scoped_set(|state| &mut state.has_field_error, false);
 
             for field in &self.fields {
                 let lookup_key = field
@@ -242,6 +243,7 @@ impl Validator for ModelFieldsValidator {
                     }
                     Err(ValError::Omit) => {}
                     Err(ValError::LineErrors(line_errors)) => {
+                        state.has_field_error = true;
                         for err in line_errors {
                             // Note: this will always use the field name even if there is an alias
                             // However, we don't mind so much because this error can only happen if the


### PR DESCRIPTION
## Change Summary

Followup to #1623 

This vastly extends the tests, to cover `dataclass` and `TypedDict` as well as model, and also checks that these things behave properly in a union.

For now I keep the state around, but I think in principle we could make these container types default-aware, make them the only place to legally set a default factory which takes data, and remove the state.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
