### PR TITLE
Adjust error message expectation for next GraalPy version

### DIFF
--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -1,7 +1,7 @@
 import copy
 import json
-import platform
 import re
+import types
 import zoneinfo
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from decimal import Decimal
@@ -279,8 +279,8 @@ def test_custom_invalid_tz():
     with pytest.raises(ValidationError) as excinfo:
         schema.validate_python(dt)
 
-    # exception messages differ between python and pypy
-    if platform.python_implementation() in ('PyPy', 'GraalVM'):
+    # exception messages differ between cpython (using C datetime) and pypy (using pydatetime)
+    if isinstance(tzinfo.utcoffset, types.FunctionType):
         error_message = 'NotImplementedError: tzinfo subclass must override utcoffset()'
     else:
         error_message = 'NotImplementedError: a tzinfo subclass must implement utcoffset()'


### PR DESCRIPTION
The upcoming version of GraalPy added a builtin `_datetime` module and so the error messages will be more aligned with CPython. Instead of a complex version condition, I tried to detect whether the interpreter uses a builtin datetime module (CPython and next GraalPy) or it's using `_pydatetime` (PyPy and current GraalPy)

CC @timfel