### PR TITLE
clean up GC traversal for some top-level types

### DIFF
--- a/src/py_gc.rs
+++ b/src/py_gc.rs
@@ -64,7 +64,7 @@ macro_rules! impl_py_gc_traverse {
             }
         }
     };
-    ($name:ty { $($fields:ident),* }) => {
+    ($name:ty { $($fields:ident),* $(,)? }) => {
         impl crate::py_gc::PyGcTraverse for $name {
             fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
                 $(self.$fields.py_gc_traverse(visit)?;)*

--- a/src/serializers/extra.rs
+++ b/src/serializers/extra.rs
@@ -261,6 +261,14 @@ pub(crate) struct ExtraOwned {
     exclude: Option<Py<PyAny>>,
 }
 
+impl_py_gc_traverse!(ExtraOwned {
+    model,
+    fallback,
+    context,
+    include,
+    exclude,
+});
+
 #[derive(Clone)]
 enum FieldNameOwned {
     Root,

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -48,6 +48,13 @@ pub struct SchemaSerializer {
     py_config: Option<Py<PyDict>>,
 }
 
+impl_py_gc_traverse!(SchemaSerializer {
+    serializer,
+    definitions,
+    py_schema,
+    py_config,
+});
+
 #[pymethods]
 impl SchemaSerializer {
     #[new]
@@ -186,13 +193,7 @@ impl SchemaSerializer {
     }
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        visit.call(&self.py_schema)?;
-        if let Some(ref py_config) = self.py_config {
-            visit.call(py_config)?;
-        }
-        self.serializer.py_gc_traverse(&visit)?;
-        self.definitions.py_gc_traverse(&visit)?;
-        Ok(())
+        self.py_gc_traverse(&visit)
     }
 }
 

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -536,6 +536,13 @@ pub struct ValidationInfo {
     mode: InputType,
 }
 
+impl_py_gc_traverse!(ValidationInfo {
+    config,
+    context,
+    data,
+    field_name
+});
+
 impl ValidationInfo {
     fn new(py: Python, extra: &Extra<'_, '_>, config: &Py<PyAny>, field_name: Option<Py<PyString>>) -> Self {
         Self {
@@ -548,11 +555,7 @@ impl ValidationInfo {
     }
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        visit.call(&self.config)?;
-        if let Some(context) = &self.context {
-            visit.call(context)?;
-        }
-        Ok(())
+        self.py_gc_traverse(&visit)
     }
 
     fn __clear__(&mut self) {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -121,6 +121,13 @@ pub struct SchemaValidator {
     cache_str: StringCacheMode,
 }
 
+impl_py_gc_traverse!(SchemaValidator {
+    validator,
+    definitions,
+    py_schema,
+    py_config,
+});
+
 #[pymethods]
 impl SchemaValidator {
     #[new]
@@ -403,12 +410,7 @@ impl SchemaValidator {
     }
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.validator.py_gc_traverse(&visit)?;
-        visit.call(&self.py_schema)?;
-        if let Some(ref py_config) = self.py_config {
-            visit.call(py_config)?;
-        }
-        Ok(())
+        self.py_gc_traverse(&visit)
     }
 }
 


### PR DESCRIPTION
## Change Summary

I noticed that `ExtraOwned` had changed a bit since the original `__traverse__` implementations were written. This is a quick cleanup to use the `py_gc_traverse` helpers a bit more consistently to hopefully help keep these up to date.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
