### PR TITLE
move `check` from `Extra` to `SerializationState`

### DIFF
--- a/src/serializers/fields.rs
+++ b/src/serializers/fields.rs
@@ -215,7 +215,7 @@ impl GeneralFieldsSerializer {
                         .filter(|_| !extra.serialize_as_any)
                         .unwrap_or_else(|| AnySerializer::get());
                     (&key, serializer)
-                } else if extra.check == SerCheck::Strict {
+                } else if state.check == SerCheck::Strict {
                     return Err(PydanticSerializationUnexpectedValue::new(
                         Some(format!("Unexpected field `{key}`")),
                         Some(key_str.to_string()),
@@ -233,7 +233,7 @@ impl GeneralFieldsSerializer {
             }
         }
 
-        if extra.check.enabled()
+        if state.check.enabled()
             // If any of these are true we can't count fields
             && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none || extra.exclude_computed_fields || state.exclude().is_some())
             // Check for missing fields, we can't have extra fields here
@@ -399,7 +399,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
         let model = state.model.clone().unwrap_or_else(|| value.clone());
 
         let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
-            state.warn_fallback_py(self.get_name(), value, extra)?;
+            state.warn_fallback_py(self.get_name(), value)?;
             return infer_to_python(value, state, extra);
         };
         let output_dict = self.main_to_python(
@@ -450,7 +450,7 @@ impl TypeSerializer for GeneralFieldsSerializer {
         extra: &Extra<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
         let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
-            state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+            state.warn_fallback_ser::<S>(self.get_name(), value)?;
             return infer_serialize(value, serializer, state, extra);
         };
         let missing_sentinel = get_missing_sentinel_object(value.py());

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -648,6 +648,7 @@ pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
         model: state.model.clone(),
         field_name: state.field_name.clone(),
         include_exclude: state.include_exclude.clone(),
+        check: state.check,
     };
 
     // Avoid falling immediately back into inference because we need to use the serializer

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -390,7 +390,7 @@ pub(crate) trait TypeSerializer: Send + Sync + Debug {
         match extra.ob_type_lookup.is_type(key, ObType::None) {
             IsType::Exact | IsType::Subclass => py_err!(PyTypeError; "`{}` not valid as object key", expected_type),
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -680,7 +680,7 @@ impl<'py> DoSerialize<'py, Py<PyAny>, PyErr> for SerializeToPython {
         state: &mut SerializationState<'py>,
         extra: &Extra<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        state.warn_fallback_py(name, value, extra)?;
+        state.warn_fallback_py(name, value)?;
         infer_to_python(value, state, extra)
     }
 }
@@ -709,9 +709,7 @@ impl<'py, S: Serializer> DoSerialize<'py, S::Ok, WrappedSerError<S::Error>> for 
         state: &mut SerializationState<'py>,
         extra: &Extra<'_, 'py>,
     ) -> Result<S::Ok, WrappedSerError<S::Error>> {
-        state
-            .warn_fallback_ser::<S>(name, value, extra)
-            .map_err(WrappedSerError)?;
+        state.warn_fallback_ser::<S>(name, value).map_err(WrappedSerError)?;
         infer_serialize(value, self.serializer, state, extra).map_err(WrappedSerError)
     }
 }

--- a/src/serializers/type_serializers/bytes.rs
+++ b/src/serializers/type_serializers/bytes.rs
@@ -82,7 +82,7 @@ impl TypeSerializer for BytesSerializer {
                 _ => Ok(value.clone().unbind()),
             },
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -97,7 +97,7 @@ impl TypeSerializer for BytesSerializer {
         match key.downcast::<PyBytes>() {
             Ok(py_bytes) => self.bytes_mode.bytes_to_string(key.py(), py_bytes.as_bytes()),
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -113,7 +113,7 @@ impl TypeSerializer for BytesSerializer {
         match value.downcast::<PyBytes>() {
             Ok(py_bytes) => self.bytes_mode.serialize_bytes(py_bytes.as_bytes(), serializer),
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/complex.rs
+++ b/src/serializers/type_serializers/complex.rs
@@ -42,7 +42,7 @@ impl TypeSerializer for ComplexSerializer {
                 _ => Ok(value.clone().unbind()),
             },
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -70,7 +70,7 @@ impl TypeSerializer for ComplexSerializer {
                 Ok(serializer.collect_str::<String>(&s)?)
             }
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/datetime_etc.rs
+++ b/src/serializers/type_serializers/datetime_etc.rs
@@ -125,7 +125,7 @@ macro_rules! build_temporal_serializer {
                         _ => Ok(value.clone().unbind()),
                     },
                     _ => {
-                        state.warn_fallback_py(self.get_name(), value, extra)?;
+                        state.warn_fallback_py(self.get_name(), value)?;
                         infer_to_python(value, state, extra)
                     }
                 }
@@ -140,7 +140,7 @@ macro_rules! build_temporal_serializer {
                 match $downcast(key) {
                     Ok(py_value) => Ok(self.temporal_mode.$json_key_fn(py_value)?),
                     Err(_) => {
-                        state.warn_fallback_py(self.get_name(), key, extra)?;
+                        state.warn_fallback_py(self.get_name(), key)?;
                         infer_json_key(key, state, extra)
                     }
                 }
@@ -156,7 +156,7 @@ macro_rules! build_temporal_serializer {
                 match $downcast(value) {
                     Ok(py_value) => self.temporal_mode.$serialize_fn(py_value, serializer),
                     Err(_) => {
-                        state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                        state.warn_fallback_ser::<S>(self.get_name(), value)?;
                         infer_serialize(value, serializer, state, extra)
                     }
                 }

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -44,7 +44,7 @@ impl TypeSerializer for DecimalSerializer {
         match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Decimal, value, state, extra),
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -59,7 +59,7 @@ impl TypeSerializer for DecimalSerializer {
         match extra.ob_type_lookup.is_type(key, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Decimal, key, state, extra),
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -75,7 +75,7 @@ impl TypeSerializer for DecimalSerializer {
         match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_serialize_known(ObType::Decimal, value, serializer, state, extra),
             IsType::False => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/dict.rs
+++ b/src/serializers/type_serializers/dict.rs
@@ -105,7 +105,7 @@ impl TypeSerializer for DictSerializer {
                 Ok(new_dict.into())
             }
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -145,7 +145,7 @@ impl TypeSerializer for DictSerializer {
                 map.end()
             }
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/enum_.rs
+++ b/src/serializers/type_serializers/enum_.rs
@@ -71,7 +71,7 @@ impl TypeSerializer for EnumSerializer {
                 Ok(value.clone().unbind())
             }
         } else {
-            state.warn_fallback_py(self.get_name(), value, extra)?;
+            state.warn_fallback_py(self.get_name(), value)?;
             infer_to_python(value, state, extra)
         }
     }
@@ -93,7 +93,7 @@ impl TypeSerializer for EnumSerializer {
             // owned variant of cow.
             Ok(Cow::Owned(k.into_owned()))
         } else {
-            state.warn_fallback_py(self.get_name(), key, extra)?;
+            state.warn_fallback_py(self.get_name(), key)?;
             infer_json_key(key, state, extra)
         }
     }
@@ -112,7 +112,7 @@ impl TypeSerializer for EnumSerializer {
                 None => infer_serialize(&dot_value, serializer, state, extra),
             }
         } else {
-            state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+            state.warn_fallback_ser::<S>(self.get_name(), value)?;
             infer_serialize(value, serializer, state, extra)
         }
     }

--- a/src/serializers/type_serializers/float.rs
+++ b/src/serializers/type_serializers/float.rs
@@ -99,7 +99,7 @@ impl TypeSerializer for FloatSerializer {
         let py = value.py();
         match extra.ob_type_lookup.is_type(value, ObType::Float) {
             IsType::Exact => Ok(value.clone().unbind()),
-            IsType::Subclass => match extra.check {
+            IsType::Subclass => match state.check {
                 SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_from_msg(None).to_py_err()),
                 SerCheck::Lax | SerCheck::None => match extra.mode {
                     SerMode::Json => value.extract::<f64>()?.into_py_any(py),
@@ -107,7 +107,7 @@ impl TypeSerializer for FloatSerializer {
                 },
             },
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -122,7 +122,7 @@ impl TypeSerializer for FloatSerializer {
         match extra.ob_type_lookup.is_type(key, ObType::Float) {
             IsType::Exact | IsType::Subclass => to_str_json_key(key),
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -139,7 +139,7 @@ impl TypeSerializer for FloatSerializer {
         match value.extract::<f64>() {
             Ok(v) => serialize_f64(v, serializer, self.inf_nan_mode),
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/generator.rs
+++ b/src/serializers/type_serializers/generator.rs
@@ -90,7 +90,7 @@ impl TypeSerializer for GeneratorSerializer {
                 }
             }
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -130,7 +130,7 @@ impl TypeSerializer for GeneratorSerializer {
                 seq.end()
             }
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/list.rs
+++ b/src/serializers/type_serializers/list.rs
@@ -75,7 +75,7 @@ impl TypeSerializer for ListSerializer {
                 items.into_py_any(py)
             }
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -116,7 +116,7 @@ impl TypeSerializer for ListSerializer {
                 seq.end()
             }
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/model.rs
+++ b/src/serializers/type_serializers/model.rs
@@ -177,7 +177,7 @@ impl ModelSerializer {
             return self.serialize_root_model(value, state, extra, do_serialize);
         }
 
-        if !self.allow_value(value, extra.check)? {
+        if !self.allow_value(value, state.check)? {
             return do_serialize.serialize_fallback(self.get_name(), value, state, extra);
         }
 
@@ -194,7 +194,7 @@ impl ModelSerializer {
         extra: &Extra<'_, 'py>,
         do_serialize: impl DoSerialize<'py, T, E>,
     ) -> Result<T, E> {
-        if !self.allow_value_root_model(value, extra.check)? {
+        if !self.allow_value_root_model(value, state.check)? {
             return do_serialize.serialize_fallback(self.get_name(), value, state, extra);
         }
 
@@ -268,10 +268,10 @@ impl TypeSerializer for ModelSerializer {
         extra: &Extra<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
         // FIXME: root model in json key position should serialize as inner value?
-        if self.allow_value(key, extra.check)? {
+        if self.allow_value(key, state.check)? {
             infer_json_key_known(ObType::PydanticSerializable, key, state, extra)
         } else {
-            state.warn_fallback_py(&self.name, key, extra)?;
+            state.warn_fallback_py(&self.name, key)?;
             infer_json_key(key, state, extra)
         }
     }

--- a/src/serializers/type_serializers/set_frozenset.rs
+++ b/src/serializers/type_serializers/set_frozenset.rs
@@ -73,7 +73,7 @@ macro_rules! build_serializer {
                         }
                     }
                     Err(_) => {
-                        state.warn_fallback_py(self.get_name(), value, extra)?;
+                        state.warn_fallback_py(self.get_name(), value)?;
                         infer_to_python(value, state, extra)
                     }
                 }
@@ -107,7 +107,7 @@ macro_rules! build_serializer {
                         seq.end()
                     }
                     Err(_) => {
-                        state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                        state.warn_fallback_ser::<S>(self.get_name(), value)?;
                         infer_serialize(value, serializer, state, extra)
                     }
                 }

--- a/src/serializers/type_serializers/string.rs
+++ b/src/serializers/type_serializers/string.rs
@@ -53,7 +53,7 @@ impl TypeSerializer for StrSerializer {
                 _ => Ok(value.clone().unbind()),
             },
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -69,7 +69,7 @@ impl TypeSerializer for StrSerializer {
             // FIXME py cow to avoid the copy
             Ok(Cow::Owned(py_str.to_string_lossy().into_owned()))
         } else {
-            state.warn_fallback_py(self.get_name(), key, extra)?;
+            state.warn_fallback_py(self.get_name(), key)?;
             infer_json_key(key, state, extra)
         }
     }
@@ -84,7 +84,7 @@ impl TypeSerializer for StrSerializer {
         match value.downcast::<PyString>() {
             Ok(py_str) => serialize_py_str(py_str, serializer),
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/timedelta.rs
+++ b/src/serializers/type_serializers/timedelta.rs
@@ -56,7 +56,7 @@ impl TypeSerializer for TimeDeltaSerializer {
                 _ => Ok(value.clone().unbind()),
             },
             _ => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -71,7 +71,7 @@ impl TypeSerializer for TimeDeltaSerializer {
         match EitherTimedelta::try_from(key) {
             Ok(either_timedelta) => self.temporal_mode.timedelta_json_key(&either_timedelta),
             Err(_) => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -87,7 +87,7 @@ impl TypeSerializer for TimeDeltaSerializer {
         match EitherTimedelta::try_from(value) {
             Ok(either_timedelta) => self.temporal_mode.timedelta_serialize(either_timedelta, serializer),
             Err(_) => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }

--- a/src/serializers/type_serializers/url.rs
+++ b/src/serializers/type_serializers/url.rs
@@ -50,7 +50,7 @@ macro_rules! build_serializer {
                         _ => Ok(value.clone().unbind()),
                     },
                     Err(_) => {
-                        state.warn_fallback_py(self.get_name(), value, extra)?;
+                        state.warn_fallback_py(self.get_name(), value)?;
                         infer_to_python(value, state, extra)
                     }
                 }
@@ -65,7 +65,7 @@ macro_rules! build_serializer {
                 match key.extract::<$extract>() {
                     Ok(py_url) => Ok(Cow::Owned(py_url.__str__(key.py()).to_string())),
                     Err(_) => {
-                        state.warn_fallback_py(self.get_name(), key, extra)?;
+                        state.warn_fallback_py(self.get_name(), key)?;
                         infer_json_key(key, state, extra)
                     }
                 }
@@ -81,7 +81,7 @@ macro_rules! build_serializer {
                 match value.extract::<$extract>() {
                     Ok(py_url) => serializer.serialize_str(&py_url.__str__(value.py())),
                     Err(_) => {
-                        state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                        state.warn_fallback_ser::<S>(self.get_name(), value)?;
                         infer_serialize(value, serializer, state, extra)
                     }
                 }

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -55,7 +55,7 @@ impl TypeSerializer for UuidSerializer {
                 _ => Ok(value.clone().unbind()),
             },
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), value, extra)?;
+                state.warn_fallback_py(self.get_name(), value)?;
                 infer_to_python(value, state, extra)
             }
         }
@@ -73,7 +73,7 @@ impl TypeSerializer for UuidSerializer {
                 Ok(Cow::Owned(str))
             }
             IsType::False => {
-                state.warn_fallback_py(self.get_name(), key, extra)?;
+                state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state, extra)
             }
         }
@@ -92,7 +92,7 @@ impl TypeSerializer for UuidSerializer {
                 serializer.serialize_str(&s)
             }
             IsType::False => {
-                state.warn_fallback_ser::<S>(self.get_name(), value, extra)?;
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
                 infer_serialize(value, serializer, state, extra)
             }
         }


### PR DESCRIPTION
## Change Summary

The last value in `Extra` which changes, now moved to `SerializationState`.

With this done, I can make a follow-up where `Extra` becomes a constant value inside `SerializationState`, which will mean only `state` needs to get passed around and everything possibly relevant is contained within it.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
