### PR TITLE
ci: PGO-optimize linux aarch64, restore builds for windows aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
           interpreter: ${{ matrix.interpreter }}
           rust-toolchain: ${{ steps.rust-toolchain.outputs.name }}
 
-      - run: ${{ matrix.ls || 'ls -lh' }} dist/
+      - run: ${{ (startsWith(matrix.platform.os, 'windows') && 'dir') || 'ls -lh' }} dist/
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Change Summary

Better builds for the arm platforms:
- PGO optimize the linux wheels (used increasingly frequently in cloud servers, worth doing)
- restore windows wheels (similar to https://github.com/pydantic/jiter/pull/210)

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
