### PR TITLE
fix: use validator name instead of tag value in tagged union error loc

### DIFF
--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -386,10 +386,10 @@ impl TaggedUnionValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        if let Ok(Some((tag, validator))) = self.lookup.validate(py, tag) {
+        if let Ok(Some((_, validator))) = self.lookup.validate(py, tag) {
             return match validator.validate(py, input, state) {
                 Ok(res) => Ok(res),
-                Err(err) => Err(err.with_outer_location(tag)),
+                Err(err) => Err(err.with_outer_location(validator.get_name())),
             };
         }
         match self.custom_error {


### PR DESCRIPTION
## Change Summary

Tagged union errors currently show the discriminator’s tag value (e.g., apple, tag_for_a) in loc. This change makes them show the validator name instead (e.g., typed-dict).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix: https://github.com/pydantic/pydantic/issues/10433
## Checklist

* [x] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [x] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
