### PR TITLE
move `extra` inside of `state`

### DIFF
--- a/src/serializers/filter.rs
+++ b/src/serializers/filter.rs
@@ -95,7 +95,7 @@ impl SchemaFilter<usize> {
     pub fn index_filter<'py>(
         &self,
         index: usize,
-        state: &SerializationState<'py>,
+        state: &SerializationState<'_, 'py>,
         len: Option<usize>,
     ) -> PyResult<NextFilters<'py>> {
         let include = state.include().map(|v| map_negative_indices(v, len)).transpose()?;
@@ -133,7 +133,7 @@ impl SchemaFilter<isize> {
     pub fn key_filter<'py>(
         &self,
         key: &Bound<'py, PyAny>,
-        state: &SerializationState<'py>,
+        state: &SerializationState<'_, 'py>,
     ) -> PyResult<NextFilters<'py>> {
         let hash = key.hash()?;
         self.filter(key, hash, state.include(), state.exclude())
@@ -266,7 +266,7 @@ impl AnyFilter {
     pub fn key_filter<'py>(
         &self,
         key: &Bound<'py, PyAny>,
-        state: &SerializationState<'py>,
+        state: &SerializationState<'_, 'py>,
     ) -> PyResult<NextFilters<'py>> {
         // just use 0 for the int_key, it's always ignored in the implementation here
         self.filter(key, 0, state.include(), state.exclude())
@@ -275,7 +275,7 @@ impl AnyFilter {
     pub fn index_filter<'py>(
         &self,
         index: usize,
-        state: &SerializationState<'py>,
+        state: &SerializationState<'_, 'py>,
         len: Option<usize>,
     ) -> PyResult<NextFilters<'py>> {
         let include = state.include().map(|v| map_negative_indices(v, len)).transpose()?;

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -23,7 +23,7 @@ use crate::url::{PyMultiHostUrl, PyUrl};
 use super::config::InfNanMode;
 use super::errors::SERIALIZATION_ERR_MARKER;
 use super::errors::{py_err_se_err, PydanticSerializationError};
-use super::extra::{Extra, SerMode};
+use super::extra::SerMode;
 use super::filter::{AnyFilter, SchemaFilter};
 use super::ob_type::ObType;
 use super::shared::any_dataclass_iter;
@@ -31,10 +31,9 @@ use super::SchemaSerializer;
 
 pub(crate) fn infer_to_python<'py>(
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> PyResult<Py<PyAny>> {
-    infer_to_python_known(extra.ob_type_lookup.get_type(value), value, state, extra)
+    infer_to_python_known(state.extra.ob_type_lookup.get_type(value), value, state)
 }
 
 // arbitrary ids to identify that we recursed through infer_to_{python,json}_known
@@ -44,12 +43,11 @@ const INFER_DEF_REF_ID: usize = usize::MAX;
 pub(crate) fn infer_to_python_known<'py>(
     ob_type: ObType,
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> PyResult<Py<PyAny>> {
     let py = value.py();
 
-    let mode = extra.mode;
+    let mode = state.extra.mode;
     let mut guard = match state.recursion_guard(value, INFER_DEF_REF_ID) {
         Ok(v) => v,
         Err(e) => {
@@ -68,7 +66,7 @@ pub(crate) fn infer_to_python_known<'py>(
             value
                 .downcast::<$t>()?
                 .iter()
-                .map(|v| infer_to_python(&v, state, extra))
+                .map(|v| infer_to_python(&v, state))
                 .collect::<PyResult<Vec<Py<PyAny>>>>()?
         }};
     }
@@ -84,14 +82,14 @@ pub(crate) fn infer_to_python_known<'py>(
                 let op_next = filter.index_filter(index, state, len)?;
                 if let Some((next_include, next_exclude)) = op_next {
                     let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    items.push(infer_to_python(&element, state, extra)?);
+                    items.push(infer_to_python(&element, state)?);
                 }
             }
             items
         }};
     }
 
-    let value = match extra.mode {
+    let value = match state.extra.mode {
         SerMode::Json => match ob_type {
             // `bool` and `None` can't be subclasses, `ObType::Int`, `ObType::Float`, `ObType::Str` refer to exact types
             ObType::None | ObType::Bool | ObType::Int | ObType::Str => value.clone().unbind(),
@@ -146,8 +144,8 @@ pub(crate) fn infer_to_python_known<'py>(
             }
             ObType::Dict => {
                 let dict = value.downcast::<PyDict>()?;
-                serialize_pairs_python(py, dict.iter().map(Ok), state, extra, |k, state| {
-                    Ok(PyString::new(py, &infer_json_key(&k, state, extra)?).into_any())
+                serialize_pairs_python(py, dict.iter().map(Ok), state, |k, state| {
+                    Ok(PyString::new(py, &infer_json_key(&k, state)?).into_any())
                 })?
             }
             ObType::Datetime => {
@@ -181,13 +179,13 @@ pub(crate) fn infer_to_python_known<'py>(
                 let uuid = super::type_serializers::uuid::uuid_to_string(value)?;
                 uuid.into_py_any(py)?
             }
-            ObType::PydanticSerializable => call_pydantic_serializer(value, state, extra, serialize_to_python())?,
-            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, extra, |k, state| {
-                Ok(PyString::new(py, &infer_json_key(&k, state, extra)?).into_any())
+            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python())?,
+            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, |k, state| {
+                Ok(PyString::new(py, &infer_json_key(&k, state)?).into_any())
             })?,
             ObType::Enum => {
                 let v = value.getattr(intern!(py, "value"))?;
-                infer_to_python(&v, state, extra)?
+                infer_to_python(&v, state)?
             }
             ObType::Generator => {
                 let py_seq = value.downcast::<PyIterator>()?;
@@ -199,7 +197,7 @@ pub(crate) fn infer_to_python_known<'py>(
                     let op_next = filter.index_filter(index, state, None)?;
                     if let Some((next_include, next_exclude)) = op_next {
                         let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                        items.push(infer_to_python(&element, state, extra)?);
+                        items.push(infer_to_python(&element, state)?);
                     }
                 }
                 PyList::new(py, items)?.into()
@@ -212,11 +210,11 @@ pub(crate) fn infer_to_python_known<'py>(
             ObType::Path => value.str()?.into_py_any(py)?,
             ObType::Pattern => value.getattr(intern!(py, "pattern"))?.unbind(),
             ObType::Unknown => {
-                if let Some(fallback) = extra.fallback {
+                if let Some(fallback) = state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
-                    let next_result = infer_to_python(&next_value, state, extra);
+                    let next_result = infer_to_python(&next_value, state);
                     return next_result;
-                } else if extra.serialize_unknown {
+                } else if state.extra.serialize_unknown {
                     serialize_unknown(value).into_py_any(py)?
                 } else {
                     return Err(unknown_type_error(value));
@@ -242,17 +240,16 @@ pub(crate) fn infer_to_python_known<'py>(
             }
             ObType::Dict => {
                 let dict = value.downcast::<PyDict>()?;
-                serialize_pairs_python(py, dict.iter().map(Ok), state, extra, |k, _| Ok(k))?
+                serialize_pairs_python(py, dict.iter().map(Ok), state, |k, _| Ok(k))?
             }
-            ObType::PydanticSerializable => call_pydantic_serializer(value, state, extra, serialize_to_python())?,
-            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, extra, |k, _| Ok(k))?,
+            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python())?,
+            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, |k, _| Ok(k))?,
             ObType::Generator => {
                 let iter = super::type_serializers::generator::SerializationIterator::new(
                     value.downcast()?,
                     super::type_serializers::any::AnySerializer::get(),
                     SchemaFilter::default(),
                     state,
-                    extra,
                 );
                 iter.into_py_any(py)?
             }
@@ -261,9 +258,9 @@ pub(crate) fn infer_to_python_known<'py>(
                 v.into_py_any(py)?
             }
             ObType::Unknown => {
-                if let Some(fallback) = extra.fallback {
+                if let Some(fallback) = state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
-                    let next_result = infer_to_python(&next_value, state, extra);
+                    let next_result = infer_to_python(&next_value, state);
                     return next_result;
                 }
                 value.clone().unbind()
@@ -274,51 +271,43 @@ pub(crate) fn infer_to_python_known<'py>(
     Ok(value)
 }
 
-pub(crate) struct SerializeInfer<'slf, 'py> {
+pub(crate) struct SerializeInfer<'slf, 'a, 'py> {
     value: &'slf Bound<'py, PyAny>,
-    state: RefCell<&'slf mut SerializationState<'py>>,
-    extra: &'slf Extra<'slf, 'py>,
+    state: RefCell<&'slf mut SerializationState<'a, 'py>>,
 }
 
-impl<'slf, 'py> SerializeInfer<'slf, 'py> {
-    pub(crate) fn new(
-        value: &'slf Bound<'py, PyAny>,
-        state: &'slf mut SerializationState<'py>,
-        extra: &'slf Extra<'slf, 'py>,
-    ) -> Self {
+impl<'slf, 'a, 'py> SerializeInfer<'slf, 'a, 'py> {
+    pub(crate) fn new(value: &'slf Bound<'py, PyAny>, state: &'slf mut SerializationState<'a, 'py>) -> Self {
         Self {
             value,
             state: RefCell::new(state),
-            extra,
         }
     }
 }
 
-impl Serialize for SerializeInfer<'_, '_> {
+impl Serialize for SerializeInfer<'_, '_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let ob_type = self.extra.ob_type_lookup.get_type(self.value);
         let state = &mut self.state.borrow_mut();
-        infer_serialize_known(ob_type, self.value, serializer, state, self.extra)
+        let ob_type = state.extra.ob_type_lookup.get_type(self.value);
+        infer_serialize_known(ob_type, self.value, serializer, state)
     }
 }
 
 pub(crate) fn infer_serialize<'py, S: Serializer>(
     value: &Bound<'py, PyAny>,
     serializer: S,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> Result<S::Ok, S::Error> {
-    infer_serialize_known(extra.ob_type_lookup.get_type(value), value, serializer, state, extra)
+    infer_serialize_known(state.extra.ob_type_lookup.get_type(value), value, serializer, state)
 }
 
 pub(crate) fn infer_serialize_known<'py, S: Serializer>(
     ob_type: ObType,
     value: &Bound<'py, PyAny>,
     serializer: S,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> Result<S::Ok, S::Error> {
-    let extra_serialize_unknown = extra.serialize_unknown;
+    let extra_serialize_unknown = state.extra.serialize_unknown;
     let mut guard = match state.recursion_guard(value, INFER_DEF_REF_ID) {
         Ok(v) => v,
         Err(e) => {
@@ -346,7 +335,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             let py_seq = value.downcast::<$t>().map_err(py_err_se_err)?;
             let mut seq = serializer.serialize_seq(Some(py_seq.len()))?;
             for element in py_seq.iter() {
-                let item_serializer = SerializeInfer::new(&element, state, extra);
+                let item_serializer = SerializeInfer::new(&element, state);
                 seq.serialize_element(&item_serializer)?
             }
             seq.end()
@@ -364,7 +353,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
                 let op_next = filter.index_filter(index, state, len).map_err(py_err_se_err)?;
                 if let Some((next_include, next_exclude)) = op_next {
                     let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    let item_serializer = SerializeInfer::new(&element, state, extra);
+                    let item_serializer = SerializeInfer::new(&element, state);
                     seq.serialize_element(&item_serializer)?
                 }
             }
@@ -407,7 +396,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
         }
         ObType::Dict => {
             let dict = value.downcast::<PyDict>().map_err(py_err_se_err)?;
-            serialize_pairs_json(dict.iter().map(Ok), dict.len(), serializer, state, extra)
+            serialize_pairs_json(dict.iter().map(Ok), dict.len(), serializer, state)
         }
         ObType::List => serialize_seq_filter!(PyList),
         ObType::Tuple => serialize_seq_filter!(PyTuple),
@@ -438,11 +427,11 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             serializer.serialize_str(&py_url.__str__(value.py()))
         }
         ObType::PydanticSerializable => {
-            call_pydantic_serializer(value, state, extra, serialize_to_json(serializer)).map_err(|e| e.0)
+            call_pydantic_serializer(value, state, serialize_to_json(serializer)).map_err(|e| e.0)
         }
         ObType::Dataclass => {
             let (pairs_iter, fields_dict) = any_dataclass_iter(value).map_err(py_err_se_err)?;
-            serialize_pairs_json(pairs_iter, fields_dict.len(), serializer, state, extra)
+            serialize_pairs_json(pairs_iter, fields_dict.len(), serializer, state)
         }
         ObType::Uuid => {
             let uuid = super::type_serializers::uuid::uuid_to_string(value).map_err(py_err_se_err)?;
@@ -450,7 +439,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
         }
         ObType::Enum => {
             let v = value.getattr(intern!(value.py(), "value")).map_err(py_err_se_err)?;
-            infer_serialize(&v, serializer, state, extra)
+            infer_serialize(&v, serializer, state)
         }
         ObType::Generator => {
             let py_seq = value.downcast::<PyIterator>().map_err(py_err_se_err)?;
@@ -461,7 +450,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
                 let op_next = filter.index_filter(index, state, None).map_err(py_err_se_err)?;
                 if let Some((next_include, next_exclude)) = op_next {
                     let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    let item_serializer = SerializeInfer::new(&element, state, extra);
+                    let item_serializer = SerializeInfer::new(&element, state);
                     seq.serialize_element(&item_serializer)?;
                 }
             }
@@ -482,11 +471,11 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             serializer.serialize_str(&s)
         }
         ObType::Unknown => {
-            if let Some(fallback) = extra.fallback {
+            if let Some(fallback) = state.extra.fallback {
                 let next_value = fallback.call1((value,)).map_err(py_err_se_err)?;
-                let next_result = infer_serialize(&next_value, serializer, state, extra);
+                let next_result = infer_serialize(&next_value, serializer, state);
                 return next_result;
-            } else if extra.serialize_unknown {
+            } else if state.extra.serialize_unknown {
                 serializer.serialize_str(&serialize_unknown(value))
             } else {
                 let msg = format!(
@@ -520,18 +509,16 @@ fn serialize_unknown<'py>(value: &Bound<'py, PyAny>) -> Cow<'py, str> {
 
 pub(crate) fn infer_json_key<'a, 'py>(
     key: &'a Bound<'py, PyAny>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> PyResult<Cow<'a, str>> {
-    let ob_type = extra.ob_type_lookup.get_type(key);
-    infer_json_key_known(ob_type, key, state, extra)
+    let ob_type = state.extra.ob_type_lookup.get_type(key);
+    infer_json_key_known(ob_type, key, state)
 }
 
 pub(crate) fn infer_json_key_known<'a, 'py>(
     ob_type: ObType,
     key: &'a Bound<'py, PyAny>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> PyResult<Cow<'a, str>> {
     match ob_type {
         ObType::None => super::type_serializers::simple::none_json_key(),
@@ -585,7 +572,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
         ObType::Tuple => {
             let mut key_build = super::type_serializers::tuple::KeyBuilder::new();
             for element in key.downcast::<PyTuple>()?.iter_borrowed() {
-                key_build.push(&infer_json_key(&element, state, extra)?);
+                key_build.push(&infer_json_key(&element, state)?);
             }
             Ok(Cow::Owned(key_build.finish()))
         }
@@ -600,7 +587,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
         }
         ObType::Enum => {
             let k = key.getattr(intern!(key.py(), "value"))?;
-            infer_json_key(&k, state, extra).map(|cow| Cow::Owned(cow.into_owned()))
+            infer_json_key(&k, state).map(|cow| Cow::Owned(cow.into_owned()))
         }
         ObType::Path => {
             // FIXME it would be nice to have a "PyCow" which carries ownership of the Python type too
@@ -617,10 +604,10 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
                 .into_owned(),
         )),
         ObType::Unknown => {
-            if let Some(fallback) = extra.fallback {
+            if let Some(fallback) = state.extra.fallback {
                 let next_key = fallback.call1((key,))?;
-                infer_json_key(&next_key, state, extra).map(|cow| Cow::Owned(cow.into_owned()))
-            } else if extra.serialize_unknown {
+                infer_json_key(&next_key, state).map(|cow| Cow::Owned(cow.into_owned()))
+            } else if state.extra.serialize_unknown {
                 Ok(serialize_unknown(key))
             } else {
                 Err(unknown_type_error(key))
@@ -634,8 +621,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
 /// `do_serialize` should be a closure which performs serialization without type inference
 pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
     do_serialize: impl DoSerialize<'py, T, E>,
 ) -> Result<T, E> {
     let py = value.py();
@@ -649,19 +635,19 @@ pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
         field_name: state.field_name.clone(),
         include_exclude: state.include_exclude.clone(),
         check: state.check,
+        extra: state.extra.clone(),
     };
 
     // Avoid falling immediately back into inference because we need to use the serializer
     // to drive the next step of serialization
-    do_serialize.serialize_no_infer(&extracted_serializer.serializer, value, &mut state, extra)
+    do_serialize.serialize_no_infer(&extracted_serializer.serializer, value, &mut state)
 }
 
 fn serialize_pairs_python<'py>(
     py: Python,
     pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
-    key_transform: impl Fn(Bound<'py, PyAny>, &mut SerializationState<'py>) -> PyResult<Bound<'py, PyAny>>,
+    state: &mut SerializationState<'_, 'py>,
+    key_transform: impl Fn(Bound<'py, PyAny>, &mut SerializationState<'_, 'py>) -> PyResult<Bound<'py, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let new_dict = PyDict::new(py);
     let filter = AnyFilter::new();
@@ -672,7 +658,7 @@ fn serialize_pairs_python<'py>(
         if let Some((next_include, next_exclude)) = op_next {
             let state = &mut state.scoped_include_exclude(next_include, next_exclude);
             let k = key_transform(k, state)?;
-            let v = infer_to_python(&v, state, extra)?;
+            let v = infer_to_python(&v, state)?;
             new_dict.set_item(k, v)?;
         }
     }
@@ -683,8 +669,7 @@ fn serialize_pairs_json<'py, S: Serializer>(
     pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
     iter_size: usize,
     serializer: S,
-    state: &mut SerializationState<'py>,
-    extra: &Extra<'_, 'py>,
+    state: &mut SerializationState<'_, 'py>,
 ) -> Result<S::Ok, S::Error> {
     let mut map = serializer.serialize_map(Some(iter_size))?;
     let filter = AnyFilter::new();
@@ -695,8 +680,8 @@ fn serialize_pairs_json<'py, S: Serializer>(
         let op_next = filter.key_filter(&key, state).map_err(py_err_se_err)?;
         if let Some((next_include, next_exclude)) = op_next {
             let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-            let key = infer_json_key(&key, state, extra).map_err(py_err_se_err)?;
-            let value_serializer = SerializeInfer::new(&value, state, extra);
+            let key = infer_json_key(&key, state).map_err(py_err_se_err)?;
+            let value_serializer = SerializeInfer::new(&value, state);
             map.serialize_entry(&key, &value_serializer)?;
         }
     }

--- a/src/serializers/prebuilt.rs
+++ b/src/serializers/prebuilt.rs
@@ -7,7 +7,6 @@ use crate::common::prebuilt::get_prebuilt;
 use crate::serializers::SerializationState;
 use crate::SchemaSerializer;
 
-use super::extra::Extra;
 use super::shared::{CombinedSerializer, TypeSerializer};
 
 #[derive(Debug)]
@@ -36,38 +35,29 @@ impl TypeSerializer for PrebuiltSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        self.schema_serializer
-            .get()
-            .serializer
-            .to_python_no_infer(value, state, extra)
+        self.schema_serializer.get().serializer.to_python_no_infer(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.schema_serializer
-            .get()
-            .serializer
-            .json_key_no_infer(key, state, extra)
+        self.schema_serializer.get().serializer.json_key_no_infer(key, state)
     }
 
     fn serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
         self.schema_serializer
             .get()
             .serializer
-            .serde_serialize_no_infer(value, serializer, state, extra)
+            .serde_serialize_no_infer(value, serializer, state)
     }
 
     fn get_name(&self) -> &str {

--- a/src/serializers/type_serializers/any.rs
+++ b/src/serializers/type_serializers/any.rs
@@ -10,9 +10,7 @@ use serde::ser::Serializer;
 
 use crate::{definitions::DefinitionsBuilder, serializers::SerializationState};
 
-use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, TypeSerializer,
-};
+use super::{infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, TypeSerializer};
 
 #[derive(Debug, Clone, Default)]
 pub struct AnySerializer;
@@ -42,29 +40,26 @@ impl TypeSerializer for AnySerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        infer_to_python(value, state, extra)
+        infer_to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        infer_json_key(key, state, extra)
+        infer_json_key(key, state)
     }
 
     fn serde_serialize<'py, S: Serializer>(
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
-        infer_serialize(value, serializer, state, extra)
+        infer_serialize(value, serializer, state)
     }
 
     fn get_name(&self) -> &str {

--- a/src/serializers/type_serializers/decimal.rs
+++ b/src/serializers/type_serializers/decimal.rs
@@ -10,9 +10,7 @@ use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, inf
 use crate::serializers::ob_type::{IsType, ObType};
 use crate::serializers::SerializationState;
 
-use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, Extra, TypeSerializer,
-};
+use super::{infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, TypeSerializer};
 
 #[derive(Debug)]
 pub struct DecimalSerializer {}
@@ -37,15 +35,14 @@ impl TypeSerializer for DecimalSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
         let _py = value.py();
-        match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
-            IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Decimal, value, state, extra),
+        match state.extra.ob_type_lookup.is_type(value, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Decimal, value, state),
             IsType::False => {
                 state.warn_fallback_py(self.get_name(), value)?;
-                infer_to_python(value, state, extra)
+                infer_to_python(value, state)
             }
         }
     }
@@ -53,14 +50,13 @@ impl TypeSerializer for DecimalSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        match extra.ob_type_lookup.is_type(key, ObType::Decimal) {
-            IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Decimal, key, state, extra),
+        match state.extra.ob_type_lookup.is_type(key, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Decimal, key, state),
             IsType::False => {
                 state.warn_fallback_py(self.get_name(), key)?;
-                infer_json_key(key, state, extra)
+                infer_json_key(key, state)
             }
         }
     }
@@ -69,14 +65,13 @@ impl TypeSerializer for DecimalSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
-        match extra.ob_type_lookup.is_type(value, ObType::Decimal) {
-            IsType::Exact | IsType::Subclass => infer_serialize_known(ObType::Decimal, value, serializer, state, extra),
+        match state.extra.ob_type_lookup.is_type(value, ObType::Decimal) {
+            IsType::Exact | IsType::Subclass => infer_serialize_known(ObType::Decimal, value, serializer, state),
             IsType::False => {
                 state.warn_fallback_ser::<S>(self.get_name(), value)?;
-                infer_serialize(value, serializer, state, extra)
+                infer_serialize(value, serializer, state)
             }
         }
     }

--- a/src/serializers/type_serializers/definitions.rs
+++ b/src/serializers/type_serializers/definitions.rs
@@ -12,7 +12,7 @@ use crate::definitions::{DefinitionRef, RecursionSafeCache};
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
-use super::{py_err_se_err, BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
+use super::{py_err_se_err, BuildSerializer, CombinedSerializer, TypeSerializer};
 
 #[derive(Debug)]
 pub struct DefinitionsSerializerBuilder;
@@ -79,39 +79,35 @@ impl TypeSerializer for DefinitionRefSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
         self.definition.read(|comb_serializer| {
             let comb_serializer = comb_serializer.unwrap();
             let mut guard = state.recursion_guard(value, self.definition.id())?;
-            comb_serializer.to_python_no_infer(value, guard.state(), extra)
+            comb_serializer.to_python_no_infer(value, guard.state())
         })
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.definition
-            .read(|s| s.unwrap().json_key_no_infer(key, state, extra))
+        self.definition.read(|s| s.unwrap().json_key_no_infer(key, state))
     }
 
     fn serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
         self.definition.read(|comb_serializer| {
             let comb_serializer = comb_serializer.unwrap();
             let mut guard = state
                 .recursion_guard(value, self.definition.id())
                 .map_err(py_err_se_err)?;
-            comb_serializer.serde_serialize_no_infer(value, serializer, guard.state(), extra)
+            comb_serializer.serde_serialize_no_infer(value, serializer, guard.state())
         })
     }
 

--- a/src/serializers/type_serializers/json.rs
+++ b/src/serializers/type_serializers/json.rs
@@ -15,8 +15,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_json_key, py_err_se_err, to_json_bytes, utf8_py_error, BuildSerializer, CombinedSerializer, Extra,
-    TypeSerializer,
+    infer_json_key, py_err_se_err, to_json_bytes, utf8_py_error, BuildSerializer, CombinedSerializer, TypeSerializer,
 };
 
 #[derive(Debug)]
@@ -48,32 +47,30 @@ impl TypeSerializer for JsonSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        if extra.round_trip {
-            let bytes = to_json_bytes(value, &self.serializer, state, extra, None, false, 0)?;
+        if state.extra.round_trip {
+            let bytes = to_json_bytes(value, &self.serializer, state, None, false, 0)?;
             let py = value.py();
             let s = from_utf8(&bytes).map_err(|e| utf8_py_error(py, e, &bytes))?;
             Ok(PyString::new(py, s).into())
         } else {
-            self.serializer.to_python(value, state, extra)
+            self.serializer.to_python(value, state)
         }
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        if extra.round_trip {
-            let bytes = to_json_bytes(key, &self.serializer, state, extra, None, false, 0)?;
+        if state.extra.round_trip {
+            let bytes = to_json_bytes(key, &self.serializer, state, None, false, 0)?;
             let py = key.py();
             let s = from_utf8(&bytes).map_err(|e| utf8_py_error(py, e, &bytes))?;
             Ok(Cow::Owned(s.to_string()))
         } else {
-            infer_json_key(key, state, extra)
+            infer_json_key(key, state)
         }
     }
 
@@ -81,17 +78,16 @@ impl TypeSerializer for JsonSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
-        if extra.round_trip {
-            let bytes = to_json_bytes(value, &self.serializer, state, extra, None, false, 0).map_err(py_err_se_err)?;
+        if state.extra.round_trip {
+            let bytes = to_json_bytes(value, &self.serializer, state, None, false, 0).map_err(py_err_se_err)?;
             match from_utf8(&bytes) {
                 Ok(s) => serializer.serialize_str(s),
                 Err(e) => Err(Error::custom(e.to_string())),
             }
         } else {
-            self.serializer.serde_serialize(value, serializer, state, extra)
+            self.serializer.serde_serialize(value, serializer, state)
         }
     }
 

--- a/src/serializers/type_serializers/json_or_python.rs
+++ b/src/serializers/type_serializers/json_or_python.rs
@@ -5,7 +5,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
@@ -48,29 +48,26 @@ impl TypeSerializer for JsonOrPythonSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        self.python.to_python(value, state, extra)
+        self.python.to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.json.json_key(key, state, extra)
+        self.json.json_key(key, state)
     }
 
     fn serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
-        self.json.serde_serialize(value, serializer, state, extra)
+        self.json.serde_serialize(value, serializer, state)
     }
 
     fn get_name(&self) -> &str {

--- a/src/serializers/type_serializers/literal.rs
+++ b/src/serializers/type_serializers/literal.rs
@@ -15,8 +15,8 @@ use crate::serializers::SerializationState;
 use crate::tools::{extract_i64, SchemaDict};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, Extra,
-    SerMode, TypeSerializer,
+    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, SerMode,
+    TypeSerializer,
 };
 
 #[derive(Debug)]
@@ -81,7 +81,7 @@ enum OutputValue<'py> {
 }
 
 impl LiteralSerializer {
-    fn check<'py>(&self, value: &Bound<'py, PyAny>, state: &SerializationState<'py>) -> PyResult<OutputValue<'py>> {
+    fn check<'py>(&self, value: &Bound<'py, PyAny>, state: &SerializationState<'_, 'py>) -> PyResult<OutputValue<'py>> {
         if state.check.enabled() {
             if !self.expected_int.is_empty() && !value.is_instance_of::<PyBool>() {
                 if let Some(int) = extract_i64(value) {
@@ -117,23 +117,22 @@ impl TypeSerializer for LiteralSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match self.check(value, state)? {
-            OutputValue::OkInt(int) => match extra.mode {
+            OutputValue::OkInt(int) => match state.extra.mode {
                 SerMode::Json => int.into_py_any(py),
                 _ => Ok(value.clone().unbind()),
             },
-            OutputValue::OkStr(s) => match extra.mode {
+            OutputValue::OkStr(s) => match state.extra.mode {
                 SerMode::Json => Ok(s.into()),
                 _ => Ok(value.clone().unbind()),
             },
-            OutputValue::Ok => infer_to_python(value, state, extra),
+            OutputValue::Ok => infer_to_python(value, state),
             OutputValue::Fallback => {
                 state.warn_fallback_py(self.get_name(), value)?;
-                infer_to_python(value, state, extra)
+                infer_to_python(value, state)
             }
         }
     }
@@ -141,16 +140,15 @@ impl TypeSerializer for LiteralSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
         match self.check(key, state)? {
             OutputValue::OkInt(int) => Ok(Cow::Owned(int.to_string())),
             OutputValue::OkStr(s) => Ok(Cow::Owned(s.to_string_lossy().into_owned())),
-            OutputValue::Ok => infer_json_key(key, state, extra),
+            OutputValue::Ok => infer_json_key(key, state),
             OutputValue::Fallback => {
                 state.warn_fallback_py(self.get_name(), key)?;
-                infer_json_key(key, state, extra)
+                infer_json_key(key, state)
             }
         }
     }
@@ -159,16 +157,15 @@ impl TypeSerializer for LiteralSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
         match self.check(value, state).map_err(py_err_se_err)? {
             OutputValue::OkInt(int) => int.serialize(serializer),
             OutputValue::OkStr(s) => s.to_string_lossy().serialize(serializer),
-            OutputValue::Ok => infer_serialize(value, serializer, state, extra),
+            OutputValue::Ok => infer_serialize(value, serializer, state),
             OutputValue::Fallback => {
                 state.warn_fallback_ser::<S>(self.get_name(), value)?;
-                infer_serialize(value, serializer, state, extra)
+                infer_serialize(value, serializer, state)
             }
         }
     }

--- a/src/serializers/type_serializers/with_default.rs
+++ b/src/serializers/type_serializers/with_default.rs
@@ -10,7 +10,7 @@ use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 use crate::validators::DefaultType;
 
-use super::{BuildSerializer, CombinedSerializer, Extra, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
 
 #[derive(Debug)]
 pub struct WithDefaultSerializer {
@@ -42,29 +42,26 @@ impl TypeSerializer for WithDefaultSerializer {
     fn to_python<'py>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Py<PyAny>> {
-        self.serializer.to_python(value, state, extra)
+        self.serializer.to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.serializer.json_key(key, state, extra)
+        self.serializer.json_key(key, state)
     }
 
     fn serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'py>,
-        extra: &Extra<'_, 'py>,
+        state: &mut SerializationState<'_, 'py>,
     ) -> Result<S::Ok, S::Error> {
-        self.serializer.serde_serialize(value, serializer, state, extra)
+        self.serializer.serde_serialize(value, serializer, state)
     }
 
     fn get_name(&self) -> &str {


### PR DESCRIPTION
## Change Summary

This moves `Extra` inside of `SerializationState`, completing the refactoring I started with #1857, and now matching the validation code where it's `&mut State` which is passed around the place.

Another reduction in LOC and complexity :tada:

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
