### PR TITLE
fix: only percent-encode characters in the userinfo encode set

### DIFF
--- a/src/url.rs
+++ b/src/url.rs
@@ -603,9 +603,6 @@ fn is_punnycode_domain(lib_url: &Url, domain: &str) -> bool {
 }
 
 /// See <https://url.spec.whatwg.org/#userinfo-percent-encode-set>
-///
-/// Note that this doesn't actually include % itself - see the note in
-/// https://url.spec.whatwg.org/#string-percent-encode-after-encoding
 const USERINFO_ENCODE_SET: &AsciiSet = &CONTROLS
     // query percent-encodes is controls plus the below
     .add(b' ')
@@ -628,7 +625,10 @@ const USERINFO_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'[')
     .add(b'\\')
     .add(b']')
-    .add(b'|');
+    .add(b'|')
+    // https://datatracker.ietf.org/doc/html/rfc3986.html#section-2.4
+    // we must also percent-encode '%'
+    .add(b'%');
 
 fn encode_userinfo_component(value: &str) -> Cow<'_, str> {
     let encoded = percent_encode(value.as_bytes(), USERINFO_ENCODE_SET).to_string();

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -1345,11 +1345,11 @@ def test_multi_url_build_hosts_encodes_credentials() -> None:
     ]
     url = MultiHostUrl.build(scheme='postgresql', hosts=hosts)
     assert (
-        str(url) == 'postgresql://user%20name:p%40ss%2Fword%3F%23__@example.com:5431,other:p%40%ss__@example.org:5432'
+        str(url) == 'postgresql://user%20name:p%40ss%2Fword%3F%23__@example.com:5431,other:p%40%25ss__@example.org:5432'
     )
     assert url.hosts() == [
         {'username': 'user%20name', 'password': 'p%40ss%2Fword%3F%23__', 'host': 'example.com', 'port': 5431},
-        {'username': 'other', 'password': 'p%40%ss__', 'host': 'example.org', 'port': 5432},
+        {'username': 'other', 'password': 'p%40%25ss__', 'host': 'example.org', 'port': 5432},
     ]
 
 


### PR DESCRIPTION
## Change Summary

See https://github.com/pydantic/pydantic-core/pull/1829#issuecomment-3422373130

The fix released in 2.41.2 was slightly too aggressive, this corrects the character set used to match the URL spec.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
