### PR TITLE
fix runs-on condition for linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
           # was just a dummy variable to set a default value for target
           - target: undefined
 
-    runs-on: ${{ matrix.runs-on || format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.runs-on || format('{0}-latest', (matrix.os == 'linux' && 'ubuntu') || matrix.os) }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Change Summary

Regression from #1837, not sure why CI did not prevent

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
