### PR TITLE
fix: no prebuilt on rebuilds

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -16,7 +16,7 @@ fn build_schema_validator_with_globals(
     globals: Option<&Bound<'_, PyDict>>,
 ) -> SchemaValidator {
     let schema = py.eval(code, globals, None).unwrap().extract().unwrap();
-    SchemaValidator::py_new(py, &schema, None).unwrap()
+    SchemaValidator::py_new(py, &schema, None, false).unwrap()
 }
 
 fn build_schema_validator(py: Python, code: &CStr) -> SchemaValidator {
@@ -510,7 +510,7 @@ fn complete_model(bench: &mut Bencher) {
 
         let complete_schema = py.import("complete_schema").unwrap();
         let schema = complete_schema.call_method0("schema").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, false).unwrap();
 
         let input = complete_schema.call_method0("input_data_lax").unwrap();
         let input = black_box(input);
@@ -533,7 +533,7 @@ fn nested_model_using_definitions(bench: &mut Bencher) {
 
         let complete_schema = py.import("nested_schema").unwrap();
         let schema = complete_schema.call_method0("schema_using_defs").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, false).unwrap();
 
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);
@@ -560,7 +560,7 @@ fn nested_model_inlined(bench: &mut Bencher) {
 
         let complete_schema = py.import("nested_schema").unwrap();
         let schema = complete_schema.call_method0("inlined_schema").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, false).unwrap();
 
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -132,13 +132,20 @@ impl<T: PyGcTraverse> PyGcTraverse for Definitions<T> {
 #[derive(Debug)]
 pub struct DefinitionsBuilder<T> {
     definitions: Definitions<T>,
+    use_prebuilt: bool,
 }
 
 impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
-    pub fn new() -> Self {
+    pub fn new(use_prebuilt: bool) -> Self {
         Self {
             definitions: Definitions(AHashMap::new()),
+            use_prebuilt,
         }
+    }
+
+    /// Whether prebuilt validators/serializers should be used
+    pub fn use_prebuilt(&self) -> bool {
+        self.use_prebuilt
     }
 
     /// Get a ReferenceId for the given reference string.

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -58,12 +58,12 @@ impl_py_gc_traverse!(SchemaSerializer {
 #[pymethods]
 impl SchemaSerializer {
     #[new]
-    #[pyo3(signature = (schema, config=None))]
-    pub fn py_new(schema: Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
-        // use_prebuilt=false: When creating a new SchemaSerializer from Python, we never want to
-        // reuse prebuilt serializers. This is either a fresh build (no prebuilt exists) or a rebuild
-        // (where we explicitly don't want stale references to old serializers).
-        let mut definitions_builder = DefinitionsBuilder::new(false);
+    #[pyo3(signature = (schema, config=None, *, rebuild=false))]
+    pub fn py_new(schema: Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>, rebuild: bool) -> PyResult<Self> {
+        // use_prebuilt=true by default, but false during rebuilds to avoid stale references
+        // to old serializers (see issue #1894)
+        let use_prebuilt = !rebuild;
+        let mut definitions_builder = DefinitionsBuilder::new(use_prebuilt);
         let serializer = CombinedSerializer::build(schema.downcast()?, config, &mut definitions_builder)?;
         Ok(Self {
             serializer,

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -58,7 +58,7 @@ impl_py_gc_traverse!(SchemaSerializer {
 #[pymethods]
 impl SchemaSerializer {
     #[new]
-    #[pyo3(signature = (schema, config=None, *, rebuild=false))]
+    #[pyo3(signature = (schema, config=None, rebuild=false))]
     pub fn py_new(schema: Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>, rebuild: bool) -> PyResult<Self> {
         // use_prebuilt=true by default, but false during rebuilds to avoid stale references
         // to old serializers (see issue #1894)
@@ -184,7 +184,8 @@ impl SchemaSerializer {
     }
 
     pub fn __reduce__<'py>(slf: &Bound<'py, Self>) -> PyResult<(Bound<'py, PyType>, Bound<'py, PyTuple>)> {
-        let init_args = (&slf.get().py_schema, &slf.get().py_config).into_pyobject(slf.py())?;
+        // Pass rebuild=true to avoid reusing prebuilt serializers when unpickling
+        let init_args = (&slf.get().py_schema, &slf.get().py_config, true).into_pyobject(slf.py())?;
         Ok((slf.get_type(), init_args))
     }
 

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -13,8 +13,8 @@ use crate::py_gc::PyGcTraverse;
 pub(crate) use config::{BytesMode, SerializationConfig};
 pub use errors::{PydanticSerializationError, PydanticSerializationUnexpectedValue};
 pub(crate) use extra::{Extra, SerMode, SerializationState, WarningsMode};
-use shared::{BuildSerializer, to_json_bytes};
-pub use shared::{CombinedSerializer};
+pub use shared::CombinedSerializer;
+use shared::{to_json_bytes, BuildSerializer};
 
 mod computed_fields;
 mod config;

--- a/src/serializers/shared.rs
+++ b/src/serializers/shared.rs
@@ -155,16 +155,6 @@ combined_serializer! {
 }
 
 impl CombinedSerializer {
-    // Used when creating the base serializer instance, to avoid reusing the instance
-    // when unpickling:
-    pub fn build_base(
-        schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
-    ) -> PyResult<Arc<CombinedSerializer>> {
-        Self::_build(schema, config, definitions, false)
-    }
-
     fn _build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
@@ -308,7 +298,10 @@ impl BuildSerializer for CombinedSerializer {
         config: Option<&Bound<'_, PyDict>>,
         definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Arc<CombinedSerializer>> {
-        Self::_build(schema, config, definitions, true)
+        // Read use_prebuilt from the definitions builder - this ensures all nested
+        // serializers respect the same setting as the top-level build
+        let use_prebuilt = definitions.use_prebuilt();
+        Self::_build(schema, config, definitions, use_prebuilt)
     }
 }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -131,7 +131,7 @@ impl_py_gc_traverse!(SchemaValidator {
 #[pymethods]
 impl SchemaValidator {
     #[new]
-    #[pyo3(signature = (schema, config=None, *, rebuild=false))]
+    #[pyo3(signature = (schema, config=None, rebuild=false))]
     pub fn py_new(py: Python, schema: &Bound<'_, PyAny>, config: Option<&Bound<'_, PyDict>>, rebuild: bool) -> PyResult<Self> {
         // use_prebuilt=true by default, but false during rebuilds to avoid stale references
         // to old validators (see issue #1894)

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -394,7 +394,8 @@ impl SchemaValidator {
     }
 
     pub fn __reduce__<'py>(slf: &Bound<'py, Self>) -> PyResult<(Bound<'py, PyType>, Bound<'py, PyTuple>)> {
-        let init_args = (&slf.get().py_schema, &slf.get().py_config).into_pyobject(slf.py())?;
+        // Pass rebuild=true to avoid reusing prebuilt serializers when unpickling
+        let init_args = (&slf.get().py_schema, &slf.get().py_config, true).into_pyobject(slf.py())?;
         Ok((slf.get_type(), init_args))
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -132,7 +132,12 @@ impl_py_gc_traverse!(SchemaValidator {
 impl SchemaValidator {
     #[new]
     #[pyo3(signature = (schema, config=None, rebuild=false))]
-    pub fn py_new(py: Python, schema: &Bound<'_, PyAny>, config: Option<&Bound<'_, PyDict>>, rebuild: bool) -> PyResult<Self> {
+    pub fn py_new(
+        py: Python,
+        schema: &Bound<'_, PyAny>,
+        config: Option<&Bound<'_, PyDict>>,
+        rebuild: bool,
+    ) -> PyResult<Self> {
         // use_prebuilt=true by default, but false during rebuilds to avoid stale references
         // to old validators (see issue #1894)
         let use_prebuilt = !rebuild;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,6 +54,51 @@ mod tests {
     }
 
     #[test]
+    fn test_build_schema_serializer_with_rebuild() {
+        Python::attach(|py| {
+            let code = c_str!(
+                r"{
+                'type': 'typed-dict',
+                'fields': {
+                    'name': {
+                        'type': 'typed-dict-field',
+                        'schema': {
+                            'type': 'str',
+                        },
+                    },
+                },
+            }"
+            );
+            let schema: Bound<'_, PyDict> = py.eval(code, None, None).unwrap().extract().unwrap();
+            // Test with rebuild=true to cover the use_prebuilt=false branch
+            SchemaSerializer::py_new(schema, None, true).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_schema_validator_with_rebuild() {
+        Python::attach(|py| {
+            let code = c_str!(
+                r#"schema = {
+    "type": "dict",
+    "keys_schema": {
+        "type": "str",
+    },
+    "values_schema": {
+        "type": "str",
+    },
+    "strict": False,
+}"#
+            );
+            let locals = PyDict::new(py);
+            py.run(code, None, Some(&locals)).unwrap();
+            let schema = locals.get_item("schema").unwrap().unwrap();
+            // Test with rebuild=true to cover the use_prebuilt=false branch
+            SchemaValidator::py_new(py, &schema, None, true).unwrap();
+        });
+    }
+
+    #[test]
     fn test_literal_schema() {
         Python::attach(|py| {
             let code = c_str!(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -49,7 +49,7 @@ mod tests {
             }"
             );
             let schema: Bound<'_, PyDict> = py.eval(code, None, None).unwrap().extract().unwrap();
-            SchemaSerializer::py_new(schema, None).unwrap();
+            SchemaSerializer::py_new(schema, None, false).unwrap();
         });
     }
 
@@ -76,7 +76,7 @@ json_input = '{"a": "something"}'
             py.run(code, None, Some(&locals)).unwrap();
             let schema = locals.get_item("schema").unwrap().unwrap();
             let json_input = locals.get_item("json_input").unwrap().unwrap();
-            let binding = SchemaValidator::py_new(py, &schema, None)
+            let binding = SchemaValidator::py_new(py, &schema, None, false)
                 .unwrap()
                 .validate_json(py, &json_input, None, None, None, None, false.into(), None, None)
                 .unwrap();
@@ -137,7 +137,7 @@ dump_json_input_2 = {'a': 'something'}
                 .unwrap();
             let dump_json_input_1 = locals.get_item("dump_json_input_1").unwrap().unwrap();
             let dump_json_input_2 = locals.get_item("dump_json_input_2").unwrap().unwrap();
-            let serializer = SchemaSerializer::py_new(schema, None).unwrap();
+            let serializer = SchemaSerializer::py_new(schema, None, false).unwrap();
             let serialization_result = serializer
                 .to_json(
                     py,


### PR DESCRIPTION
### Change Summary

This PR adds a `rebuild: bool = False` parameter to `SchemaValidator.__init__` and `SchemaSerializer.__init__` to fix the memory leak described in #1894.

### Problem

PR #1616 introduced `PrebuiltValidator`/`PrebuiltSerializer` as a memory optimization that reuses existing validators/serializers from model classes. However, when `model_rebuild(force=True)` is called on recursive models:

1. `Collection.model_rebuild()` creates a new validator
2. When building, it encounters `BlockGroup` and `PredictiveModel` in a union
3. Since those models have `__pydantic_complete__=True`, their existing validators are wrapped in `PrebuiltValidator` (a strong `Py<SchemaValidator>` reference)
4. Later, when `BlockGroup` and `PredictiveModel` are rebuilt, they get NEW validators
5. But `Collection`'s validator still holds references to the OLD validators via `PrebuiltValidator`
6. The old validators can never be garbage collected

This causes unbounded RSS growth (~50MB per 1000 rebuild cycles).

### Solution

- Add `rebuild: bool = False` parameter to `SchemaValidator::py_new` and `SchemaSerializer::py_new`
- When `rebuild=True`, set `use_prebuilt=false` in `DefinitionsBuilder`, which skips the prebuilt optimization
- Thread `use_prebuilt` through `DefinitionsBuilder` so nested builds respect the same setting
- Pass `rebuild=True` from `__reduce__` to maintain correct unpickling behavior (avoiding prebuilt during reconstruction)

Requires accompanying pydantic PR to pass `rebuild=True` when calling `SchemaValidator`/`SchemaSerializer` during `model_rebuild(force=True)`.

### Unchanged

- Normal model creation still uses the prebuilt optimization (`rebuild=False` by default)
- Existing behavior is preserved for all non-rebuild scenarios

## Related Issues

- Fixes #1894 (RSS growth on model rebuild)
- Should also resolve #1893 (stale referents on rebuild)
- Also (incidentally) solves https://github.com/pydantic/pydantic/issues/12696

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable (code comments added)
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
  * I wasn't able to get it to run, current main branch pydantic segfaults with pytest
  * CI seems to be broken, it needs hypothesis?
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Companion PR

A pydantic PR is required to complete this fix, which will:
- Pass `rebuild=True` to `SchemaValidator` and `SchemaSerializer` in `complete_model_class` when rebuilding
- Thread the flag through `create_schema_validator` and `PluggableSchemaValidator`
- See: https://github.com/pydantic/pydantic/pull/12689

Selected Reviewer: @Viicos