### PR TITLE
add type inference for serializing ip address types

### DIFF
--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -167,9 +167,13 @@ pub(crate) fn infer_to_python_known<'py>(
                 let either_delta = EitherTimedelta::try_from(value)?;
                 state.config.temporal_mode.timedelta_to_json(value.py(), either_delta)?
             }
-            ObType::Url | ObType::MultiHostUrl | ObType::Path | ObType::Ipv4Address | ObType::Ipv6Address => {
-                serialize_via_str(value, serialize_to_python())?
-            }
+            ObType::Url
+            | ObType::MultiHostUrl
+            | ObType::Path
+            | ObType::Ipv4Address
+            | ObType::Ipv6Address
+            | ObType::Ipv4Network
+            | ObType::Ipv6Network => serialize_via_str(value, serialize_to_python())?,
             ObType::Uuid => {
                 let uuid = super::type_serializers::uuid::uuid_to_string(value)?;
                 uuid.into_py_any(py)?
@@ -414,9 +418,13 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             let either_delta = EitherTimedelta::try_from(value).map_err(py_err_se_err)?;
             state.config.temporal_mode.timedelta_serialize(either_delta, serializer)
         }
-        ObType::Url | ObType::MultiHostUrl | ObType::Path | ObType::Ipv4Address | ObType::Ipv6Address => {
-            serialize_via_str(value, serialize_to_json(serializer)).map_err(unwrap_ser_error)
-        }
+        ObType::Url
+        | ObType::MultiHostUrl
+        | ObType::Path
+        | ObType::Ipv4Address
+        | ObType::Ipv6Address
+        | ObType::Ipv4Network
+        | ObType::Ipv6Network => serialize_via_str(value, serialize_to_json(serializer)).map_err(unwrap_ser_error),
         ObType::PydanticSerializable => {
             call_pydantic_serializer(value, state, serialize_to_json(serializer)).map_err(unwrap_ser_error)
         }
@@ -547,7 +555,13 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
             let either_delta = EitherTimedelta::try_from(key)?;
             state.config.temporal_mode.timedelta_json_key(&either_delta)
         }
-        ObType::Url | ObType::MultiHostUrl | ObType::Path | ObType::Ipv4Address | ObType::Ipv6Address => {
+        ObType::Url
+        | ObType::MultiHostUrl
+        | ObType::Path
+        | ObType::Ipv4Address
+        | ObType::Ipv6Address
+        | ObType::Ipv4Network
+        | ObType::Ipv6Network => {
             // FIXME it would be nice to have a "PyCow" which carries ownership of the Python type too
             Ok(Cow::Owned(key.str()?.to_string_lossy().into_owned()))
         }

--- a/src/serializers/ob_type.rs
+++ b/src/serializers/ob_type.rs
@@ -53,6 +53,8 @@ pub struct ObTypeLookup {
     // ip address types
     ipv4_address: Py<PyAny>,
     ipv6_address: Py<PyAny>,
+    ipv4_network: Py<PyAny>,
+    ipv6_network: Py<PyAny>,
 }
 
 static TYPE_LOOKUP: PyOnceLock<ObTypeLookup> = PyOnceLock::new();
@@ -94,6 +96,8 @@ impl ObTypeLookup {
             complex: PyComplex::type_object_raw(py) as usize,
             ipv4_address: py.import("ipaddress").unwrap().getattr("IPv4Address").unwrap().unbind(),
             ipv6_address: py.import("ipaddress").unwrap().getattr("IPv6Address").unwrap().unbind(),
+            ipv4_network: py.import("ipaddress").unwrap().getattr("IPv4Network").unwrap().unbind(),
+            ipv6_network: py.import("ipaddress").unwrap().getattr("IPv6Network").unwrap().unbind(),
         }
     }
 
@@ -166,6 +170,8 @@ impl ObTypeLookup {
             ObType::Complex => self.complex == ob_type,
             ObType::Ipv4Address => self.ipv4_address.as_ptr() as usize == ob_type,
             ObType::Ipv6Address => self.ipv6_address.as_ptr() as usize == ob_type,
+            ObType::Ipv4Network => self.ipv4_network.as_ptr() as usize == ob_type,
+            ObType::Ipv6Network => self.ipv6_network.as_ptr() as usize == ob_type,
             ObType::Unknown => false,
         };
 
@@ -351,6 +357,10 @@ impl ObTypeLookup {
             ObType::Ipv4Address
         } else if value.is_instance(self.ipv6_address.bind(py)).unwrap_or(false) {
             ObType::Ipv6Address
+        } else if value.is_instance(self.ipv4_network.bind(py)).unwrap_or(false) {
+            ObType::Ipv4Network
+        } else if value.is_instance(self.ipv6_network.bind(py)).unwrap_or(false) {
+            ObType::Ipv6Network
         } else {
             ObType::Unknown
         }
@@ -437,6 +447,8 @@ pub enum ObType {
     // ip address types
     Ipv4Address,
     Ipv6Address,
+    Ipv4Network,
+    Ipv6Network,
     // unknown type
     Unknown,
 }

--- a/tests/serializers/test_any.py
+++ b/tests/serializers/test_any.py
@@ -735,6 +735,26 @@ class SubIpV6(ipaddress.IPv6Address):
         return super().__str__() + '_subclassed'
 
 
+class SubNetV4(ipaddress.IPv4Network):
+    def __str__(self):
+        return super().__str__() + '_subclassed'
+
+
+class SubNetV6(ipaddress.IPv6Network):
+    def __str__(self):
+        return super().__str__() + '_subclassed'
+
+
+class SubInterfaceV4(ipaddress.IPv4Interface):
+    def __str__(self):
+        return super().__str__() + '_subclassed'
+
+
+class SubInterfaceV6(ipaddress.IPv6Interface):
+    def __str__(self):
+        return super().__str__() + '_subclassed'
+
+
 @pytest.mark.parametrize(
     ('value', 'expected_json'),
     [
@@ -742,9 +762,17 @@ class SubIpV6(ipaddress.IPv6Address):
         (ipaddress.IPv6Address('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334'),
         (SubIpV4('192.168.1.1'), '192.168.1.1_subclassed'),
         (SubIpV6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334_subclassed'),
+        (ipaddress.IPv4Network('192.168.1.0/24'), '192.168.1.0/24'),
+        (ipaddress.IPv6Network('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334/128'),
+        (SubNetV4('192.168.1.0/24'), '192.168.1.0/24_subclassed'),
+        (SubNetV6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334/128_subclassed'),
+        (ipaddress.IPv4Interface('192.168.1.1/24'), '192.168.1.1/24'),
+        (ipaddress.IPv6Interface('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334/128'),
+        (SubInterfaceV4('192.168.1.1/24'), '192.168.1.1/24_subclassed'),
+        (SubInterfaceV6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), '2001:db8:85a3::8a2e:370:7334/128_subclassed'),
     ],
 )
-def test_ip_address_type_inference(any_serializer, value, expected_json):
+def test_ipaddress_type_inference(any_serializer, value, expected_json):
     assert any_serializer.to_python(value) == value
     assert any_serializer.to_python(value, mode='json') == expected_json
     assert any_serializer.to_json(value) == f'"{expected_json}"'.encode()


### PR DESCRIPTION
## Change Summary

This adds serialization for IP address types, which was a pain point of Pydantic 2.12's changes to `serialize_as_any`.

## Related issue number

Fixes #1856

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
