### PR TITLE
move `model` from `Extra` to `SerializationState`

### DIFF
--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -645,6 +645,7 @@ pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
         warnings: state.warnings.clone(),
         rec_guard: state.rec_guard.clone(),
         config: extracted_serializer.config,
+        model: state.model.clone(),
         field_name: state.field_name.clone(),
         include_exclude: state.include_exclude.clone(),
     };

--- a/src/serializers/type_serializers/function.rs
+++ b/src/serializers/type_serializers/function.rs
@@ -151,7 +151,7 @@ impl FunctionPlainSerializer {
         let py = value.py();
         if self.when_used.should_use(value, extra) {
             let v = if self.is_field_serializer {
-                if let Some(model) = extra.model {
+                if let Some(model) = state.model.as_ref() {
                     if self.info_arg {
                         let info = SerializationInfo::new(state, extra, self.is_field_serializer)?;
                         self.func.call1(py, (model, value, info))?
@@ -401,7 +401,7 @@ impl FunctionWrapSerializer {
         if self.when_used.should_use(value, extra) {
             let serialize = SerializationCallable::new(&self.serializer, extra, state);
             let v = if self.is_field_serializer {
-                if let Some(model) = extra.model {
+                if let Some(model) = state.model.as_ref() {
                     if self.info_arg {
                         let info = SerializationInfo::new(state, extra, self.is_field_serializer)?;
                         self.func.call1(py, (model, value, serialize, info))?
@@ -559,7 +559,7 @@ struct SerializationInfo {
 }
 
 impl SerializationInfo {
-    fn new(state: &mut SerializationState<'_>, extra: &Extra<'_, '_>, is_field_serializer: bool) -> PyResult<Self> {
+    fn new(state: &SerializationState<'_>, extra: &Extra<'_, '_>, is_field_serializer: bool) -> PyResult<Self> {
         if is_field_serializer {
             match state.field_name.as_ref() {
                 Some(field_name) => Ok(Self {


### PR DESCRIPTION
## Change Summary

This moves `model` from `Extra` to `SerializationState`, the plan is that `Extra` should contain globally-set stuff which never needs to change.

I introduced a few FIXME comments where it seems like `model` is not being set correctly, I will investigate those and potentially fix in a follow-up. (Would prefer to have zero behaviour changes in this PR.)

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
