### PR TITLE
ci: lint fixes for rust 1.91

### DIFF
--- a/src/errors/location.rs
+++ b/src/errors/location.rs
@@ -41,7 +41,7 @@ impl From<String> for LocItem {
 
 impl From<&String> for LocItem {
     fn from(s: &String) -> Self {
-        s.to_string().into()
+        s.clone().into()
     }
 }
 
@@ -87,20 +87,15 @@ impl Serialize for LocItem {
 /// Note: location in List is stored in **REVERSE** so adding an "outer" item to location involves
 /// pushing to the vec which is faster than inserting and shifting everything along.
 /// Then when "using" location in `Display` and `ToPyObject` order has to be reversed
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum Location {
     // no location, avoid creating an unnecessary vec
+    #[default]
     Empty,
     // store the in a vec of LocItems, Note: this is the REVERSE of location, see above
     // we could perhaps use a smallvec or similar here, probably only worth it if we store a Cow in LocItem
     List(Vec<LocItem>),
-}
-
-impl Default for Location {
-    fn default() -> Self {
-        Self::Empty
-    }
 }
 
 static EMPTY_TUPLE: PyOnceLock<Py<PyTuple>> = PyOnceLock::new();

--- a/src/serializers/config.rs
+++ b/src/serializers/config.rs
@@ -191,7 +191,7 @@ impl TemporalMode {
 
     pub fn datetime_json_key<'py>(self, datetime: &Bound<'_, PyDateTime>) -> PyResult<Cow<'py, str>> {
         match self {
-            Self::Iso8601 => Ok(datetime_to_string(datetime)?.to_string().into()),
+            Self::Iso8601 => Ok(datetime_to_string(datetime)?.into()),
             Self::Seconds => Ok(datetime_to_seconds(datetime)?.to_string().into()),
             Self::Milliseconds => Ok(datetime_to_milliseconds(datetime)?.to_string().into()),
         }
@@ -199,7 +199,7 @@ impl TemporalMode {
 
     pub fn date_json_key<'py>(self, date: &Bound<'_, PyDate>) -> PyResult<Cow<'py, str>> {
         match self {
-            Self::Iso8601 => Ok(date_to_string(date)?.to_string().into()),
+            Self::Iso8601 => Ok(date_to_string(date)?.into()),
             Self::Seconds => Ok(date_to_seconds(date)?.to_string().into()),
             Self::Milliseconds => Ok(date_to_milliseconds(date)?.to_string().into()),
         }
@@ -207,7 +207,7 @@ impl TemporalMode {
 
     pub fn time_json_key<'py>(self, time: &Bound<'_, PyTime>) -> PyResult<Cow<'py, str>> {
         match self {
-            Self::Iso8601 => Ok(time_to_string(time)?.to_string().into()),
+            Self::Iso8601 => Ok(time_to_string(time)?.into()),
             Self::Seconds => Ok(time_to_seconds(time)?.to_string().into()),
             Self::Milliseconds => Ok(time_to_milliseconds(time)?.to_string().into()),
         }

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -514,7 +514,7 @@ impl CollectWarnings {
             return Ok(());
         }
 
-        let formatted_warnings: Vec<String> = self.warnings.iter().map(|w| w.__repr__(py).to_string()).collect();
+        let formatted_warnings: Vec<String> = self.warnings.iter().map(|w| w.__repr__(py)).collect();
 
         let message = format!("Pydantic serializer warnings:\n  {}", formatted_warnings.join("\n  "));
         if self.mode == WarningsMode::Warn {

--- a/src/serializers/infer.rs
+++ b/src/serializers/infer.rs
@@ -552,7 +552,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
         }
         ObType::MultiHostUrl => {
             let py_url: PyMultiHostUrl = key.extract()?;
-            Ok(Cow::Owned(py_url.__str__(key.py()).to_string()))
+            Ok(Cow::Owned(py_url.__str__(key.py())))
         }
         ObType::Tuple => {
             let mut key_build = super::type_serializers::tuple::KeyBuilder::new();

--- a/src/validators/dataclass.rs
+++ b/src/validators/dataclass.rs
@@ -403,7 +403,7 @@ impl Validator for DataclassArgsValidator {
                 return Err(ValError::new_with_loc(
                     ErrorTypeDefaults::FrozenField,
                     field_value,
-                    field.name.to_string(),
+                    &field.name,
                 ));
             }
             // by using dict but removing the field in question, we match V1 behaviour

--- a/src/validators/model_fields.rs
+++ b/src/validators/model_fields.rs
@@ -433,7 +433,7 @@ impl Validator for ModelFieldsValidator {
                     return Err(ValError::new_with_loc(
                         ErrorTypeDefaults::FrozenField,
                         field_value,
-                        field.name.to_string(),
+                        &field.name,
                     ));
                 }
 


### PR DESCRIPTION
## Change Summary

New Rust 1.91 release caught a few new things, particularly around redundant string clones.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
