### PR TITLE
Correct invalid serialization of `date`/`datetime`/`time`/`timedelta` by pulling downcast checks up

### DIFF
--- a/src/serializers/type_serializers/datetime_etc.rs
+++ b/src/serializers/type_serializers/datetime_etc.rs
@@ -119,15 +119,15 @@ macro_rules! build_temporal_serializer {
                 exclude: Option<&Bound<'_, PyAny>>,
                 extra: &Extra,
             ) -> PyResult<Py<PyAny>> {
-                match extra.mode {
-                    SerMode::Json => match $downcast(value) {
-                        Ok(py_value) => Ok(self.temporal_mode.$to_json(value.py(), py_value)?),
-                        Err(_) => {
-                            extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
-                            infer_to_python(value, include, exclude, extra)
-                        }
+                match $downcast(value) {
+                    Ok(py_value) => match extra.mode {
+                        SerMode::Json => Ok(self.temporal_mode.$to_json(value.py(), py_value)?),
+                        _ => Ok(value.clone().unbind()),
                     },
-                    _ => infer_to_python(value, include, exclude, extra),
+                    _ => {
+                        extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
+                        infer_to_python(value, include, exclude, extra)
+                    }
                 }
             }
 

--- a/src/serializers/type_serializers/timedelta.rs
+++ b/src/serializers/type_serializers/timedelta.rs
@@ -50,15 +50,15 @@ impl TypeSerializer for TimeDeltaSerializer {
         exclude: Option<&Bound<'_, PyAny>>,
         extra: &Extra,
     ) -> PyResult<Py<PyAny>> {
-        match extra.mode {
-            SerMode::Json => match EitherTimedelta::try_from(value) {
-                Ok(either_timedelta) => Ok(self.temporal_mode.timedelta_to_json(value.py(), either_timedelta)?),
-                Err(_) => {
-                    extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
-                    infer_to_python(value, include, exclude, extra)
-                }
+        match EitherTimedelta::try_from(value) {
+            Ok(either_timedelta) => match extra.mode {
+                SerMode::Json => Ok(self.temporal_mode.timedelta_to_json(value.py(), either_timedelta)?),
+                _ => Ok(value.clone().unbind()),
             },
-            _ => infer_to_python(value, include, exclude, extra),
+            _ => {
+                extra.warnings.on_fallback_py(self.get_name(), value, extra)?;
+                infer_to_python(value, include, exclude, extra)
+            }
         }
     }
 


### PR DESCRIPTION
## Change Summary

Modifies the pydantic-core serializers for `date`, `datetime`, `time`, and `timedelta` such that they perform their downcast checks first prior to performing any serialization logic. This fixes incorrect serialization with certain user-defined types and correctly emits warnings where we were incorrectly doing so ebfore.

## Related issue number

Fixes pydantic/pydantic#12439

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos